### PR TITLE
Visual and accessibility improvements

### DIFF
--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -11,10 +11,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 Here you can find all the documentation for the Stately Studio and [XState](/xstate/intro). There are a few ways you might want to get started:
 
 <ul className="content-boxes">
-  <li><a href="/states/intro">🏁 <strong>Get started</strong> Jump straight into learning how to use the Editor, starting with states.</a></li>
-  <li><a href="#studio-editor">⬇️ <strong>Editor overview</strong> Keep reading to find out more about the Studio Editor.</a></li>
-  <li><a href="/state-machines-and-statecharts">🧠 <strong>Learn state machines and statecharts</strong> With our no-code introduction.</a></li>
-  <li><a href="/xstate/intro">💻 <strong>Learn XState</strong> Get started with our JavaScript and TypeScript library for state machines and statecharts.</a></li>
+  <li><a className="link-box" href="/states/intro">🏁 <strong>Get started</strong> Jump straight into learning how to use the Editor, starting with states.</a></li>
+  <li><a className="link-box" href="#studio-editor">⬇️ <strong>Editor overview</strong> Keep reading to find out more about the Studio Editor.</a></li>
+  <li><a className="link-box" href="/state-machines-and-statecharts">🧠 <strong>Learn state machines and statecharts</strong> With our no-code introduction.</a></li>
+  <li><a className="link-box" href="/xstate/intro">💻 <strong>Learn XState</strong> Get started with our JavaScript and TypeScript library for state machines and statecharts.</a></li>
 </ul>
 
 The Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](/tools/developer-tools), and much more coming soon. 

--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -10,10 +10,12 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Here you can find all the documentation for the Stately Studio and [XState](/xstate/intro). There are a few ways you might want to get started:
 
-- ⬇️ Keep reading to [find out more about the Studio Editor](#studio-editor).
-- 🏁 Jump straight into [learning how to use the Editor, starting with states](/states/intro).
-- 🧠 Learn about [state machines and statecharts in our no-code introduction](/state-machines-and-statecharts).
-- 💻 Get started with [XState, our JavaScript and TypeScript library for state machines and statecharts](/xstate/intro).
+<ul className="content-boxes">
+  <li><a href="/states/intro">🏁 <strong>Get started</strong> Jump straight into learning how to use the Editor, starting with states.</a></li>
+  <li><a href="#studio-editor">⬇️ <strong>Editor overview</strong> Keep reading to find out more about the Studio Editor.</a></li>
+  <li><a href="/state-machines-and-statecharts">🧠 <strong>Learn state machines and statecharts</strong> With our no-code introduction.</a></li>
+  <li><a href="/xstate/intro">💻 <strong>Learn XState</strong> Get started with our JavaScript and TypeScript library for state machines and statecharts.</a></li>
+</ul>
 
 The Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](/tools/developer-tools), and much more coming soon. 
 

--- a/docs/xstate/intro.mdx
+++ b/docs/xstate/intro.mdx
@@ -3,7 +3,7 @@ title: XState
 slug: '/xstate'
 ---
 
-XState is a JavaScript and TypeScript library for finite state machines and statecharts.
+XState is a JavaScript and TypeScript library for creating, interpreting, and executing finite state machines and statecharts, as well as managing invocations of those machines as actors.
 
 - [Install XState](/xstate/installation)
 - [Learn about the XState basics](/xstate/basics/what-is-a-statechart)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 require('dotenv').config();
+const a11yEmoji = require('@fec/remark-a11y-emoji');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -62,6 +63,9 @@ const config = {
               'studio',
             ],
           },
+
+          // Add accessible emoji remark plugin
+          remarkPlugins: [a11yEmoji],
         },
         blog: false,
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,6 +47,8 @@ const config = {
 
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/statelyai/docs/tree/main/',
+
+          // Different types of admonitions/“tip boxes” available for our use.
           admonitions: {
             tag: ':::',
             keywords: [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.3.1",
+    "@fec/remark-a11y-emoji": "^3.1.0",
     "@tsconfig/docusaurus": "^1.0.6",
     "dotenv": "^16.0.3",
     "typescript": "^4.8.4"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,6 +23,8 @@
 html, body {
   font-weight: var(--ifm-font-weight-normal);
   letter-spacing: -0.011rem;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Nick’s colours */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1132,6 +1132,64 @@ footer [class*=iconExternalLink] {
   text-decoration-thickness: 1px;
 }
 
+/* Context boxes (custom HTML used in content pages) */
+
+.content-boxes {
+  display: grid; 
+  grid-template-columns: repeat(1, 1fr); 
+  grid-template-rows: repeat(4, 1fr); 
+  grid-column-gap: 1rem;
+  grid-row-gap: 1rem; 
+  padding: 0;
+}
+
+@media (min-width: 400px) {
+  .content-boxes {
+    display: grid; 
+    grid-template-columns: repeat(2, 1fr); 
+    grid-template-rows: repeat(2, 1fr); 
+    grid-column-gap: 1rem;
+    grid-row-gap: 1rem; 
+    padding: 0;
+  }
+}
+
+ul.content-boxes {
+  margin: 1.5rem 0;
+}
+
+.content-boxes li {
+  display: flex;
+  list-style-type: none;
+}
+
+.content-boxes li + li {
+  margin: 0;
+}
+
+.content-boxes li a {
+  border: 1px solid var(--st-layout-border);
+  border-radius: var(--ifm-breadcrumb-border-radius);
+  color: var(--st-text);
+  display: block;
+  margin: 0;
+  padding: 1rem;
+  text-decoration: none;
+}
+
+.content-boxes li a:hover,
+.content-boxes li a:active,
+.content-boxes li a:focus {
+  border-color: var(--st-text-link-active);
+}
+
+.content-boxes li strong {
+  display: block;
+  color: var(--st-text-link);
+  font-size: 1.1rem;
+  margin: 0.25rem 0;
+}
+
 /* Footer */
 
 .footer {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -142,13 +142,13 @@ html, body {
 :root {
   --ifm-font-family-base:Inter,Helvetica,'Helvetica Neue',Arial,sans-serif;
   --ifm-font-family-monospace:SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;
-  --ifm-font-size-base:105%;
+  --ifm-font-size-base:100%;
   --ifm-line-height-base:1.45;
   --ifm-link-decoration:underline;
   --docusaurus-highlighted-code-line-bg:rgba(0,0,0,0.1);
   --ifm-heading-vertical-rhythm-bottom:.75;
   --ifm-code-background:var(--st-code-highlight-background);
-  --ifm-code-font-size:100%;
+  --ifm-code-font-size:95%;
   --ifm-code-padding-horizontal:.1rem;
   --ifm-code-padding-vertical:.1rem;
   --ifm-color-secondary:var(--st-text-secondary);
@@ -271,7 +271,7 @@ html, body {
   --ifm-menu-color-background-active: var(--st-highlight-background); 
   --ifm-menu-color-background-hover: var(--st-highlight-background-hover); 
   --ifm-menu-link-padding-horizontal: 0.75rem; 
-  --ifm-menu-link-padding-vertical: 0.2em; 
+  --ifm-menu-link-padding-vertical: 0.4em; 
   --ifm-menu-link-sublist-icon: url("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16px\" height=\"16px\" viewBox=\"0 0 24 24\"><path fill=\"black\" d=\"M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z\"></path></svg>"); 
 
   /* contents list */
@@ -877,7 +877,7 @@ html [class*=toggleButton] {
 .menu__list .menu__list { 
   flex: 0 0 100%; 
   margin-top: 0; 
-  margin-bottom: 0.1rem; 
+  margin-bottom: 0.2rem; 
 }
 .menu__list-item:not(:first-child) { 
   margin-top: 0; 
@@ -895,6 +895,11 @@ html [class*=toggleButton] {
   border-radius: 0;
   display: flex; 
   transition: background var(--ifm-transition-fast) var(--ifm-transition-timing-default); 
+}
+
+.theme-doc-sidebar-item-link-level-1 .menu__link {
+  padding-top: calc(var(--ifm-menu-link-padding-horizontal)*.5);
+  padding-bottom: calc(var(--ifm-menu-link-padding-horizontal)*.5);
 }
 
 .theme-doc-sidebar-item-link-level-2, .theme-doc-sidebar-item-link-level-3, .theme-doc-sidebar-item-link-level-4 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -620,6 +620,12 @@ a, a:hover {
 }
 
 .pagination-nav__link {
+  border-color: var(--st-layout-border) !important;
+}
+
+.pagination-nav__link:hover,
+.pagination-nav__link:active,
+.pagination-nav__link:focus {
   border-color: var(--st-link-button-border) !important;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1167,7 +1167,7 @@ ul.content-boxes {
   margin: 0;
 }
 
-.content-boxes li a {
+a.link-box {
   border: 1px solid var(--st-layout-border);
   border-radius: var(--ifm-breadcrumb-border-radius);
   color: var(--st-text);
@@ -1177,13 +1177,13 @@ ul.content-boxes {
   text-decoration: none;
 }
 
-.content-boxes li a:hover,
-.content-boxes li a:active,
-.content-boxes li a:focus {
+a.link-box:hover,
+a.link-box:active,
+a.link-box:focus {
   border-color: var(--st-text-link-active);
 }
 
-.content-boxes li strong {
+a.link-box strong {
   display: block;
   color: var(--st-text-link);
   font-size: 1.1rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -277,7 +277,7 @@ html, body {
   /* contents list */
   --ifm-toc-border-color: var(--st-layout-border); 
   --ifm-toc-link-color: var(--st-text); 
-  --ifm-toc-padding-vertical: 0.35rem; 
+  --ifm-toc-padding-vertical: 0.5rem; 
   --ifm-toc-padding-horizontal: 0.5rem; 
 
   /* tables */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,19 +27,19 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Nick’s colours */
+/* Editor’s colours */
 :root {
   /* Yellow */
-  --st-yellow-900: #2E0D00;
-  --st-yellow-800: #522300;
-  --st-yellow-700: #7D4201;
-  --st-yellow-600: #955701;
-  --st-yellow-500: #AF6600;
-  --st-yellow-400: #DA9500;
-  --st-yellow-300: #F5B900;
-  --st-yellow-200: #FACC40;
-  --st-yellow-100: #FEE17D;
-  --st-yellow-50: #FEF39D;
+  --st-yellow-50: rgba(254, 253, 192, .5);
+  --st-yellow-100: #FEFCBF;
+  --st-yellow-200: #FAF089;
+  --st-yellow-300: #F6E05E;
+  --st-yellow-400: #ECC94B;
+  --st-yellow-500: #D69E2E;
+  --st-yellow-600: #B7791F;
+  --st-yellow-700: #975A16;
+  --st-yellow-800: #744210;
+  --st-yellow-900: #5F370E;
 
   /* Pink */
   --st-pink-900: #370022;
@@ -90,16 +90,16 @@ html, body {
   --st-turquoise-50: #D6F7F9;
 
   /* Blue */
-  --st-blue-900: #0A123A;
-  --st-blue-800: #152972;
-  --st-blue-700: #1E4AAB;
-  --st-blue-600: #005DE6;
-  --st-blue-500: #0074F5;
-  --st-blue-400: #4CA5FF;
-  --st-blue-300: #80C9FF;
-  --st-blue-200: #A4D6FE;
-  --st-blue-100: #C8E7FC;
-  --st-blue-50: #E3F2FF;
+  --st-blue-900: #1A365D;
+  --st-blue-800: #2a4365;
+  --st-blue-700: #2c5282;
+  --st-blue-600: #2b6cb0;
+  --st-blue-500: #3182ce;
+  --st-blue-400: #4299e1;
+  --st-blue-300: #63b3ed;
+  --st-blue-200: #90cdf4;
+  --st-blue-100: #bee3f8;
+  --st-blue-50: #ebf8ff;
 
   /* Violet */
   --st-violet-900: #1A0A41;
@@ -114,18 +114,19 @@ html, body {
   --st-violet-50: #FCECFF;
 
   /* Gray */
-  --st-gray-900: #15151D;
-  --st-gray-850: #21202b;
-  --st-gray-800: #2E2E3D;
-  --st-gray-700: #4C5060;
-  --st-gray-600: #5F647A;
-  --st-gray-500: #71758D;
-  --st-gray-400: #9CA1B3;
-  --st-gray-300: #BCC2CD;
-  --st-gray-200: #CDD1DB;
-  --st-gray-100: #DEE3E8;
-  --st-gray-50: #EEF1F3;
-  --st-gray-25: #F4F7F8;
+  --st-gray-900: #151618;
+  --st-gray-850: #212226;
+  --st-gray-825: #27282A;
+  --st-gray-800: #2D2E34;
+  --st-gray-700: #45464F;
+  --st-gray-600: #5D5F6A;
+  --st-gray-500: #757785;
+  --st-gray-400: #8F919D;
+  --st-gray-300: #ABACB5;
+  --st-gray-200: #C6C7CD;
+  --st-gray-100: #E1E2E5;
+  --st-gray-50: #EFEFF1;
+  --st-gray-25: #F7F8FA;
 
   /* Red */
   --st-red-900: #30060A;
@@ -320,8 +321,8 @@ html[data-theme='light'], html[data-theme='light'] body {
   --st-code-highlight-background: var(--st-blue-50);
   --st-copy-button-background: var(--st-blue-100);
   --st-copy-button-text: var(--st-blue-800);
-  --st-highlight-background: var(--st-gray-100);
-  --st-highlight-background-hover: var(--st-gray-50);
+  --st-highlight-background: var(--st-yellow-100);
+  --st-highlight-background-hover: var(--st-yellow-50);
   --st-button-background: var(--st-blue-200);
   --st-button-background-hover: var(--st-blue-100);
   --st-button-text: var(--st-blue-800);
@@ -344,9 +345,10 @@ html[data-theme='light'], html[data-theme='light'] body {
   --docsearch-logo-color: var(--st-gray-600);
   --docsearch-modal-background: white;
   --docsearch-modal-shadow: 0 0 1rem 0 var(--st-gray-500);
-  --docsearch-searchbox-background: var(--st-gray-100);
-  --docsearch-searchbox-focus-background: var(--st-gray-50);
+  --docsearch-searchbox-background: white;
+  --docsearch-searchbox-focus-background: white;
   --docsearch-searchbox-shadow: inset 0 0 0 1px var(--st-gray-200);
+  --docsearch-searchbox-shadow-active: inset 0 0 0 1px var(--st-link-button-border);
   --docsearch-hit-source: var(--st-gray-700);
   --docsearch-hit-color: var(--st-gray-700);
   --docsearch-hit-active-color: var(--st-gray-800);
@@ -364,8 +366,8 @@ html[data-theme='light'], html[data-theme='light'] body {
   --st-tip-background: var(--st-gray-50);
   --st-tip-accent: var(--st-gray-100);
   --st-tip-text: var(--st-gray-700);
-  --st-warning-background: var(--st-yellow-50);
-  --st-warning-accent: var(--st-yellow-100);
+  --st-warning-background: var(--st-yellow-100);
+  --st-warning-accent: var(--st-yellow-200);
   --st-warning-text: var(--st-yellow-800);
   --st-danger-background: var(--st-red-50);
   --st-danger-accent: var(--st-red-100);
@@ -422,18 +424,18 @@ html[data-theme='dark'], html[data-theme='dark'] body {
 
   --st-background: var(--st-gray-900);
   --st-background-secondary: var(--st-gray-800);
-  --st-text: var(--st-gray-300);
-  --st-text-highlight: var(--st-gray-200);
+  --st-text: var(--st-gray-200);
+  --st-text-highlight: var(--st-gray-100);
   --st-heading: var(--st-text-highlight);
-  --st-text-secondary: var(--st-gray-400);
+  --st-text-secondary: var(--st-gray-200);
   --st-text-link: var(--st-blue-300);
   --st-text-link-hover: var(--st-blue-400);
   --st-text-link-active: var(--st-blue-400);
   --st-announcement-bar-text: var(--st-blue-200);
   --st-announcement-bar-gradient: radial-gradient(circle, var(--st-blue-800) 0%, var(--st-blue-700) 67%, var(--st-blue-700) 90%, var(--st-blue-800) 100%);
-  --st-navbar-background: var(--st-gray-800);
-  --st-search-background: var(--st-gray-900);
-  --st-search-background-active: var(--st-gray-850);
+  --st-navbar-background: var(--st-gray-900);
+  --st-search-background: var(--st-gray-800);
+  --st-search-background-active: var(--st-gray-800);
   --st-header-border: var(--st-gray-700);
   --st-layout-border: var(--st-gray-700);
   --st-code-border: var(--st-background);
@@ -442,14 +444,14 @@ html[data-theme='dark'], html[data-theme='dark'] body {
   --st-copy-button-background: var(--st-blue-700);
   --st-copy-button-text: var(--st-blue-100);
   --st-highlight-background: var(--st-gray-800);
-  --st-highlight-background-hover: var(--st-gray-700);
+  --st-highlight-background-hover: var(--st-gray-825);
   --st-button-background-hover: var(--st-blue-700);
   --st-button-background: var(--st-gray-800);
   --st-button-text: white;
   --st-icon-filter: invert(100%) brightness(100%);
   --st-header-link: var(--st-gray-200);
   --st-footer-link: var(--st-gray-200);
-  --st-link-button-border: var(--st-gray-700);
+  --st-link-button-border: var(--st-blue-500);
   --st-menu-link-hover: var(--st-gray-100);
   --st-menu-link-active: var(--st-gray-100);
 
@@ -489,9 +491,10 @@ html[data-theme='dark'], html[data-theme='dark'] body {
   --docsearch-logo-color: var(--st-gray-500); 
   --docsearch-modal-background:var(--st-gray-900); 
   --docsearch-modal-shadow: 0 0 1rem 0 black;
-  --docsearch-searchbox-background: var(--st-gray-850); 
+  --docsearch-searchbox-background: var(--st-gray-800); 
   --docsearch-searchbox-focus-background: var(--st-gray-800);
-  --docsearch-searchbox-shadow: inset 0 0 0 1px var(--st-gray-400); 
+  --docsearch-searchbox-shadow: inset 0 0 0 1px var(--st-gray-700);
+  --docsearch-searchbox-shadow-active: inset 0 0 0 1px var(--st-link-button-border); 
   --docsearch-hit-source: var(--st-gray-300);
   --docsearch-hit-color: var(--st-gray-300); 
   --docsearch-hit-active-color: white; 
@@ -753,18 +756,20 @@ html .DocSearch-Modal {
   border-radius: 10px !important;
 }
 
+html .DocSearch-Form:has(.DocSearch-Input:focus) {
+  box-shadow: var(--docsearch-searchbox-shadow-active);
+}
+
 html body.DocSearch--active #__docusaurus:not(.DocSearch-Container) {
   filter: blur(2px);
 }
 
-/* only show searchbox border on hover and when modal is open */
-
 html .DocSearch-Button {
-  box-shadow: none;
+  box-shadow: var(--docsearch-searchbox-shadow);
 }
 
-html .DocSearch-Button:active, .DocSearch-Button:focus, .DocSearch-Button:hover {
-  box-shadow: var(--docsearch-searchbox-shadow);
+html .DocSearch-Button:active, html .DocSearch-Button:focus, html .DocSearch-Button:hover {
+  box-shadow: var(--docsearch-searchbox-shadow-active);
 }
 
 html .DocSearch-MagnifierLabel,
@@ -881,6 +886,7 @@ html [class*=toggleButton] {
 }
 
 .menu { 
+  font-weight: var(--ifm-font-weight-normal);
   overflow-x: hidden; 
 }
 .menu__list { 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -689,7 +689,13 @@ code {
 /* force search to align with sidebar by making logo width of sidebar */
 .navbar__brand {
   margin-right: 0;
-  width: calc(var(--doc-sidebar-width) - 1rem);
+}
+
+@media (min-width: 997px) {
+  .navbar__brand {
+    margin-right: 0;
+    width: calc(var(--doc-sidebar-width) - 1rem);
+  }
 }
 
 .navbar__logo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,16 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
+"@fec/remark-a11y-emoji@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@fec/remark-a11y-emoji/-/remark-a11y-emoji-3.1.0.tgz#765ead0e26b6f06878f246c6e920a6edf0a5dc08"
+  integrity sha512-cYjCutvrValbQ2dykKhEE6OBTsEGpAJzeJnDtGKXhk2JYkMNSlKPnUk/kRFHH+PHmrAF+FlNIU28XKD+nYy7jQ==
+  dependencies:
+    emoji-regex "^9.2.0"
+    gemoji "^6.1.0"
+    mdast-util-find-and-replace "^1.0.0"
+    unist-util-visit "^2.0.3"
+
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -3522,7 +3532,7 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emoji-regex@^9.2.2:
+emoji-regex@^9.2.0, emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
@@ -3965,6 +3975,11 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+gemoji@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/gemoji/-/gemoji-6.1.0.tgz#268fbb0c81d1a8c32a4bcc39bdfdd66080ba7ce9"
+  integrity sha512-MOlX3doQ1fsfzxQX8Y+u6bC5Ssc1pBUBIPVyrS69EzKt+5LIZAOm0G5XGVNhwXFgkBF3r+Yk88ONyrFHo8iNFA==
 
 gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -4966,6 +4981,15 @@ mdast-util-definitions@^4.0.0:
   integrity sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
   dependencies:
     unist-util-visit "^2.0.0"
+
+mdast-util-find-and-replace@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz#b7db1e873f96f66588c321f1363069abf607d1b5"
+  integrity sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit-parents "^3.0.0"
 
 mdast-util-to-hast@10.0.1:
   version "10.0.1"


### PR DESCRIPTION
This PR:
- Knocks font size down slightly and increase sidebar horizontal spacing (see below)
- Makes emoji used in content more accessible with remark plugin
- Adds context boxes style for the homepage list of links (see below)
- Adds a little more detail to the XState page intro, based on an explainer David wrote
- Fixes the alignment of the lightmode/darkmode button on narrow viewports
- Fixes the font weight in Firefox
- Makes colours and contrast more like current Studio modes

## Updated! New colours and contrast

<img width="1602" alt="CleanShot 2023-02-17 at 13 05 21@2x" src="https://user-images.githubusercontent.com/266663/219660662-0fc41721-6028-40d0-9abb-a1617f499b5c.png">
<img width="1602" alt="CleanShot 2023-02-17 at 13 04 55@2x" src="https://user-images.githubusercontent.com/266663/219660673-13f87bac-0fdd-4d90-b37d-aaa8d84386c9.png">

## Knock font size down slightly and increase sidebar horizontal spacing 

Before:
<img width="291" alt="CleanShot 2023-02-15 at 15 27 32@2x" src="https://user-images.githubusercontent.com/266663/219078319-e625d9d8-0351-4f2b-90b5-344fe98cd3dd.png">
After:
<img width="291" alt="CleanShot 2023-02-15 at 15 46 13@2x" src="https://user-images.githubusercontent.com/266663/219078412-7412344f-93ab-4ee1-ba86-4fa816440678.png">

## Add context boxes style for the homepage list of links

This is just HTML in the homepage content, with corresponding CSS in the custom.css file.

Before:
<img width="852" alt="CleanShot 2023-02-16 at 12 22 51@2x" src="https://user-images.githubusercontent.com/266663/219364060-ea2cd819-cd9b-4d1f-a4f0-97ee6c22f3e1.png">

After:
<img width="852" alt="CleanShot 2023-02-16 at 12 23 07@2x" src="https://user-images.githubusercontent.com/266663/219364071-cb1628ef-aa4c-462b-b4bd-2a5f27369563.png">
