### PR TITLE
Add a more prominent link to GitHub from the docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,6 +111,11 @@ const config = {
             label: 'Blog',
             position: 'right',
           },
+          {
+            type: 'html',
+            position: 'right',
+            value: '<a class="navbar__link navbar__icon" href="https://github.com/statelyai/xstate"><svg alt="XState GitHub repository" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 22V18C15.1392 16.7473 14.78 15.4901 14 14.5C17 14.5 20 12.5 20 9C20.08 7.75 19.73 6.52 19 5.5C19.28 4.35 19.28 3.15 19 2C19 2 18 2 16 3.5C13.36 3 10.64 3 8.00004 3.5C6.00004 2 5.00004 2 5.00004 2C4.70004 3.15 4.70004 4.35 5.00004 5.5C4.27191 6.51588 3.91851 7.75279 4.00004 9C4.00004 12.5 7.00004 14.5 10 14.5C9.61004 14.99 9.32004 15.55 9.15004 16.15C8.98004 16.75 8.93004 17.38 9.00004 18V22" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M9 18C4.49 20 4 16 2 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></a>',
+          },
         ],
       },
       footer: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -661,6 +661,27 @@ code {
   border-bottom: 1px solid var(--st-header-border);
 }
 
+.navbar__icon {
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 2rem;
+  width: 2rem;
+}
+
+.navbar__icon:hover {
+  background-color: var(--st-highlight-background-hover);
+}
+
+.navbar__icon svg {
+  display: block;
+}
+
+.navbar-sidebar--show .navbar-sidebar .navbar__icon {
+  margin-left: 0.5rem;
+}
+
 /* force search to align with sidebar by making logo width of sidebar */
 .navbar__brand {
   margin-right: 0;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -330,6 +330,8 @@ html[data-theme='light'], html[data-theme='light'] body {
   --st-menu-link-hover: var(--st-gray-800);
   --st-menu-link-active: var(--st-gray-800);
 
+  --ifm-breadcrumb-separator: url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" x=\"0px\" y=\"0px\" viewBox=\"0 0 256 256\"><polygon fill=\"gray\" points=\"79.093,0 48.907,30.187 146.72,128 48.907,225.813 79.093,256 207.093,128\"/></svg>");
+
   --docsearch-primary-color: var(--st-gray-800);
   --docsearch-text-color: var(--st-text);
   --docsearch-highlight-color: var(--st-gray-200);
@@ -396,7 +398,7 @@ html[data-theme='dark'], html[data-theme='dark'] body {
   --ifm-hover-overlay:gray;
   --ifm-color-content:white;
   --ifm-color-content-secondary:white;
-  --ifm-breadcrumb-separator-filter:invert(64%) sepia(11%) saturate(0%) hue-rotate(149deg) brightness(99%) contrast(95%);
+  --ifm-breadcrumb-separator-filter: none;
   --ifm-code-background:var(--st-code-highlight-background);
   --ifm-scrollbar-track-background-color:var(--st-gray-850);
   --ifm-scrollbar-thumb-background-color:var(--st-gray-800);
@@ -448,6 +450,8 @@ html[data-theme='dark'], html[data-theme='dark'] body {
   --st-link-button-border: var(--st-gray-700);
   --st-menu-link-hover: var(--st-gray-100);
   --st-menu-link-active: var(--st-gray-100);
+
+  --ifm-breadcrumb-separator: url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" x=\"0px\" y=\"0px\" viewBox=\"0 0 256 256\"><polygon fill=\"darkgray\" points=\"79.093,0 48.907,30.187 146.72,128 48.907,225.813 79.093,256 207.093,128\"/></svg>");
 
   /* alert colours */
   --st-tip-background: var(--st-gray-800);
@@ -825,8 +829,6 @@ html [class*=toggleButton] {
 
 .breadcrumbs__item:not(:last-child):after {
   color: var(--st-text);
-  --ifm-breadcrumb-separator: url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" x=\"0px\" y=\"0px\" viewBox=\"0 0 256 256\"><polygon fill=\"black\" points=\"79.093,0 48.907,30.187 146.72,128 48.907,225.813 79.093,256 207.093,128\"/></svg>");
-  --ifm-breadcrumb-separator-filter: var(--st-icon-filter);
   opacity: 1;
 }
 


### PR DESCRIPTION
This PR adds an icon to the navigation bar which takes the user to the XState GitHub repo.
![CleanShot 2023-02-08 at 14 44 47@2x](https://user-images.githubusercontent.com/266663/217562918-cd0deb03-a1a4-490b-8703-f95d607f3143.png)
<img width="651" alt="CleanShot 2023-02-08 at 14 44 35@2x" src="https://user-images.githubusercontent.com/266663/217562929-cd299423-d227-4a55-b4ac-206596af430a.png">

I’ve used an icon link as it stops us overcrowding the navbar with text links, and folks are used to following a GitHub icon for repos. The icon is a Lucide icon, to match the style of the icons used in the Studio UI.