### PR TITLE
Turn docs sidebar category headings into links (and upgrade Docusaurus to 2.4.0)

### DIFF
--- a/docs/actions-and-actors/entry-and-exit-actions.mdx
+++ b/docs/actions-and-actors/entry-and-exit-actions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Entry & exit actions
+description: 'An action can be fired upon entry or exit of a state. Actions are “fire-and-forget effects”; once the machine has fired the action, it moves on and forgets the action. You can also fire actions on transitions.'
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/docs/descriptions.mdx
+++ b/docs/descriptions.mdx
@@ -4,13 +4,13 @@ title: Descriptions
 
 import ThemedImage from '@theme/ThemedImage';
 
+You can add descriptions to state and event nodes to describe their purpose and share related notes with your team. Descriptions support markdown formatting, including links and images.
+
 :::tip
 
 Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/watch?v=qflVEMsCrEE&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=10) (1m34s).
 
 :::
-
-You can add descriptions to state and event nodes to describe their purpose and share related notes with your team. Descriptions support markdown formatting, including links and images.
 
 The machine object will include your descriptions in the state or event's `description` when you export your statecharts to JSON.
 

--- a/docs/import-from-code.mdx
+++ b/docs/import-from-code.mdx
@@ -2,13 +2,13 @@
 title: Import from code
 ---
 
+Importing from code is helpful if you’ve already built machines while working with [XState](/xstate/), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio Editor.
+
 :::tip
 
 Watch our [“Import from code” video on YouTube](https://www.youtube.com/watch?v=DAoIFaugDLo) (2m24s).
 
 :::
-
-Importing from code is helpful if you’ve already built machines while working with [XState](/xstate/), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio Editor.
 
 ## Import code
 

--- a/docs/states/final-states.mdx
+++ b/docs/states/final-states.mdx
@@ -4,13 +4,13 @@ title: Final states
 
 import ThemedImage from '@theme/ThemedImage';
 
+When a machine reaches the final state, it can no longer receive any events, and anything running inside it is canceled and cleaned up. The box with a surrounding border icon represents the final state.
+
 :::tip
 
 Watch our [“What are final states?” video on YouTube](https://www.youtube.com/watch?v=wqW8Gz4NYDc&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=7) (55s).
 
 :::
-
-When a machine reaches the final state, it can no longer receive any events, and anything running inside it is canceled and cleaned up. The box with a surrounding border icon represents the final state.
 
 A machine can have multiple final states or no final states.
 

--- a/docs/states/initial-states.mdx
+++ b/docs/states/initial-states.mdx
@@ -4,13 +4,13 @@ title: Initial states
 
 import ThemedImage from '@theme/ThemedImage';
 
+When a state machine starts, it enters the **initial state** first. A machine can only have one top-level initial state; if there were multiple initial states, the machine wouldn’t know where to start!
+
 :::tip
 
 Watch our [“What are initial states?” video on YouTube](https://www.youtube.com/watch?v=goCpmgyrjL0&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=3) (1m17s).
 
 :::
-
-When a state machine starts, it enters the **initial state** first. A machine can only have one top-level initial state; if there were multiple initial states, the machine wouldn’t know where to start!
 
 In our video player, paused is the initial state because the video player is paused by default and requires user interaction to start playing.
 

--- a/docs/states/intro.mdx
+++ b/docs/states/intro.mdx
@@ -4,13 +4,13 @@ title: States
 
 import ThemedImage from '@theme/ThemedImage';
 
+A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
+
 :::tip
 
 Watch our [“What are states?” video on YouTube](https://www.youtube.com/watch?v=z-6yhmSWUcc&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=2) (53s).
 
 :::
-
-A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
 
 <p>
   <ThemedImage

--- a/docs/states/parallel-states.mdx
+++ b/docs/states/parallel-states.mdx
@@ -4,13 +4,13 @@ title: Parallel states
 
 import ThemedImage from '@theme/ThemedImage';
 
+A parallel state is a state separated into multiple regions of child states, where each region is active simultaneously.
+
 :::tip
 
 Watch our [“What are parallel states?” video on YouTube](https://www.youtube.com/watch?v=CWwgT1TbI4c&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=6) (54s).
 
 :::
-
-A parallel state is a state separated into multiple regions of child states, where each region is active simultaneously.
 
 A dashed line borders each region.
 

--- a/docs/states/parent-states.mdx
+++ b/docs/states/parent-states.mdx
@@ -4,15 +4,15 @@ title: Parent states
 
 import ThemedImage from '@theme/ThemedImage';
 
+States can contain more states, also known as **child states**. These child states are only active when the parent state is active.
+
+Child states are nested inside their parent states.
+
 :::tip
 
 Watch our [“Parent and child states” video on YouTube](https://www.youtube.com/watch?v=aUhEdeIf_mQ&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=5) (1m6s).
 
 :::
-
-States can contain more states, also known as **child states**. These child states are only active when the parent state is active.
-
-Child states are nested inside their parent states.
 
 <p>
 <ThemedImage

--- a/docs/tools/visualizer.mdx
+++ b/docs/tools/visualizer.mdx
@@ -4,6 +4,8 @@ title: Visualizer
 
 # Visualizer
 
+The Stately Visualizer is a tool for creating and inspecting statecharts to visualize the state of your applications. You can use the viz as a playground for exploring XState’s capabilities.
+
 :::studio
 
 Are you looking for the _Stately Studio_ visual _Editor_? Check out the [Stately Studio overview](/).

--- a/docs/transitions-and-events/delayed-transitions.mdx
+++ b/docs/transitions-and-events/delayed-transitions.mdx
@@ -5,13 +5,13 @@ title: Delayed (after) transitions
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+**Delayed transitions** are transitions that only happen after a specified interval of time. If another event happens before the end of the timer, the transition doesn’t complete. Delayed transitions are handy if you need to build timeouts and intervals into your application logic.
+
 :::tip
 
 Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtube.com/watch?v=5RE_eazRhrw&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=12) (1m17s).
 
 :::
-
-**Delayed transitions** are transitions that only happen after a specified interval of time. If another event happens before the end of the timer, the transition doesn’t complete. Delayed transitions are handy if you need to build timeouts and intervals into your application logic.
 
 Delayed transitions are labeled “after” and often referred to as “after” transitions.
 

--- a/docs/transitions-and-events/intro.mdx
+++ b/docs/transitions-and-events/intro.mdx
@@ -5,13 +5,13 @@ title: Transitions and events
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+A machine moves from state to state through **transitions**. Transitions are caused by events; when an event happens, the machine transitions to the next state.
+
 :::tip
 
 Watch our [“Transitions and events” video on YouTube](https://www.youtube.com/watch?v=0qgP4RZyq58&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=4) (1m50s).
 
 :::
-
-A machine moves from state to state through **transitions**. Transitions are caused by events; when an event happens, the machine transitions to the next state.
 
 Transitions are “deterministic”; each combination of state and event always points to the same next state.
 

--- a/docs/transitions-and-events/state-done-events.mdx
+++ b/docs/transitions-and-events/state-done-events.mdx
@@ -5,13 +5,13 @@ title: State done events
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+A **state done event** transitions from a parent state when one of its child states reaches its final state. State done events are labeled “onDone.”
+
 :::tip
 
 Watch our [“What are state done events?” video on YouTube](https://www.youtube.com/watch?v=3laC3gWBLnM&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=11) (1m16s).
 
 :::
-
-A **state done event** transitions from a parent state when one of its child states reaches its final state. State done events are labeled “onDone.”
 
 <!-- TODO: write more about why you might use an onDone event -->
 

--- a/docs/xstate/actors/spawn.mdx
+++ b/docs/xstate/actors/spawn.mdx
@@ -1,5 +1,6 @@
 ---
 title: Spawning actors
+description: 'Sometimes invoking actors may not be flexible enough for your needs. In such cases, you might want to invoke child machines that last across several states or invoke a dynamic number of actors.'
 ---
 
 # Spawning actors

--- a/docs/xstate/advanced/react-patterns.mdx
+++ b/docs/xstate/advanced/react-patterns.mdx
@@ -1,5 +1,6 @@
 ---
 title: React Patterns
+description: 'Using React hooks are the easiest way to use state machines in your components. You can use the official @xstate/react package to give you useful hooks out of the box, such as useMachine.'
 ---
 
 # React Patterns

--- a/docs/xstate/basics/inline-vs-named-options.mdx
+++ b/docs/xstate/basics/inline-vs-named-options.mdx
@@ -1,5 +1,6 @@
 ---
 title: Inline vs. named Options
+description: 'Named actions are when you pass options into the config using names. You can also declare your actions inline without names.'
 ---
 
 # Inline vs. named Options

--- a/docs/xstate/model-based-testing/quickstart.mdx
+++ b/docs/xstate/model-based-testing/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Quickstart'
+description: 'How to get started quickly with model-based testing using XState and @xstate/test.'
 ---
 
 # Quickstart

--- a/docs/xstate/running-machines/intro.mdx
+++ b/docs/xstate/running-machines/intro.mdx
@@ -1,5 +1,6 @@
 ---
 title: Running machines
+description: 'Depending on where you’re using XState, you’ll likely need to run machines differently. We’ll start with the VanillaJS approach for now.'
 ---
 
 # Running machines

--- a/docs/xstate/running-machines/node.mdx
+++ b/docs/xstate/running-machines/node.mdx
@@ -1,5 +1,6 @@
 ---
 title: Node
+description: 'Patterns for long-running processes and async functions when running machines in Node.'
 ---
 
 # Node

--- a/docs/xstate/running-machines/node.mdx
+++ b/docs/xstate/running-machines/node.mdx
@@ -49,4 +49,82 @@ XState is extremely powerful at managing long-running processes like this, where
 
 ## Async functions
 
-%{{ wait-for }}
+Lots of backend code relies on short-running processes, such as backend functions, especially in serverless contexts where code needs to boot up and shut down as fast as possible.
+
+Much of this type of code relies on `async` functions:
+
+```ts twoslash
+const myFunc = async () => {};
+```
+
+The best pattern to use for async functions is `waitFor`, which allows you to `await` a state machine being in a particular state.
+
+```ts twoslash
+import { interpret, createMachine } from "xstate";
+import { waitFor } from "xstate/lib/waitFor";
+
+const machine = createMachine({
+  initial: "pending",
+  states: {
+    pending: {
+      after: {
+        3000: {
+          target: "done",
+        },
+      },
+    },
+    done: {},
+  },
+});
+
+const myFunc = async () => {
+  const actor = interpret(machine).start();
+
+  const doneState = await waitFor(actor, (state) =>
+    state.matches("done"),
+  );
+
+  console.log(doneState.value); // 'done'
+};
+```
+
+In the example above, the machine waits for three seconds before moving on to its `done` state, at which point the `await` will resolve, and the program will move on.
+
+By default, `waitFor` will time out after 10 seconds if the desired state is not reached. You can customize this timeout by passing `timeout` in the options:
+
+```ts twoslash {8-11}
+import { interpret, createMachine } from "xstate";
+import { waitFor } from "xstate/lib/waitFor";
+
+const machine = createMachine({
+  initial: "pending",
+  states: {
+    pending: {
+      after: {
+        3000: {
+          target: "done",
+        },
+      },
+    },
+    done: {},
+  },
+});
+
+// ---cut---
+
+const myFunc = async () => {
+  const actor = interpret(machine).start();
+
+  const doneState = await waitFor(
+    actor,
+    (state) => state.matches("done"),
+    {
+      // 20 seconds in ms
+      timeout: 20_000,
+    },
+  );
+};
+```
+
+`waitFor` will also throw an error if the actor reaches a final state _before_ satisfying the condition. [Read more about final states](/xstate/states/final-states.mdx).
+

--- a/docs/xstate/running-machines/react.mdx
+++ b/docs/xstate/running-machines/react.mdx
@@ -1,5 +1,6 @@
 ---
 title: XState in React
+description: 'You can use XState with React to coordinate local state, manage global state performantly, and consume data from other hooks.'
 ---
 
 # XState in React

--- a/docs/xstate/templates.mdx
+++ b/docs/xstate/templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Templates'
+description: 'We have XState templates for TypeScript, React Typescript, Vue, Svelte, and more!'
 ---
 
 Check out our new templates:

--- a/docs/xstate/typescript/typegen.mdx
+++ b/docs/xstate/typescript/typegen.mdx
@@ -1,5 +1,6 @@
 ---
 title: Typegen
+description: 'You can automatically generate intelligent typings for XState using our VS Code extension or our CLI.'
 ---
 
 <!-- Needs technical review -->

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -112,7 +112,7 @@
     "description": "The ARIA label for the breadcrumbs"
   },
   "theme.docs.DocCard.categoryDescription": {
-    "message": "{count} items",
+    "message": "{count} pages.",
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
   "theme.docs.paginator.navAriaLabel": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.3.1",
-    "@docusaurus/preset-classic": "^2.3.1",
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/preset-classic": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "@xstate/inspect": "^0.7.0",
     "@xstate/machine-extractor": "^0.7.1",
@@ -29,7 +29,7 @@
     "xstate": "^4.34.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.3.1",
+    "@docusaurus/module-type-aliases": "^2.4.0",
     "@fec/remark-a11y-emoji": "^3.1.0",
     "@tsconfig/docusaurus": "^1.0.6",
     "dotenv": "^16.0.3",

--- a/sidebars.js
+++ b/sidebars.js
@@ -161,8 +161,11 @@ const sidebars = {
         {
           type: 'category',
           label: 'Basics',
+          link: {
+            type: 'doc',
+            id: 'xstate/basics/what-is-a-statechart',
+          },
           items: [
-            'xstate/basics/what-is-a-statechart',
             'xstate/basics/options',
             'xstate/basics/inline-vs-named-options',
           ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,12 +22,11 @@ const sidebars = {
     {
       type: 'category',
       label: '➡️  Get started',
+      link: {
+        type: 'doc',
+        id: 'studio',
+      },
       items: [
-        {
-          type: 'doc',
-          label: 'Introduction',
-          id: 'studio',
-        },
         {
           type: 'doc', 
           label:'State machines and statecharts',
@@ -44,12 +43,11 @@ const sidebars = {
         {
           type: 'category',
           label: 'States',
+          link: {
+            type: 'doc',
+            id: 'states/intro',
+          },
           items: [
-            {
-              type: 'doc',
-              id: 'states/intro',
-              label: 'Intro'
-            },
             'states/initial-states',
             'states/final-states',
             'states/parent-states',
@@ -60,12 +58,11 @@ const sidebars = {
         {
           type: 'category',
           label: 'Transitions and events',
+          link: {
+            type: 'doc',
+            id: 'transitions-and-events/intro',
+          },
           items: [
-            {
-              type: 'doc',
-              id: 'transitions-and-events/intro',
-              label: 'Intro'
-            },
             'transitions-and-events/guards',
             'transitions-and-events/eventless-transitions',
             'transitions-and-events/delayed-transitions',
@@ -154,12 +151,11 @@ const sidebars = {
       label: '🛠️  XState library',
       collapsed: false,
       collapsible: true,
+      link: {
+        type: 'doc',
+        id: 'xstate/intro',
+      },
       items: [
-        {
-          type: 'doc',
-          id: 'xstate/intro',
-          label: 'Intro',
-        },
         'xstate/installation',
         'xstate/templates',
         {
@@ -195,8 +191,11 @@ const sidebars = {
         {
           type: 'category',
           label: 'Running machines',
+          link: {
+            type: 'doc',
+            id: 'xstate/running-machines/intro',
+          },
           items: [
-            'xstate/running-machines/intro',
             'xstate/running-machines/react',
             'xstate/running-machines/node',
           ],
@@ -217,8 +216,11 @@ const sidebars = {
         {
           type: 'category',
           label: 'Model-based testing',
+          link: {
+            type: 'doc',
+            id: 'xstate/model-based-testing/intro',
+          },
           items: [
-            'xstate/model-based-testing/intro',
             'xstate/model-based-testing/when-to-use',
             'xstate/model-based-testing/quickstart',
             'xstate/model-based-testing/test-paths',
@@ -233,8 +235,11 @@ const sidebars = {
         {
           type: 'category',
           label: 'Actors',
+          link: {
+            type: 'doc',
+            id: 'xstate/actors/intro',
+          },
           items: [
-            'xstate/actors/intro',
             'xstate/actors/promises',
             'xstate/actors/actions-vs-actors',
             'xstate/actors/callbacks',
@@ -295,9 +300,9 @@ const sidebars = {
       ],
     },
     {
-      type: 'category',
+      type: 'doc',
       label: '🧑‍🏫  Examples',
-      items: ['examples/intro'],
+      id: 'examples/intro',
     },
     {
       type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -64,47 +64,47 @@ const sidebars = {
         'states/final-states',
         'states/parent-states',
         'states/parallel-states',
-        'states/history-states'
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Transitions and events',
-      link: {
-        type: 'generated-index',
-        title: 'Transitions and events',
-        description: 'Learn about all the possible transitions and events in the Stately Editor.',
-        slug: '/category/transitions-and-events',
-        keywords: ['guides'],
-      },
-      items: [
-        {
-          type: 'doc',
-          label: 'Transitions and events',
-          id: 'transitions-and-events/intro',
+        'states/history-states',
+      {
+        type: 'category',
+        label: 'Transitions and events',
+        link: {
+          type: 'generated-index',
+          title: 'Transitions and events',
+          description: 'Learn about all the possible transitions and events in the Stately Editor.',
+          slug: '/category/transitions-and-events',
+          keywords: ['guides'],
         },
-        'transitions-and-events/guards',
-        'transitions-and-events/eventless-transitions',
-        'transitions-and-events/delayed-transitions',
-        'transitions-and-events/self-transitions',
-        'transitions-and-events/state-done-events',
-        'transitions-and-events/invoke-done-events',
-        'transitions-and-events/invoke-error-events'
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Actions and actors',
-      link: {
-        type: 'generated-index',
-        title: 'Actions and actors',
-        description: 'Learn about actions and actors in the Stately Editor.',
-        slug: '/category/actions-and-actors',
-        keywords: ['guides'],
+        items: [
+          {
+            type: 'doc',
+            label: 'Transitions and events',
+            id: 'transitions-and-events/intro',
+          },
+          'transitions-and-events/guards',
+          'transitions-and-events/eventless-transitions',
+          'transitions-and-events/delayed-transitions',
+          'transitions-and-events/self-transitions',
+          'transitions-and-events/state-done-events',
+          'transitions-and-events/invoke-done-events',
+          'transitions-and-events/invoke-error-events'
+        ]
       },
-      items: [
-        'actions-and-actors/entry-and-exit-actions',
-        'actions-and-actors/actors',
+      {
+        type: 'category',
+        label: 'Actions and actors',
+        link: {
+          type: 'generated-index',
+          title: 'Actions and actors',
+          description: 'Learn about actions and actors in the Stately Editor.',
+          slug: '/category/actions-and-actors',
+          keywords: ['guides'],
+        },
+        items: [
+          'actions-and-actors/entry-and-exit-actions',
+          'actions-and-actors/actors',
+        ]
+      },
       ]
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,10 +23,18 @@ const sidebars = {
       type: 'category',
       label: '➡️  Get started',
       link: {
-        type: 'doc',
-        id: 'studio',
+        type: 'generated-index',
+        title: '➡️  Get started with Stately',
+        description: 'Learn about state machines, statecharts, and the Stately Editor',
+        slug: '/category/get-started',
+        keywords: ['guides'],
       },
       items: [
+        {
+          type: 'doc',
+          label: 'Introduction',
+          id: 'studio',
+        },
         {
           type: 'doc', 
           label:'State machines and statecharts',
@@ -37,60 +45,91 @@ const sidebars = {
     {
       type: 'category',
       label: '🏁  Core concepts',
+      link: {
+        type: 'generated-index',
+        title: '🏁  Stately core concepts',
+        description: 'Learn about states, transitions, events, actions, and actors in the Stately Studio.',
+        slug: '/category/core-concepts',
+        keywords: ['guides'],
+      },
       collapsed: false,
       collapsible: true,
       items: [
         {
-          type: 'category',
-          label: 'States',
-          link: {
-            type: 'doc',
-            id: 'states/intro',
-          },
-          items: [
-            'states/initial-states',
-            'states/final-states',
-            'states/parent-states',
-            'states/parallel-states',
-            'states/history-states'
-          ]
+          type: 'doc',
+          label: 'Introducing states',
+          id: 'states/intro',
         },
+        'states/initial-states',
+        'states/final-states',
+        'states/parent-states',
+        'states/parallel-states',
+        'states/history-states'
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Transitions and events',
+      link: {
+        type: 'generated-index',
+        title: 'Transitions and events',
+        description: 'Learn about all the possible transitions and events in the Stately Editor.',
+        slug: '/category/transitions-and-events',
+        keywords: ['guides'],
+      },
+      items: [
         {
-          type: 'category',
+          type: 'doc',
           label: 'Transitions and events',
-          link: {
-            type: 'doc',
-            id: 'transitions-and-events/intro',
-          },
-          items: [
-            'transitions-and-events/guards',
-            'transitions-and-events/eventless-transitions',
-            'transitions-and-events/delayed-transitions',
-            'transitions-and-events/self-transitions',
-            'transitions-and-events/state-done-events',
-            'transitions-and-events/invoke-done-events',
-            'transitions-and-events/invoke-error-events'
-          ]
+          id: 'transitions-and-events/intro',
         },
-        {
-          type: 'category',
-          label: 'Actions and actors',
-          items: [
-            'actions-and-actors/entry-and-exit-actions',
-            'actions-and-actors/actors',
-          ]
-        },
+        'transitions-and-events/guards',
+        'transitions-and-events/eventless-transitions',
+        'transitions-and-events/delayed-transitions',
+        'transitions-and-events/self-transitions',
+        'transitions-and-events/state-done-events',
+        'transitions-and-events/invoke-done-events',
+        'transitions-and-events/invoke-error-events'
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Actions and actors',
+      link: {
+        type: 'generated-index',
+        title: 'Actions and actors',
+        description: 'Learn about actions and actors in the Stately Editor.',
+        slug: '/category/actions-and-actors',
+        keywords: ['guides'],
+      },
+      items: [
+        'actions-and-actors/entry-and-exit-actions',
+        'actions-and-actors/actors',
       ]
     },
     {
       type: 'category',
       label: '⚡️  Using the Studio',
+      link: {
+        type: 'generated-index',
+        title: '⚡️  Using the Studio',
+        description: 'Learn how to use the Stately Editor and Studio.',
+        slug: '/category/using-the-studio',
+        keywords: ['guides'],
+      },
       collapsed: false,
       collapsible: true,
       items: [
         {
           type: 'category',
           label: 'Edit',
+          link: {
+            type: 'generated-index',
+            title: 'Edit mode',
+            description: 'Learn how to Edit mode in the Stately Editor.',
+            slug: '/category/edit-mode',
+            keywords: ['guides'],
+          },
           items: [
             'descriptions',
             'import-from-code',
@@ -114,6 +153,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Accounts',
+          link: {
+            type: 'generated-index',
+            title: 'Accounts',
+            description: 'Learn about the Stately Studio plans and how to manage your account.',
+            slug: '/category/accounts',
+            keywords: ['guides'],
+          },
           items: [
             {
               type: 'doc', 
@@ -149,23 +195,39 @@ const sidebars = {
     {
       type: 'category',
       label: '🛠️  XState library',
+      link: {
+        type: 'generated-index',
+        title: '🛠️  XState library',
+        description: 'Learn about XState.',
+        slug: '/category/xstate',
+        keywords: ['guides'],
+      },
       collapsed: false,
       collapsible: true,
-      link: {
-        type: 'doc',
-        id: 'xstate/intro',
-      },
       items: [
+        {
+          type: 'doc',
+          label: 'Introducing XState',
+          id: 'xstate/intro',
+        },
         'xstate/installation',
         'xstate/templates',
         {
           type: 'category',
           label: 'Basics',
           link: {
-            type: 'doc',
-            id: 'xstate/basics/what-is-a-statechart',
+            type: 'generated-index',
+            title: 'XState basics',
+            description: 'Learn the basics of XState.',
+            slug: '/category/xstate-basics',
+            keywords: ['guides'],
           },
           items: [
+            {
+              type: 'doc',
+              label: 'What is a statechart?',
+              id: 'xstate/basics/what-is-a-statechart',
+            },
             'xstate/basics/options',
             'xstate/basics/inline-vs-named-options',
           ],
@@ -173,6 +235,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Actions and context',
+          link: {
+            type: 'generated-index',
+            title: 'Actions in XState',
+            description: 'Learn how to use actions in XState.',
+            slug: '/category/xstate-actions',
+            keywords: ['guides'],
+          },
           items: [
             'xstate/actions/actions',
             'xstate/actions/context',
@@ -182,6 +251,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Transitions and choices',
+          link: {
+            type: 'generated-index',
+            title: 'Transitions and choices in XState',
+            description: 'Learn how to use transitions and guards in XState.',
+            slug: '/category/xstate-transitions-and-choices',
+            keywords: ['guides'],
+          },
           items: [
             'xstate/transitions-and-choices/guards',
             'xstate/transitions-and-choices/guarded-actions',
@@ -195,10 +271,18 @@ const sidebars = {
           type: 'category',
           label: 'Running machines',
           link: {
-            type: 'doc',
-            id: 'xstate/running-machines/intro',
+            type: 'generated-index',
+            title: 'Running machines in XState',
+            description: 'Learn how to run machines in XState.',
+            slug: '/category/xstate-running-machines',
+            keywords: ['guides'],
           },
           items: [
+            {
+              type: 'doc',
+              label: 'Running machines',
+              id: 'xstate/running-machines/intro',
+            },
             'xstate/running-machines/react',
             'xstate/running-machines/node',
           ],
@@ -206,6 +290,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Deep dive: states',
+          link: {
+            type: 'generated-index',
+            title: 'Deep dive into states in XState',
+            description: 'Learn all about states in XState.',
+            slug: '/category/xstate-states',
+            keywords: ['guides'],
+          },
           items: [
             'xstate/states/parent-and-child-states',
             'xstate/states/other-state-attributes',
@@ -220,10 +311,18 @@ const sidebars = {
           type: 'category',
           label: 'Model-based testing',
           link: {
-            type: 'doc',
-            id: 'xstate/model-based-testing/intro',
+            type: 'generated-index',
+            title: 'Model-based testing in XState',
+            description: 'Learn all about when and how to use model-based testing with XState.',
+            slug: '/category/xstate-model-based-testing',
+            keywords: ['guides'],
           },
           items: [
+            {
+              type: 'doc',
+              label: 'Model-based testing',
+              id: 'xstate/model-based-testing/intro',
+            },
             'xstate/model-based-testing/when-to-use',
             'xstate/model-based-testing/quickstart',
             'xstate/model-based-testing/test-paths',
@@ -239,10 +338,18 @@ const sidebars = {
           type: 'category',
           label: 'Actors',
           link: {
-            type: 'doc',
-            id: 'xstate/actors/intro',
+            type: 'generated-index',
+            title: 'Actors in XState',
+            description: 'Learn all about using actors in XState.',
+            slug: '/category/xstate-actors',
+            keywords: ['guides'],
           },
           items: [
+            {
+              type: 'doc',
+              label: 'Introducing actors',
+              id: 'xstate/actors/intro',
+            },
             'xstate/actors/promises',
             'xstate/actors/actions-vs-actors',
             'xstate/actors/callbacks',
@@ -260,6 +367,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'TypeScript',
+          link: {
+            type: 'generated-index',
+            title: 'TypeScript in XState',
+            description: 'Learn about TypeScript in XState.',
+            slug: '/category/xstate-typescript',
+            keywords: ['guides'],
+          },
           items: [
             'xstate/typescript/typegen',
             'xstate/typescript/type-helpers',
@@ -269,6 +383,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Packages',
+          link: {
+            type: 'generated-index',
+            title: 'XState packages',
+            description: 'Find all the packages in XState.',
+            slug: '/category/xstate-packages',
+            keywords: ['guides'],
+          },
           items: [
             'xstate/packages/xstate-fsm',
             'xstate/packages/xstate-graph',
@@ -282,6 +403,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Advanced Topics',
+          link: {
+            type: 'generated-index',
+            title: 'Advanced topics in XState',
+            description: 'Learn even more about XState.',
+            slug: '/category/xstate-advanced-topics',
+            keywords: ['guides'],
+          },
           items: ['xstate/advanced/react-patterns', 'xstate/advanced/scxml'],
         },
       ],
@@ -291,6 +419,13 @@ const sidebars = {
       label: '🧰  Developer tools',
       collapsed: false,
       collapsible: true,
+      link: {
+        type: 'generated-index',
+        title: 'Stately Developer tools',
+        description: 'Find all the developer tools you can use with XState and the Stately Editor.',
+        slug: '/category/developer-tools',
+        keywords: ['guides'],
+      },
       items: [
         'tools/xstate-vscode-extension',
         'tools/visualizer',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -925,13 +925,20 @@ html [class*=toggleButton] {
   list-style: none; 
   margin: 0px; 
   padding-left: 0px; 
-  padding: 0.2rem 0;
+  padding: 0;
 }
 .menu__list .menu__list { 
   flex: 0 0 100%; 
   margin: 0;
   padding-left: 0px; 
-  padding: 0.2rem 0;
+  padding: 0;
+}
+
+.menu__list-item:first-of-type {
+  padding-top: 0.2rem;
+}
+.menu__list-item:last-of-type {
+  padding-bottom: 0.2rem;
 }
 .menu__list-item:not(:first-child) { 
   margin-top: 0; 
@@ -1004,7 +1011,7 @@ html [class*=toggleButton] {
   text-decoration: none;
 }
 
-.menu__link--sublist-caret::before, .menu__link--sublist-caret::before {
+.menu__caret::before, .menu__link--sublist-caret::before, .menu__link--sublist-caret::before {
   display: none;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -147,6 +147,12 @@ html, body {
   --ifm-font-family-monospace:SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;
   --ifm-font-size-base:100%;
   --ifm-line-height-base:1.45;
+  --ifm-h1-vertical-rhythm-top: 3;
+  --ifm-h2-vertical-rhythm-top: 2;
+  --ifm-h3-vertical-rhythm-top: 1.5;
+  --ifm-heading-vertical-rhythm-top: 1.25;
+  --ifm-h1-vertical-rhythm-bottom: 1.25;
+  --ifm-heading-vertical-rhythm-bottom: 1;
   --ifm-link-decoration:underline;
   --docusaurus-highlighted-code-line-bg:rgba(0,0,0,0.1);
   --ifm-heading-vertical-rhythm-bottom:.75;
@@ -650,7 +656,7 @@ a, a:hover {
 
 /* Set a maximum width and centre main content (including breadcrumbs) */
 
-article {
+article, .index-page {
   margin: 0 auto;
   max-width: 66ch;
 }
@@ -879,7 +885,7 @@ html [class*=toggleButton] {
 
 /* Add more space above page title */
 
-.markdown h1:first-child {
+.markdown h1:first-child, .index-page h1 {
   margin-top: calc( var(--ifm-h1-vertical-rhythm-top) * var(--ifm-leading) ); 
 }
 
@@ -1261,14 +1267,16 @@ ul.content-boxes {
   margin: 0;
 }
 
-a.link-box {
+a.link-box, .content-boxes a.link-box {
   border: 1px solid var(--st-layout-border);
   border-radius: var(--ifm-breadcrumb-border-radius);
+  box-shadow: none;
   color: var(--st-text);
   display: block;
   margin: 0;
   padding: 1rem;
   text-decoration: none;
+  width: 100%;
 }
 
 a.link-box:hover,
@@ -1282,6 +1290,13 @@ a.link-box strong {
   color: var(--st-text-link);
   font-size: 1.1rem;
   margin: 0.25rem 0;
+}
+
+/* Index page list */
+
+.index-list {
+  list-style-type: none; 
+  padding: 0;
 }
 
 /* Footer */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -854,6 +854,14 @@ html [class*=toggleButton] {
 
 /* Breadcrumbs */
 
+.breadcrumbs__link {
+  text-decoration: none;
+}
+
+.breadcrumbs__link:hover {
+  color: var(--st-text-highlight);
+}
+
 .breadcrumbs__item--active .breadcrumbs__link {
   font-weight: bold;
   font-weight: var(--ifm-font-weight-bold);

--- a/src/theme/DocCard/index.js
+++ b/src/theme/DocCard/index.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {
+  findFirstCategoryLink,
+  useDocById,
+} from '@docusaurus/theme-common/internal';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import {translate} from '@docusaurus/Translate';
+import styles from './styles.module.css';
+function CardContainer({href, children}) {
+  return (
+    <Link
+      href={href}
+      className={clsx('card link-box', styles.cardContainer)}>
+      {children}
+    </Link>
+  );
+}
+function CardLayout({href, title, description}) {
+  return (
+    <CardContainer href={href}>
+      <h2 className={clsx('card-heading', styles.cardTitle)}>
+        {title}
+      </h2>
+      {description && (
+        <p
+          className={clsx('card-text', styles.cardDescription)}>
+          {description}
+        </p>
+      )}
+    </CardContainer>
+  );
+}
+function CardCategory({item}) {
+  const href = findFirstCategoryLink(item);
+  // Unexpected: categories that don't have a link have been filtered upfront
+  if (!href) {
+    return null;
+  }
+  return (
+    <CardLayout
+      href={href}
+      title={item.label}
+      description={
+        item.description ??
+        translate(
+          {
+            message: '{count} items',
+            id: 'theme.docs.DocCard.categoryDescription',
+            description:
+              'The default description for a category card in the generated index about how many items this category includes',
+          },
+          {count: item.items.length},
+        )
+      }
+    />
+  );
+}
+function CardLink({item}) {
+  const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
+  const doc = useDocById(item.docId ?? undefined);
+  return (
+    <CardLayout
+      href={item.href}
+      title={item.label}
+      description={item.description ?? doc?.description}
+    />
+  );
+}
+export default function DocCard({item}) {
+  switch (item.type) {
+    case 'link':
+      return <CardLink item={item} />;
+    case 'category':
+      return <CardCategory item={item} />;
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`);
+  }
+}

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -1,0 +1,27 @@
+.cardContainer {
+  --ifm-link-color: var(--ifm-color-emphasis-800);
+  --ifm-link-hover-color: var(--ifm-color-emphasis-700);
+  --ifm-link-hover-decoration: none;
+
+  box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  transition: all var(--ifm-transition-fast) ease;
+  transition-property: border, box-shadow;
+}
+
+.cardContainer:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
+}
+
+.cardContainer *:last-child {
+  margin-bottom: 0;
+}
+
+.cardTitle {
+  font-size: 1.2rem;
+}
+
+.cardDescription {
+  font-size: 0.8rem;
+}

--- a/src/theme/DocCardList/index.js
+++ b/src/theme/DocCardList/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  useCurrentSidebarCategory,
+  filterDocCardListItems,
+} from '@docusaurus/theme-common';
+import DocCard from '@theme/DocCard';
+function DocCardListForCurrentSidebarCategory({className}) {
+  const category = useCurrentSidebarCategory();
+  return <DocCardList items={category.items} className={className} />;
+}
+export default function DocCardList(props) {
+  const {items, className} = props;
+  if (!items) {
+    return <DocCardListForCurrentSidebarCategory {...props} />;
+  }
+  const filteredItems = filterDocCardListItems(items);
+  return (
+    <ul className={clsx('card-list index-list content-boxes', className)}>
+      {filteredItems.map((item, index) => (
+        <li key={index} className="card-list-item">
+          <DocCard item={item} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/theme/DocCategoryGeneratedIndexPage/index.js
+++ b/src/theme/DocCategoryGeneratedIndexPage/index.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  PageMetadata,
+  useCurrentSidebarCategory,
+} from '@docusaurus/theme-common';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import DocCardList from '@theme/DocCardList';
+import DocPaginator from '@theme/DocPaginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import Heading from '@theme/Heading';
+import styles from './styles.module.css';
+function DocCategoryGeneratedIndexPageMetadata({categoryGeneratedIndex}) {
+  return (
+    <PageMetadata
+      title={categoryGeneratedIndex.title}
+      description={categoryGeneratedIndex.description}
+      keywords={categoryGeneratedIndex.keywords}
+      // TODO `require` this?
+      image={useBaseUrl(categoryGeneratedIndex.image)}
+    />
+  );
+}
+function DocCategoryGeneratedIndexPageContent({categoryGeneratedIndex}) {
+  const category = useCurrentSidebarCategory();
+  return (
+    <div className='row'>
+    <div className={clsx('col', styles.generatedIndexPage)}>
+      <div className='index-page'>
+        <DocVersionBanner />
+        <DocBreadcrumbs />
+        <DocVersionBadge />
+        <Heading as="h1" className={styles.title}>
+          {categoryGeneratedIndex.title}
+        </Heading>
+        {categoryGeneratedIndex.description && (
+          <p>{categoryGeneratedIndex.description}</p>
+        )}
+        <DocCardList items={category.items} className={styles.list} />
+      </div>
+      <footer className="margin-top--lg">
+        <DocPaginator
+          previous={categoryGeneratedIndex.navigation.previous}
+          next={categoryGeneratedIndex.navigation.next}
+        />
+      </footer>
+    </div>
+    </div>
+  );
+}
+export default function DocCategoryGeneratedIndexPage(props) {
+  return (
+    <>
+      <DocCategoryGeneratedIndexPageMetadata {...props} />
+      <DocCategoryGeneratedIndexPageContent {...props} />
+    </>
+  );
+}

--- a/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
+++ b/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
@@ -1,0 +1,19 @@
+@media (min-width: 997px) {
+  .generatedIndexPage {
+    max-width: 75% !important;
+  }
+
+  .list article:nth-last-child(-n + 2) {
+    margin-bottom: 0 !important;
+  }
+}
+
+/* Duplicated from .markdown h1 */
+.title {
+  --ifm-h1-font-size: 3rem;
+  margin-bottom: calc(1.25 * var(--ifm-leading));
+}
+
+.list article:last-child {
+  margin-bottom: 0 !important;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,10 +1191,10 @@
     "@docsearch/css" "3.1.1"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.3.1", "@docusaurus/core@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.3.1.tgz#32849f2ffd2f086a4e55739af8c4195c5eb386f2"
-  integrity sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==
+"@docusaurus/core@2.4.0", "@docusaurus/core@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.4.0.tgz#a12c175cb2e5a7e4582e65876a50813f6168913d"
+  integrity sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==
   dependencies:
     "@babel/core" "^7.18.6"
     "@babel/generator" "^7.18.7"
@@ -1206,13 +1206,13 @@
     "@babel/runtime" "^7.18.6"
     "@babel/runtime-corejs3" "^7.18.6"
     "@babel/traverse" "^7.18.8"
-    "@docusaurus/cssnano-preset" "2.3.1"
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/mdx-loader" "2.3.1"
+    "@docusaurus/cssnano-preset" "2.4.0"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/mdx-loader" "2.4.0"
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-common" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-common" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     "@slorber/static-site-generator-webpack-plugin" "^4.0.7"
     "@svgr/webpack" "^6.2.1"
     autoprefixer "^10.4.7"
@@ -1268,33 +1268,33 @@
     webpack-merge "^5.8.0"
     webpackbar "^5.0.2"
 
-"@docusaurus/cssnano-preset@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz#e042487655e3e062417855e12edb3f6eee8f5ecb"
-  integrity sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==
+"@docusaurus/cssnano-preset@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz#9213586358e0cce517f614af041eb7d184f8add6"
+  integrity sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==
   dependencies:
     cssnano-preset-advanced "^5.3.8"
     postcss "^8.4.14"
     postcss-sort-media-queries "^4.2.1"
     tslib "^2.4.0"
 
-"@docusaurus/logger@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-2.3.1.tgz#d76aefb452e3734b4e0e645efc6cbfc0aae52869"
-  integrity sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==
+"@docusaurus/logger@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-2.4.0.tgz#393d91ad9ecdb9a8f80167dd6a34d4b45219b835"
+  integrity sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.4.0"
 
-"@docusaurus/mdx-loader@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz#7ec6acee5eff0a280e1b399ea4dd690b15a793f7"
-  integrity sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==
+"@docusaurus/mdx-loader@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz#c6310342904af2f203e7df86a9df623f86840f2d"
+  integrity sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==
   dependencies:
     "@babel/parser" "^7.18.8"
     "@babel/traverse" "^7.18.8"
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
     "@mdx-js/mdx" "^1.6.22"
     escape-html "^1.0.3"
     file-loader "^6.2.0"
@@ -1309,13 +1309,13 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
-"@docusaurus/module-type-aliases@2.3.1", "@docusaurus/module-type-aliases@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz#986186200818fed999be2e18d6c698eaf4683a33"
-  integrity sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==
+"@docusaurus/module-type-aliases@2.4.0", "@docusaurus/module-type-aliases@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz#6961605d20cd46f86163ed8c2d83d438b02b4028"
+  integrity sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==
   dependencies:
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/types" "2.3.1"
+    "@docusaurus/types" "2.4.0"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1323,18 +1323,18 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/plugin-content-blog@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz#236b8ee4f20f7047aa9c285ae77ae36683ad48a3"
-  integrity sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==
+"@docusaurus/plugin-content-blog@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz#50dbfbc7b51f152ae660385fd8b34076713374c3"
+  integrity sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/mdx-loader" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-common" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/mdx-loader" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-common" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     cheerio "^1.0.0-rc.12"
     feed "^4.2.2"
     fs-extra "^10.1.0"
@@ -1345,18 +1345,18 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-docs@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz#feae1555479558a55182f22f8a07acc5e0d7444d"
-  integrity sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==
+"@docusaurus/plugin-content-docs@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz#36e235adf902325735b873b4f535205884363728"
+  integrity sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/mdx-loader" "2.3.1"
-    "@docusaurus/module-type-aliases" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/mdx-loader" "2.4.0"
+    "@docusaurus/module-type-aliases" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     "@types/react-router-config" "^5.0.6"
     combine-promises "^1.1.0"
     fs-extra "^10.1.0"
@@ -1367,95 +1367,95 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-pages@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz#f534a37862be5b3f2ba5b150458d7527646b6f39"
-  integrity sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==
+"@docusaurus/plugin-content-pages@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz#6169909a486e1eae0ddffff0b1717ce4332db4d4"
+  integrity sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/mdx-loader" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/mdx-loader" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     fs-extra "^10.1.0"
     tslib "^2.4.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-debug@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz#26fef904713e148f6dee44957506280f8b7853bb"
-  integrity sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==
+"@docusaurus/plugin-debug@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz#1ad513fe9bcaf017deccf62df8b8843faeeb7d37"
+  integrity sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
     fs-extra "^10.1.0"
     react-json-view "^1.21.3"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-analytics@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz#e2e7db4cf6a7063e8ba5e128d4e413f4d6a0c862"
-  integrity sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==
+"@docusaurus/plugin-google-analytics@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz#8062d7a09d366329dfd3ce4e8a619da8624b6cc3"
+  integrity sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-gtag@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz#b8da54a60c0a50aca609c3643faef78cb4f247a0"
-  integrity sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==
+"@docusaurus/plugin-google-gtag@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz#a8efda476f971410dfb3aab1cfe1f0f7d269adc5"
+  integrity sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-tag-manager@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz#f19bc01cc784fa4734187c5bc637f0574857e15d"
-  integrity sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==
+"@docusaurus/plugin-google-tag-manager@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz#9a94324ac496835fc34e233cc60441df4e04dfdd"
+  integrity sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-sitemap@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz#f526ab517ca63b7a3460d585876f5952cb908aa0"
-  integrity sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==
+"@docusaurus/plugin-sitemap@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz#ba0eb43565039fe011bdd874b5c5d7252b19d709"
+  integrity sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-common" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-common" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     fs-extra "^10.1.0"
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz#f0193f06093eb55cafef66bd1ad9e0d33198bf95"
-  integrity sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==
+"@docusaurus/preset-classic@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz#92fdcfab35d8d0ffb8c38bcbf439e4e1cb0566a3"
+  integrity sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/plugin-content-blog" "2.3.1"
-    "@docusaurus/plugin-content-docs" "2.3.1"
-    "@docusaurus/plugin-content-pages" "2.3.1"
-    "@docusaurus/plugin-debug" "2.3.1"
-    "@docusaurus/plugin-google-analytics" "2.3.1"
-    "@docusaurus/plugin-google-gtag" "2.3.1"
-    "@docusaurus/plugin-google-tag-manager" "2.3.1"
-    "@docusaurus/plugin-sitemap" "2.3.1"
-    "@docusaurus/theme-classic" "2.3.1"
-    "@docusaurus/theme-common" "2.3.1"
-    "@docusaurus/theme-search-algolia" "2.3.1"
-    "@docusaurus/types" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/plugin-content-blog" "2.4.0"
+    "@docusaurus/plugin-content-docs" "2.4.0"
+    "@docusaurus/plugin-content-pages" "2.4.0"
+    "@docusaurus/plugin-debug" "2.4.0"
+    "@docusaurus/plugin-google-analytics" "2.4.0"
+    "@docusaurus/plugin-google-gtag" "2.4.0"
+    "@docusaurus/plugin-google-tag-manager" "2.4.0"
+    "@docusaurus/plugin-sitemap" "2.4.0"
+    "@docusaurus/theme-classic" "2.4.0"
+    "@docusaurus/theme-common" "2.4.0"
+    "@docusaurus/theme-search-algolia" "2.4.0"
+    "@docusaurus/types" "2.4.0"
 
 "@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
@@ -1465,27 +1465,27 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz#8e6e194236e702c0d4e8d7b7cbb6886ae456e598"
-  integrity sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==
+"@docusaurus/theme-classic@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz#a5404967b00adec3472efca4c3b3f6a5e2021c78"
+  integrity sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==
   dependencies:
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/mdx-loader" "2.3.1"
-    "@docusaurus/module-type-aliases" "2.3.1"
-    "@docusaurus/plugin-content-blog" "2.3.1"
-    "@docusaurus/plugin-content-docs" "2.3.1"
-    "@docusaurus/plugin-content-pages" "2.3.1"
-    "@docusaurus/theme-common" "2.3.1"
-    "@docusaurus/theme-translations" "2.3.1"
-    "@docusaurus/types" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-common" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/mdx-loader" "2.4.0"
+    "@docusaurus/module-type-aliases" "2.4.0"
+    "@docusaurus/plugin-content-blog" "2.4.0"
+    "@docusaurus/plugin-content-docs" "2.4.0"
+    "@docusaurus/plugin-content-pages" "2.4.0"
+    "@docusaurus/theme-common" "2.4.0"
+    "@docusaurus/theme-translations" "2.4.0"
+    "@docusaurus/types" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-common" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     "@mdx-js/react" "^1.6.22"
     clsx "^1.2.1"
     copy-text-to-clipboard "^3.0.1"
-    infima "0.2.0-alpha.42"
+    infima "0.2.0-alpha.43"
     lodash "^4.17.21"
     nprogress "^0.2.0"
     postcss "^8.4.14"
@@ -1496,17 +1496,18 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.3.1.tgz#82f52d80226efef8c4418c4eacfc5051aa215f7f"
-  integrity sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==
+"@docusaurus/theme-common@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.4.0.tgz#626096fe9552d240a2115b492c7e12099070cf2d"
+  integrity sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==
   dependencies:
-    "@docusaurus/mdx-loader" "2.3.1"
-    "@docusaurus/module-type-aliases" "2.3.1"
-    "@docusaurus/plugin-content-blog" "2.3.1"
-    "@docusaurus/plugin-content-docs" "2.3.1"
-    "@docusaurus/plugin-content-pages" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
+    "@docusaurus/mdx-loader" "2.4.0"
+    "@docusaurus/module-type-aliases" "2.4.0"
+    "@docusaurus/plugin-content-blog" "2.4.0"
+    "@docusaurus/plugin-content-docs" "2.4.0"
+    "@docusaurus/plugin-content-pages" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-common" "2.4.0"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1517,19 +1518,19 @@
     use-sync-external-store "^1.2.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-search-algolia@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz#d587b40913119e9287d14670e277b933d8f453f0"
-  integrity sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==
+"@docusaurus/theme-search-algolia@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz#07d297d50c44446d6bc5a37be39afb8f014084e1"
+  integrity sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==
   dependencies:
     "@docsearch/react" "^3.1.1"
-    "@docusaurus/core" "2.3.1"
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/plugin-content-docs" "2.3.1"
-    "@docusaurus/theme-common" "2.3.1"
-    "@docusaurus/theme-translations" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
-    "@docusaurus/utils-validation" "2.3.1"
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/plugin-content-docs" "2.4.0"
+    "@docusaurus/theme-common" "2.4.0"
+    "@docusaurus/theme-translations" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
     algoliasearch "^4.13.1"
     algoliasearch-helper "^3.10.0"
     clsx "^1.2.1"
@@ -1539,18 +1540,18 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz#b2b1ecc00a737881b5bfabc19f90b20f0fe02bb3"
-  integrity sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==
+"@docusaurus/theme-translations@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz#62dacb7997322f4c5a828b3ab66177ec6769eb33"
+  integrity sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==
   dependencies:
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.3.1.tgz#785ade2e0f4e35e1eb7fb0d04c27d11c3991a2e8"
-  integrity sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==
+"@docusaurus/types@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.4.0.tgz#f94f89a0253778b617c5d40ac6f16b17ec55ce41"
+  integrity sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==
   dependencies:
     "@types/history" "^4.7.11"
     "@types/react" "*"
@@ -1561,30 +1562,30 @@
     webpack "^5.73.0"
     webpack-merge "^5.8.0"
 
-"@docusaurus/utils-common@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.3.1.tgz#1abe66846eb641547e4964d44f3011938e58e50b"
-  integrity sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==
+"@docusaurus/utils-common@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.4.0.tgz#eb2913871860ed32e73858b4c7787dd820c5558d"
+  integrity sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==
   dependencies:
     tslib "^2.4.0"
 
-"@docusaurus/utils-validation@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz#b65c718ba9b84b7a891bccf5ac6d19b57ee7d887"
-  integrity sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==
+"@docusaurus/utils-validation@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz#1ed92bfab5da321c4a4d99cad28a15627091aa90"
+  integrity sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==
   dependencies:
-    "@docusaurus/logger" "2.3.1"
-    "@docusaurus/utils" "2.3.1"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
     joi "^17.6.0"
     js-yaml "^4.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/utils@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.3.1.tgz#24b9cae3a23b1e6dc88f95c45722c7e82727b032"
-  integrity sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==
+"@docusaurus/utils@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.4.0.tgz#fdf0c3545819e48bb57eafc5057495fd4d50e900"
+  integrity sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==
   dependencies:
-    "@docusaurus/logger" "2.3.1"
+    "@docusaurus/logger" "2.4.0"
     "@svgr/webpack" "^6.2.1"
     escape-string-regexp "^4.0.0"
     file-loader "^6.2.0"
@@ -4458,10 +4459,10 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-infima@0.2.0-alpha.42:
-  version "0.2.0-alpha.42"
-  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.42.tgz#f6e86a655ad40877c6b4d11b2ede681eb5470aa5"
-  integrity sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==
+infima@0.2.0-alpha.43:
+  version "0.2.0-alpha.43"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.43.tgz#f7aa1d7b30b6c08afef441c726bac6150228cbe0"
+  integrity sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
This PR takes the sidebar category headings and turns them into links to (automated) index pages that list all the category’s child pages. I’ve “swizzled” the index page components to make the HTML more valid + semantic and styled them in a similar way to the link boxes on the homepage.

~~This PR turns some of the sidebar category headings into links themselves. Doing this means we can remove redundantly-named child pages (`Intro` etc) into the headings themselves to shorten the nav and make the categories clickable.~~

~~Though now I’ve done it, I’m not sure whether we want it…~~

~~**Pros**:~~
~~- Sidebar is shorter, fewer items in the menus.~~
~~- Sidebar category links actually do something, rather than having `href="#"`, which is annoying when you [try to right click to open a page, or (reasonably) assume that the category is a link itself](https://github.com/statelyai/docs/issues/71).~~

~~**Cons**:~~
~~- It might not be clear to some folks that the category headings are links to pages themselves, so they might miss a whole load of introductory content.~~
~~- Not all category headings are pages themselves, so it’s inconsistent as to whether these are links or not.~~

~~**Possible compromise**:~~
~~1. Keep the intro page links in the child menus as before.~~
~~2. Link the sidebar categories to the intro child pages. (But maybe programmatically hide them from assistive tech/bots as these would be repetitive redundant links.)~~
~~3. Create intro pages for every category, so each sidebar category has a corresponding child page. These pages could just contain brief intros to the topics and link to the pages within.~~

This PR also upgrades to Docusaurus 2.4.0. This can be done in another PR if we don’t end up merging this, it’s not got any breaking changes or updates relevant to us.