### PR TITLE
This should fix the announcements bar problem

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,14 +9,16 @@ const config = {
     'Documentation for Stately: state machines and statecharts for the modern web',
   url: 'https://stately.ai',
   baseUrl: process.env.VERCEL_ENV === 'preview' ? '/' : '/docs/',
+  baseUrlIssueBanner: false,
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'icon.svg',
+  staticDirectories: ['static'],
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'statelyai', // Usually your GitHub org/user name.
-  projectName: 'docusaurus-docs', // Usually your repo name.
+  projectName: 'docs', // Usually your repo name.
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
I noticed that the problem only showed at the root of the deployed site, and at root the header had a new element with an id of `docusaurus-base-url-issue-banner-container`. So I hope we can solve this one by disabling that particular warning banner 🤞🏻 