### PR TITLE
Flag current v5 content with XState v5 warning/information box

### DIFF
--- a/docs/xstate/actors/actions-vs-actors.mdx
+++ b/docs/xstate/actors/actions-vs-actors.mdx
@@ -102,6 +102,13 @@ const machine = createMachine(
 );
 ```
 
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
+
 Now, the sequence in the example above is:
 
 1. In the `collectingFormDetails` state, we receive the `SUBMIT` event.

--- a/docs/xstate/actors/callbacks.mdx
+++ b/docs/xstate/actors/callbacks.mdx
@@ -2,6 +2,9 @@
 title: Callbacks
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 <!-- Needs technical review -->
 
 <!-- deps: ["actors", "promise-actors"] -->
@@ -13,6 +16,30 @@ Promise actors let you model promises declaratively but not every actor will be 
 - Start listeners/processes and clean them up when needed
 
 Callback actors are declared using the `() => () => {}` syntax, which is how XState distinguishes them from promise actors, which are declared as: `() => {}`.
+
+<Tabs>
+<TabItem value="v4" label="XState v4">
+
+```ts twoslash
+import { createMachine } from 'xstate';
+
+createMachine(
+  {
+    invoke: {
+      src: 'callbackActor',
+    },
+  }
+);
+```
+
+</TabItem>
+<TabItem value="v5" label="XState v5">
+
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
 
 ```ts twoslash
 import { createMachine } from 'xstate';
@@ -38,6 +65,9 @@ createMachine(
   }
 );
 ```
+
+</TabItem>
+</Tabs>
 
 Callbacks are called with:
 

--- a/docs/xstate/actors/callbacks.mdx
+++ b/docs/xstate/actors/callbacks.mdx
@@ -2,9 +2,6 @@
 title: Callbacks
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <!-- Needs technical review -->
 
 <!-- deps: ["actors", "promise-actors"] -->
@@ -16,30 +13,6 @@ Promise actors let you model promises declaratively but not every actor will be 
 - Start listeners/processes and clean them up when needed
 
 Callback actors are declared using the `() => () => {}` syntax, which is how XState distinguishes them from promise actors, which are declared as: `() => {}`.
-
-<Tabs>
-<TabItem value="v4" label="XState v4">
-
-```ts twoslash
-import { createMachine } from 'xstate';
-
-createMachine(
-  {
-    invoke: {
-      src: 'callbackActor',
-    },
-  }
-);
-```
-
-</TabItem>
-<TabItem value="v5" label="XState v5">
-
-:::warningxstate
-
-XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
-
-:::
 
 ```ts twoslash
 import { createMachine } from 'xstate';
@@ -66,8 +39,11 @@ createMachine(
 );
 ```
 
-</TabItem>
-</Tabs>
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
 
 Callbacks are called with:
 

--- a/docs/xstate/actors/intro.mdx
+++ b/docs/xstate/actors/intro.mdx
@@ -31,6 +31,12 @@ const machine = createMachine(
 );
 ```
 
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
 You can also run several invocations at the same time by specifying `invoke` as an array:
 
 ```ts twoslash

--- a/docs/xstate/actors/parent-child-communication.mdx
+++ b/docs/xstate/actors/parent-child-communication.mdx
@@ -115,6 +115,12 @@ const pingPongMachine = createMachine(
 );
 ```
 
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
 ## forwardTo
 
 <!-- deps: ["actions", "receiving-events-from-parent"] -->

--- a/docs/xstate/actors/promises.mdx
+++ b/docs/xstate/actors/promises.mdx
@@ -35,6 +35,12 @@ const userMachine = createMachine(
 );
 ```
 
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
 When a promise actor is resolved, a `done.invoke` event is sent back to the machine which includes its data, placed under the `data` property. For example:
 
 ```js

--- a/docs/xstate/basics/options.mdx
+++ b/docs/xstate/basics/options.mdx
@@ -174,6 +174,12 @@ const machine = createMachine(
 );
 ```
 
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
 Or, you can specify options later with a `.withConfig` call:
 
 ```ts twoslash

--- a/docs/xstate/typescript/typegen.mdx
+++ b/docs/xstate/typescript/typegen.mdx
@@ -148,6 +148,12 @@ createMachine(
 );
 ```
 
+:::warningxstate
+
+XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-alpha.1).
+
+:::
+
 ## Typegen best practices
 
 Below are some recommendations to help you get the most out of using typegen.


### PR DESCRIPTION
This is the first step to however we decide to handle versioning/showing v4 vs v5 content.

<img width="952" alt="CleanShot 2023-03-01 at 17 11 48@2x" src="https://user-images.githubusercontent.com/266663/222212413-664666a1-9177-4c04-960f-84d29093d7af.png">
