### PR TITLE
Update docs on built-in actions

### DIFF
--- a/docs/xstate/actions/built-in-actions.mdx
+++ b/docs/xstate/actions/built-in-actions.mdx
@@ -48,77 +48,29 @@ send((context, event) => {
 ```
 
 ### Sending events to actors
-With the `send` action, events can be sent to actors via a [target expression](#send-targets):
+With the `sendTo` action, events can be sent to actors:
 
-```ts twoslash {12-16}
+```ts twoslash {13-14}
 // @noErrors
-import { assign, createMachine, send, spawn } from 'xstate';
+import { actions, AnyActorRef, assign, createMachine, spawn } from 'xstate';
+const { sendTo } = actions;
 
 const machine = createMachine({
-  // ...
+  schema: { context: {} as { someRef: AnyActorRef } },
   states: {
     active: {
       entry: assign({
-        someRef: () => spawn(someMachine)
+        someRef: () => spawn(someMachine),
       }),
       on: {
         SOME_EVENT: {
-          // use a target expression to send an event
-          // to the actor reference
-          actions: send(
-            { type: 'PING' },
-            { to: (context) => context.someRef })
-        }
-      }
-    }
-  }
+          actions: (context) =>
+            sendTo(context.someRef, { type: 'PING' }),
+        },
+      },
+    },
+  },
 });
-```
-
-:::tip
-
-If you provide an unique `name` argument to `spawn`, you can reference it in the target expression:
-
-```ts twoslash {4,10}
-// @noErrors
-import { assign, createMachine, send, spawn } from 'xstate';
-// ---cut---
-const loginMachine = createMachine({
-  // ...
-  entry: assign({
-    formRef: () => spawn(formMachine, 'form')
-  }),
-  states: {
-    idle: {
-      on: {
-        LOGIN: {
-          actions: send({ type: 'SUBMIT' }, { to: 'form' })
-        }
-      }
-    }
-  }
-});
-```
-:::
-
-### Send targets
-An event sent from a `send` action creator can signify that it should be sent to specific targets,
-such as [invoked services](../actors/promises) or [spawned actors](../actors/spawn).
-This is done by specifying the `{ to: ... }` property in the `send` action:
-
-```ts twoslash
-// @noErrors
-import { send } from 'xstate';
-// ---cut---
-// ...
-invoke: {
-  id: 'some-service-id',
-  src: 'someService',
-  // ...
-},
-// ...
-// Indicates to send { type: 'SOME_EVENT' } to the invoked service
-actions: send({ type: 'SOME_EVENT' }, { to: 'some-service-id' })
 ```
 
 ## Raise action

--- a/docs/xstate/actions/built-in-actions.mdx
+++ b/docs/xstate/actions/built-in-actions.mdx
@@ -47,6 +47,122 @@ send((context, event) => {
 });
 ```
 
+### Sending events to actors
+With the `send` action, events can be sent to actors via a target expression:
+
+```ts twoslash {12-16}
+// @noErrors
+import { assign, createMachine, send, spawn } from 'xstate';
+
+const machine = createMachine({
+  // ...
+  states: {
+    active: {
+      entry: assign({
+        someRef: () => spawn(someMachine)
+      }),
+      on: {
+        SOME_EVENT: {
+          // use a target expression to send an event
+          // to the actor reference
+          actions: send(
+            { type: 'PING' },
+            { to: (context) => context.someRef })
+        }
+      }
+    }
+  }
+});
+```
+
+:::tip
+
+If you provide an unique `name` argument to `spawn`, you can reference it in the target expression:
+
+```ts twoslash {4,10}
+// @noErrors
+import { assign, createMachine, send, spawn } from 'xstate';
+// ---cut---
+const loginMachine = createMachine({
+  // ...
+  entry: assign({
+    formRef: () => spawn(formMachine, 'form')
+  }),
+  states: {
+    idle: {
+      on: {
+        LOGIN: {
+          actions: send({ type: 'SUBMIT' }, { to: 'form' })
+        }
+      }
+    }
+  }
+});
+```
+:::
+
+### Send targets
+An event sent from a `send` action creator can signify that it should be sent to specific targets,
+such as [invoked services](../actors/promises) or [spawned actors](../actors/spawn).
+This is done by specifying the `{ to: ... }` property in the `send` action:
+
+```ts twoslash
+// @noErrors
+import { send } from 'xstate';
+// ---cut---
+// ...
+invoke: {
+  id: 'some-service-id',
+  src: 'someService',
+  // ...
+},
+// ...
+// Indicates to send { type: 'SOME_EVENT' } to the invoked service
+actions: send({ type: 'SOME_EVENT' }, { to: 'some-service-id' })
+```
+
+## Raise action
+The `raise` action creator queues an event to the statechart, in the internal event queue.
+This means the event is sent immediately on the current “step” of the interpreter.
+
+```ts twoslash {17-18}
+import { createMachine, actions } from "xstate";
+const { raise } = actions;
+
+// Demonstrate `raise` action
+const raiseActionDemo = createMachine({
+  id: 'Raise action demo',
+  initial: 'entry',
+  states: {
+    entry: {
+      on: {
+        STEP: {
+          target: 'middle',
+        },
+        RAISE: {
+          target: 'middle',
+
+          // immediately invoke the NEXT event in 'middle'
+          actions: raise('NEXT')
+        },
+      },
+    },
+    middle: {
+      on: {
+        NEXT: 'last'
+      },
+    },
+    last: {
+      on: {
+        RESET: 'entry'
+      },
+    },
+  },
+})
+```
+
+Click on both `STEP` and `RAISE` events in the [visualizer](https://stately.ai/viz?gist=04bff4f2e4c5b4fa7f346dcd7fc21627) to see the difference.
+
 ## Pure action
 
 <!-- deps: ["actions", "self-transitions"] -->
@@ -79,6 +195,109 @@ createMachine({
   }),
 });
 ```
+
+## Log action
+
+The `log` action creator is a declarative way of logging anything related to the current state `context` and/or `event`.                          |
+
+```ts twoslash {9,14-18,29-37}
+// @noErrors
+import { createMachine, actions } from 'xstate';
+const { log } = actions;
+
+const loggingMachine = createMachine({
+  id: 'logging',
+  context: { count: 42 },
+  initial: 'start',
+  states: {
+    start: {
+      entry: log('started!'),
+      on: {
+        FINISH: {
+          target: 'end',
+          actions: log(
+            (context, event) =>
+            `count: ${context.count}, event: ${event.type}`,
+
+            'Finish label'
+          )
+        }
+      }
+    },
+    end: {}
+  }
+});
+
+const endState = loggingMachine.transition('start', 'FINISH');
+
+endState.actions;
+// the endState.actions array will now contain our log action:
+// [
+//   {
+//     type: 'xstate.log',
+//     label: 'Finish label',
+//     expr: (context, event) => ...
+//   }
+// ]
+
+// The interpreter would log the action's evaluated expression
+// based on the current state context and event.
+```
+
+Without any arguments, `log` is an action that logs an object with `context` and `event` properties, containing the current context and triggering event, respectively.
+
+## Choose action
+The `choose` action creator creates an action that specifies which actions should be executed based on some conditions.
+
+:::danger
+Do not use the `choose` action creator to execute actions that can otherwise be represented as non-conditional actions executed in certain states/transitions via `entry`, `exit`, or `actions`.
+:::
+
+```ts twoslash
+// @noErrors
+import { actions } from "xstate";
+const { choose, log } = actions;
+
+const maybeDoThese = choose([
+  {
+    cond: "cond1",
+    actions: [
+      // selected when "cond1" is true
+      log("cond1 chosen!")
+    ]
+  },
+  {
+    cond: "cond2",
+    actions: [
+      // selected when "cond1" is false and "cond2" is true
+      log((context, event) => {
+        /* ... */
+      }),
+      log("another action")
+    ]
+  },
+  {
+    cond: (context, event) => {
+      // some condition
+      return false;
+    },
+    actions: [
+      // selected when "cond1" and "cond2" are false and the inline `cond` is true
+      (context, event) => {
+        // some other action
+      }
+    ]
+  },
+  {
+    actions: [
+      log("fall-through action")
+      // selected when "cond1", "cond2", and "cond3" are false
+    ]
+  }
+]);
+```
+
+This is analogous to the SCXML `<if>`, `<elseif>`, and `<else>` elements: www.w3.org/TR/scxml/#if
 
 ## Rules of built-in actions
 

--- a/docs/xstate/actions/built-in-actions.mdx
+++ b/docs/xstate/actions/built-in-actions.mdx
@@ -4,7 +4,7 @@ title: Built-in actions
 
 # Built-in actions
 
-Along with `assign`, XState has several other built-in actions which can do different things in a state machine. We’ll introduce a couple of built-in actions for now and learn about the others later.
+Along with the [`assign`](./context#assign-action) action, XState has several other built-in actions which can do different things in a state machine. We’ll introduce a couple of built-in actions for now and learn about the others later.
 
 ## Send action
 

--- a/docs/xstate/actions/built-in-actions.mdx
+++ b/docs/xstate/actions/built-in-actions.mdx
@@ -48,7 +48,7 @@ send((context, event) => {
 ```
 
 ### Sending events to actors
-With the `send` action, events can be sent to actors via a target expression:
+With the `send` action, events can be sent to actors via a [target expression](#send-targets):
 
 ```ts twoslash {12-16}
 // @noErrors

--- a/docs/xstate/actions/context.mdx
+++ b/docs/xstate/actions/context.mdx
@@ -74,8 +74,7 @@ const machine = createMachine(
         /*
          * to keep typescript happy,
          * update using a function with the context parameter
-         * again we name it `_`,
-         * to indicate that we don't use it
+         * again we name it `_` to indicate that it's unused
          */
         message: (_) => 'Count changed',
       }),

--- a/docs/xstate/actions/context.mdx
+++ b/docs/xstate/actions/context.mdx
@@ -27,7 +27,9 @@ const machine = createMachine({
 });
 ```
 
-## Updating context
+Next, we'll see how to update the context using the assign action.
+
+## Assign action
 
 <!-- deps: ["context", "actions", "self-transitions"] -->
 
@@ -35,14 +37,20 @@ Assigning new values to the context in XState is done through the `assign` actio
 
 The `assign` action takes the context _assigner_, representing how values should be assigned in the current context. The _assigner_ can be an object:
 
-```ts twoslash {16-22}
+```ts twoslash {22-40}
 // @noErrors
 import { createMachine, assign } from 'xstate';
 
 const machine = createMachine(
   {
+    // adding a schema for the events will make them typesafe
+    schema: {
+      events: {} as { type: 'INCREMENT'; value: number; time: Date },
+    },
     context: {
       count: 0,
+      updatedAt: new Date(),
+      message: 'Hello World',
     },
     on: {
       INCREMENT: {
@@ -56,8 +64,20 @@ const machine = createMachine(
         // increment the current count by the event value
         count: (context, event) => context.count + event.value,
 
-        // assign static value to the message (no function needed)
-        message: 'Count changed',
+        /*
+         * you can update multiple properties at once
+         * we name the context parameter `_`,
+         * to indicate that we don't use it
+         */
+        updatedAt: (_, event) => event.time,
+
+        /*
+         * to keep typescript happy,
+         * update using a function with the context parameter
+         * again we name it `_`,
+         * to indicate that we don't use it
+         */
+        message: (_) => 'Count changed',
       }),
     },
   }
@@ -66,7 +86,7 @@ const machine = createMachine(
 
 Or the _assigner_ can be a function that returns the updated state:
 
-```ts twoslash {16-21}
+```ts twoslash {16-23}
 // @noErrors
 import { createMachine, assign } from 'xstate';
 
@@ -74,6 +94,7 @@ const machine = createMachine(
   {
     context: {
       count: 0,
+      message: '',
     },
     on: {
       INCREMENT: {
@@ -86,6 +107,8 @@ const machine = createMachine(
       assignToContext: assign((context) => {
         return {
           count: context.count + 1,
+
+          // assign static value to the message (no function needed)
           message: 'Count changed',
         };
       }),
@@ -99,8 +122,11 @@ You can pass several `assign` actions in an array and they’ll be executed sequ
 ```js
 // ...
   actions: [
-    assign({ count: 3 }), // context.count === 3
-    assign({ count: context => context.count * 2 }) // context.count === 6
+    assign({ count: 3 }),
+    // context.count is now 3
+
+    assign({ count: context => context.count * 2 })
+    // context.count is now 6
   ],
 // ...
 ```
@@ -159,6 +185,8 @@ const lightMachine = createMachine({
 
 ## Summary
 
-`States` are used for handling your apps states which you know about in advance. `Context` is a data store that you can use to store any arbitrary values. `assign` can be used to assign values to the context, and the context can be used in any action you call.
+`States` are used for handling your apps states which you know about in advance.
+`Context` is a data store that you can use to store any arbitrary values.
+The `assign` action can be used to assign values to the context, and the context can be used in any action you call.
 
 Next, we’ll look at some [special built-in actions](/xstate/actions/built-in-actions) XState provides to extend its powers.


### PR DESCRIPTION
This PR updates the docs on some of the XState built-in actions. I'm in two minds about adding the argument tables we have in the old docs 🤔 For now, I've left them out to keep the more minimal style of the new docs.