### PR TITLE
Fix VS Code extension link

### DIFF
--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -27,7 +27,7 @@ The Stately Studio is a suite of tools for building app logic, including the Stu
 />
 </p>
 
-You can use the [Studio Editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](#projects-and-teams). Use the [XState VS Code extension](/tools/developer-tools) to use the Editor with your codebase inside your code editor, or [export](#export) your code from the Studio into your codebase.
+You can use the [Studio Editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](#projects-and-teams). Use the [XState VS Code extension](/tools/xstate-vscode-extension) to use the Editor with your codebase inside your code editor, or [export](#export) your code from the Studio into your codebase.
 
 :::tip
 


### PR DESCRIPTION
Current link directed to Developer tools (CLI and Chrome devtools)