### PR TITLE
Change base URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const config = {
   title: 'Stately Docs',
   tagline:
     'Documentation for Stately: state machines and statecharts for the modern web',
-  url: 'https://stately-docs.vercel.app',
+  url: 'https://stately.ai',
   baseUrl: process.env.VERCEL_ENV === 'preview' ? '/' : '/docs/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
@mellson I need you to make sure I’m not doing anything wrong with this tiny PR!

I *think* this should make the meta elements use the correct URL in stately.ai/docs, but I won’t know until it’s deployed. This is what they currently show as on stately.ai/docs:

```
<meta property="og:url" content="https://stately-docs.vercel.app/docs/states/initial-states" data-rh="true">
```