### PR TITLE
Fix grid rendering in docs footer

### DIFF
--- a/docs/admonition-examples.mdx
+++ b/docs/admonition-examples.mdx
@@ -136,6 +136,24 @@ This is an XState admonition with an h2 heading.
 :::
 ```
 
+:::warningxstate
+
+## XState v5 Alpha
+
+`X feature` is only available in XState version 5. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
+```
+:::warningxstate
+
+## XState v5 Alpha
+
+`X feature` is only available in XState version 5. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+```
+
 ### TypeScript
 
 :::typescript

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,6 +60,7 @@ const config = {
               'danger',
               'typescript',
               'xstate',
+              'warningxstate',
               'studio',
             ],
           },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1388,45 +1388,48 @@ span.footer__link-item a:active {
     display: grid;
     grid-template-columns: 50% 1fr repeat(6, minmax(auto, 3rem));
     grid-template-rows: repeat(4, minmax(1.5rem, auto));
-    grid-template-areas:  "a   x01  b   c   d   e   f   g"
-                          "h   x02 x03 x04 x05 x06 x07 x08"
-                          "j   x09  i   i   i   i   i   i"
-                          "x10 x11  i   i   i   i   i   i";
+    grid-template-areas:  "link-one . github discord mastodon twitter youtube linkedin"
+                          "link-two . . . . . . ."
+                          "link-thr . form form form form form form"
+                          ". . form form form form form form";
     align-content: start;
     gap: 0;
     margin-top: 1rem;
   }
 
   .footer__links li:nth-of-type(1) {
-    grid-area: a;
-    margin-top: 0;
+    grid-area: link-one;
   }
   .footer__links li:nth-of-type(2) {
-    grid-area: h;
+    grid-area: link-two;
   }
   .footer__links li:nth-of-type(3) {
-    grid-area: j;
+    grid-area: link-thr;
   }
   .footer__links li:nth-of-type(4) {
-    grid-area: b;
+    grid-area: github;
   }
   .footer__links li:nth-of-type(5) {
-    grid-area: c;
+    grid-area: discord;
   }
   .footer__links li:nth-of-type(6) {
-    grid-area: d;
+    grid-area: mastodon;
   }
   .footer__links li:nth-of-type(7) {
-    grid-area: e;
+    grid-area: twitter;
   }
   .footer__links li:nth-of-type(8) {
-    grid-area: f;
+    grid-area: youtube;
   }
   .footer__links li:nth-of-type(9) {
-    grid-area: g;
+    grid-area: linkedin;
   }
   .footer__links li:nth-of-type(10) {
-    grid-area: i;
+    grid-area: form;
+  }
+
+  .footer__links li:nth-of-type(1) {
+    margin-top: 0;
   }
 
   .footer__links form {
@@ -1437,10 +1440,10 @@ span.footer__link-item a:active {
 @media (min-width: 997px) {
   ul.footer__links {
     grid-template-columns: var(--doc-sidebar-width) 30% 1fr repeat(6, minmax(auto, 3rem));
-    grid-template-areas:  "x01  a  x02  b   c   d   e   f   g "
-                          "x03  h  x04 x05 x06 x07 x08 x09 x10"
-                          "x11  j  x12  i   i   i   i   i   i"
-                          "x13 x14 x15  i   i   i   i   i   i";
+    grid-template-areas:  ". link-one . github discord mastodon twitter youtube linkedin"
+                          ". link-two . . . . . . ."
+                          ". link-thr . form form form form form form"
+                          ". . . form form form form form form";
   }
 }
 
@@ -1456,10 +1459,10 @@ span.footer__link-item a:active {
 
   ul.footer__links {
     grid-template-columns: 30% 1fr repeat(6, minmax(auto, 3rem));
-    grid-template-areas:  " a  x01  b   c   d   e   f   g"
-                          " h  x02 x03 x04 x05 x06 x07 x08"
-                          " j  x09  i   i   i   i   i   i"
-                          "x10 x11  i   i   i   i   i   i";
+    grid-template-areas:  "link-one . github discord mastodon twitter youtube linkedin"
+                          "link-two . . . . . . ."
+                          "link-thr . form form form form form form"
+                          ". . form form form form form form";
   }
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1171,7 +1171,7 @@ footer [class*=iconExternalLink] {
   --ifm-alert-border-color: var(--st-danger-accent);
 }
 
-.alert--warning {
+.alert--warning, .alert--warningxstate {
   --ifm-alert-background-color: var(--st-warning-background);
   --ifm-alert-background-color-highlight: var(--st-warning-accent);
   --ifm-alert-foreground-color: var(--st-warning-text);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1388,10 +1388,7 @@ span.footer__link-item a:active {
     display: grid;
     grid-template-columns: 50% 1fr repeat(6, minmax(auto, 3rem));
     grid-template-rows: repeat(4, minmax(1.5rem, auto));
-    grid-template-areas:  "a . b c d e f g"
-                          "h . . . . . . ."
-                          "j . i i i i i i"
-                          ". . i i i i i i";
+    grid-template-areas:  "a . b c d e f g" "h . . . . . . ." "j . i i i i i i" ". . i i i i i i";
     align-content: start;
     gap: 0;
     margin-top: 1rem;
@@ -1399,6 +1396,7 @@ span.footer__link-item a:active {
 
   .footer__links li:nth-of-type(1) {
     grid-area: a;
+    margin-top: 0;
   }
   .footer__links li:nth-of-type(2) {
     grid-area: h;
@@ -1428,10 +1426,6 @@ span.footer__link-item a:active {
     grid-area: i;
   }
 
-  .footer__links li:nth-of-type(1) {
-    margin-top: 0;
-  }
-
   .footer__links form {
     margin: 0;
   }
@@ -1440,10 +1434,7 @@ span.footer__link-item a:active {
 @media (min-width: 997px) {
   ul.footer__links {
     grid-template-columns: var(--doc-sidebar-width) 30% 1fr repeat(6, minmax(auto, 3rem));
-    grid-template-areas:  ". a . b c d e f g"
-                          ". h . . . . . . ."
-                          ". j . i i i i i i"
-                          ". . . i i i i i i";
+    grid-template-areas:  ". a . b c d e f g" ". h . . . . . . ." ". j . i i i i i i" ". . . i i i i i i";
   }
 }
 
@@ -1459,10 +1450,7 @@ span.footer__link-item a:active {
 
   ul.footer__links {
     grid-template-columns: 30% 1fr repeat(6, minmax(auto, 3rem));
-    grid-template-areas:  "a . b c d e f g"
-                          "h . . . . . . ."
-                          "j . i i i i i i"
-                          ". . i i i i i i";
+    grid-template-areas:  "a . b c d e f g" "h . . . . . . ." "j . i i i i i i" ". . i i i i i i";
   }
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1388,7 +1388,10 @@ span.footer__link-item a:active {
     display: grid;
     grid-template-columns: 50% 1fr repeat(6, minmax(auto, 3rem));
     grid-template-rows: repeat(4, minmax(1.5rem, auto));
-    grid-template-areas:  "a . b c d e f g" "h . . . . . . ." "j . i i i i i i" ". . i i i i i i";
+    grid-template-areas:  "a   x01  b   c   d   e   f   g"
+                          "h   x02 x03 x04 x05 x06 x07 x08"
+                          "j   x09  i   i   i   i   i   i"
+                          "x10 x11  i   i   i   i   i   i";
     align-content: start;
     gap: 0;
     margin-top: 1rem;
@@ -1434,7 +1437,10 @@ span.footer__link-item a:active {
 @media (min-width: 997px) {
   ul.footer__links {
     grid-template-columns: var(--doc-sidebar-width) 30% 1fr repeat(6, minmax(auto, 3rem));
-    grid-template-areas:  ". a . b c d e f g" ". h . . . . . . ." ". j . i i i i i i" ". . . i i i i i i";
+    grid-template-areas:  "x01  a  x02  b   c   d   e   f   g "
+                          "x03  h  x04 x05 x06 x07 x08 x09 x10"
+                          "x11  j  x12  i   i   i   i   i   i"
+                          "x13 x14 x15  i   i   i   i   i   i";
   }
 }
 
@@ -1450,7 +1456,10 @@ span.footer__link-item a:active {
 
   ul.footer__links {
     grid-template-columns: 30% 1fr repeat(6, minmax(auto, 3rem));
-    grid-template-areas:  "a . b c d e f g" "h . . . . . . ." "j . i i i i i i" ". . i i i i i i";
+    grid-template-areas:  " a  x01  b   c   d   e   f   g"
+                          " h  x02 x03 x04 x05 x06 x07 x08"
+                          " j  x09  i   i   i   i   i   i"
+                          "x10 x11  i   i   i   i   i   i";
   }
 }
 

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -182,6 +182,18 @@ const AdmonitionConfigs = {
       </Translate>
     ),
   },
+  warningxstate: {
+    infimaClassName: 'warningxstate',
+    iconComponent: XStateIcon,
+    label: (
+      <Translate
+        id="theme.admonition.warningxstate"
+        description="The default label used for the XState warning admonition (:::warningxstate)"
+      >
+        XState Warning
+      </Translate>
+    ),
+  },
 };
 // Legacy aliases, undocumented but kept for retro-compatibility
 const aliases = {


### PR DESCRIPTION
This PR has a workaround to fix the footer grid rendering.

As a bonus, it also contains a new “admonition” for use with XState v5 content. You can use:

```
:::warningxstate

## XState v5 Alpha

`X feature` is only available in XState version 5. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).

:::
```

to render a box that flags the content in a coloured box with an XState icon:

<img width="688" alt="CleanShot 2023-03-01 at 12 11 44@2x" src="https://user-images.githubusercontent.com/266663/222135925-df020b4f-fd78-4aaf-9935-5c438c4e84cb.png">
