### PR TITLE
Fixed broken links

### DIFF
--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -8,13 +8,13 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Welcome to the Stately docs
 
-Here you can find all the documentation for the Stately Studio and [XState](/xstate/intro). There are a few ways you might want to get started:
+Here you can find all the documentation for the Stately Studio and [XState](/xstate). There are a few ways you might want to get started:
 
 <ul className="content-boxes">
   <li><a className="link-box" href="/states/intro">🏁 <strong>Get started</strong> Jump straight into learning how to use the Editor, starting with states.</a></li>
   <li><a className="link-box" href="#studio-editor">⬇️ <strong>Editor overview</strong> Keep reading to find out more about the Studio Editor.</a></li>
   <li><a className="link-box" href="/state-machines-and-statecharts">🧠 <strong>Learn state machines and statecharts</strong> With our no-code introduction.</a></li>
-  <li><a className="link-box" href="/xstate/intro">💻 <strong>Learn XState</strong> Get started with our JavaScript and TypeScript library for state machines and statecharts.</a></li>
+  <li><a className="link-box" href="/xstate">💻 <strong>Learn XState</strong> Get started with our JavaScript and TypeScript library for state machines and statecharts.</a></li>
 </ul>
 
 The Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](/tools/developer-tools), and much more coming soon. 
@@ -71,7 +71,7 @@ Run the statechart, trigger events, and see the active state nodes.
 
 ### Export
 
-You can also export machines to JSON, JavaScript and TypeScript, ready to be used in your codebase with [XState](/xstate/intro).
+You can also export machines to JSON, JavaScript and TypeScript, ready to be used in your codebase with [XState](/xstate).
 
 ## Projects and teams
 


### PR DESCRIPTION
The links to the XState intro section point to `/xstate/intro` which is a 404, they should point to `/xstate` instead