### PR TITLE
Change XState intro page slug to /docs/xstate

### DIFF
--- a/docs/xstate/intro.mdx
+++ b/docs/xstate/intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: XState
+slug: '/xstate'
 ---
 
 XState is a JavaScript and TypeScript library for finite state machines and statecharts.


### PR DESCRIPTION
This PR changes the XState intro page slug to /docs/xstate.

Previously the slug was /docs/xstate/intro, which is a bit long-winded. So now we have a useful short URL for directing straight to the XState docs.