### PR TITLE
Updates Svelte Template link

### DIFF
--- a/docs/xstate/templates.mdx
+++ b/docs/xstate/templates.mdx
@@ -16,4 +16,4 @@ Or get started by forking one of these templates on CodeSandbox:
 - [XState + React + TypeScript template](https://codesandbox.io/s/xstate-react-typescript-template-wjdvn)
 - [XState + Vue template](https://codesandbox.io/s/xstate-vue-template-composition-api-1n23l)
 - [XState + Vue 3 template](https://codesandbox.io/s/xstate-vue-3-template-vrkk9)
-- [XState + Svelte template](https://codesandbox.io/s/xstate-svelte-template-jflv1)
+- [XState + Svelte template](https://github.com/statelyai/xstate/tree/main/templates/svelte-ts)


### PR DESCRIPTION
This PR fixes documentation issues regarding Svelte project setup and templates that I recently chatted about with David in a [Discord Thread](https://discord.com/channels/795785288994652170/1087844443933118596/1087882795365441567).

This PR should be considered in conjunction with a PR ("Updates Docs about Svelte Setup & Template") in the main repo (old docs & added template code).