### PR TITLE
Fix broken link and remove duplicate text

### DIFF
--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Welcome to the Stately docs
 
-Welcome to the Stately docs! Here you can find all the documentation for the Stately Studio and [XState](/xstate). There are a few ways you might want to get started:
+Here you can find all the documentation for the Stately Studio and [XState](/xstate/intro). There are a few ways you might want to get started:
 
 - ⬇️ Keep reading to [find out more about the Studio Editor](#studio-editor).
 - 🏁 Jump straight into [learning how to use the Editor, starting with states](/states/intro).


### PR DESCRIPTION
This PR fixes the broken XState link on the homepage and removes the “Welcome to the Stately docs” from the paragraph text, as it’s already said in the heading above.