### PR TITLE
Update Stately Studio and editor terms

### DIFF
--- a/docs/discover.mdx
+++ b/docs/discover.mdx
@@ -9,7 +9,7 @@ Are you seeking inspiration for your machine? Or do you want to learn how somebo
 
 <p>
 <ThemedImage
-  alt="Stately Studio Discover page showing the search results for “auth”, filtered by Editor machines under 10 states, showing 173 results."
+  alt="Stately Studio Discover page showing the search results for “auth”, filtered by editor machines under 10 states, showing 173 results."
   sources={{
     light: useBaseUrl('/discover.png'),
     dark: useBaseUrl('/discover-dm.png'),
@@ -17,7 +17,7 @@ Are you seeking inspiration for your machine? Or do you want to learn how somebo
 />
 </p>
 
-With the search feature, you can quickly filter your results by the number of states in a machine and whether the machine’s creator used [our Studio Editor](https://stately.ai/editor) or our older [Viz](https://stately.ai/viz) tool. Each machine listed details its creator, number of states, and a link to view and edit the machine in the editor.
+With the search feature, you can quickly filter your results by the number of states in a machine and whether the machine’s creator used [Stately Studio’s editor](https://stately.ai/editor) or our older [Viz](https://stately.ai/viz) tool. Each machine listed details its creator, number of states, and a link to view and edit the machine in the editor.
 
 ## Export and fork public machines
 
@@ -40,7 +40,7 @@ You must be signed into the Stately Studio to fork a machine.
 
 :::
 
-#### Fork a public machine from the Editor
+#### Fork a public machine from the editor
 
 1. Open the left drawer menu to show the **Machines** list.
 2. Choose **Fork machine** from the **...** triple dot contextual menu alongside the machine name to open the Form machine dialog.

--- a/docs/export-as-code.mdx
+++ b/docs/export-as-code.mdx
@@ -4,7 +4,7 @@ title: Export as code
 
 Exporting as code is useful if you want to use your machine with [XState](xstate/intro.mdx) inside your codebase or if you want to duplicate your machine without using **Fork**.
 
-You can currently export your machine as JSON, JavaScript, and TypeScript code using the code panel in the right tool menu. You can also export as code from the **Export machine** dialog using the export icon button in the Editor’s top bar.
+You can currently export your machine as JSON, JavaScript, and TypeScript code using the code panel in the right tool menu. You can also export as code from the **Export machine** dialog using the export icon button in the editor’s top bar.
 
 ## Export code from the code panel
 
@@ -15,6 +15,6 @@ You can currently export your machine as JSON, JavaScript, and TypeScript code u
 
 ## Export code from the Export machine dialog
 
-1. Use the export icon button in the Editor’s top bar to open the **Export machine** dialog.
+1. Use the export icon button in the editor’s top bar to open the **Export machine** dialog.
 2. Use the JSON, JavaScript, or TypeScript button to copy the code in your preferred format to your clipboard.
 3. Paste into your code editor.

--- a/docs/import-from-code.mdx
+++ b/docs/import-from-code.mdx
@@ -2,7 +2,7 @@
 title: Import from code
 ---
 
-Importing from code is helpful if you’ve already built machines while working with [XState](/xstate/), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio Editor.
+Importing from code is helpful if you’ve already built machines while working with [XState](/xstate/), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio editor.
 
 :::tip
 
@@ -22,7 +22,7 @@ Your code should be formatted as a [`createMachine()` factory function](https://
 
 :::
 
-You may have multiple `createMachine`s included in the code you insert in the text area, but the Studio will only import the first machine found in the code. We plan to support importing multiple machines in the future.
+You may have multiple `createMachine`s included in the code you insert in the text area, but Stately Studio will only import the first machine found in the code. We plan to support importing multiple machines in the future.
 
 ### Import code to overwrite your machine from the code panel
 

--- a/docs/import-from-github.mdx
+++ b/docs/import-from-github.mdx
@@ -35,7 +35,7 @@ How to import all machines from a GitHub repository into a project:
 2. Use **Import from GitHub** to open the Import repo from GitHub modal.
 3. The GitHub integration will fetch all available repositories (public and private). The search bar helps you filter the available repositories.
 4. Choose the repository from which you wish to import machines.
-5. The Studio will import your machines into a new private project using the same name as your repository and open your project in the Editor.
+5. Stately Studio will import your machines into a new private project using the same name as your repository and open your project in the editor.
 
 <p>
   <ThemedImage
@@ -47,7 +47,7 @@ How to import all machines from a GitHub repository into a project:
   />
 </p>
 
-You can [rename the project from the Project settings](/projects#change-a-projects-name-description-and-keywords) and [change the project’s visibility from the Editor’s share dialog](/projects#change-a-projects-visibility).
+You can [rename the project from the Project settings](/projects#change-a-projects-name-description-and-keywords) and [change the project’s visibility from the editor’s share dialog](/projects#change-a-projects-visibility).
 
 ### Import from a specific branch
 
@@ -67,7 +67,7 @@ If you want to import a machine, or multiple machines, from a GitHub file, we re
 
 1. Open a file containing one or more machines on GitHub.
 2. Modify the URL in the browser’s address bar to replace the `.com` with `.stately.ai`.
-3. The Editor will then display your imported machine.
+3. The editor will then display your imported machine.
 4. **Save** the machine to enable editing and easily find your machine in your projects later.
 
 Importing from a GitHub URL works with files in any branch in your private repositories, any public repositories, and any files in pull requests.
@@ -76,7 +76,7 @@ Importing from a GitHub URL works with files in any branch in your private repos
 
 When your machine is hosted at GitHub:
 `https://github.com/username/repo/blob/main/apps/superMachine.ts`, update the URL to
-`https://github.stately.ai/username/repo/blob/main/apps/superMachine.ts` and the Studio will start the import.
+`https://github.stately.ai/username/repo/blob/main/apps/superMachine.ts` and Stately Studio will start the import.
 
 <p>
   <ThemedImage

--- a/docs/projects.mdx
+++ b/docs/projects.mdx
@@ -17,13 +17,13 @@ A project is a collection of machines that helps you organize your personal mach
 />
 </p>
 
-You can access your projects from **My Projects** at the left of the Studio’s top bar when you’re signed in to the Stately Studio. **My Projects** lists your personal projects and is one of the locations where you can create new projects.
+You can access your projects from **My Projects** at the left of the top bar when you’re signed in to Stately Studio. **My Projects** lists your personal projects and is one of the locations where you can create new projects.
 
-When you select a project, the first machine in the project will open in the Studio Editor. The other machines in your project are accessible from the **Machines** list in the left drawer menu.
+When you select a project, the first machine in the project will open in the editor. The other machines in your project are accessible from the **Machines** list in the left drawer menu.
 
 <p>
 <ThemedImage
-  alt="Stately Studio Editor showing the Machines list in the left drawer for the Stately Studio Tutorials project. The selected machine is called ‘Parent states.’"
+  alt="Stately Studio editor showing the Machines list in the left drawer for the Stately Studio Tutorials project. The selected machine is called ‘Parent states.’"
   sources={{
     light: useBaseUrl('/projects/machines-list.png'),
     dark: useBaseUrl('/projects/machines-list-dm.png'),
@@ -59,24 +59,24 @@ You can create a new project when you first save a machine or from the **Create 
 
 #### Create a new project from **My Projects**
 
-1. Open **My Projects** from the link at the left of the Studio’s top bar.
+1. Open **My Projects** from the link at the left of Stately Studio’s top bar.
 2. Use the **Create project** button.
 3. Name the project. The description and keyword fields are optional.
 4. Use the **Submit** button to create the new project.
 
-#### Create a new project from the Studio Editor
+#### Create a new project from the editor
 
 The **Save** button will save your machine or prompt you to sign into Stately Studio before saving. Your project will have the same name as your current machine name.
 
-1. From the Studio Editor, use the **Save** button to save your current machine in a project.
+1. From the editor, use the **Save** button to save your current machine in a project.
 2. Choose **New Project** from the dropdown menu in the Save machine dialog.
 3. Use **Save** to save your machine and create your new project.
 
 #### Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Projects** tab on the team page.
 3. Use the **Create project** button.
 3. Name the project. The description and keyword fields are optional.
@@ -86,13 +86,13 @@ Only team members with the **Owner**, **Admin**, or **Editor** roles can create 
 
 You can move projects between your teams if you have an [**Owner**](teams.mdx#owner-role) role on both teams.
 
-1. Use the **Share** button in the Studio’s top bar to open the Share dialog.
+1. Use the **Share** button in Stately Studio’s top bar to open the Share dialog.
 2. Choose the destination team from the dropdown menu in the Move project section.
 3. Confirm that you want to move the project from the project move warning dialog using the **Move to *project name*** button.
 
 <p>
 <ThemedImage
-  alt="Stately Studio Editor page showing the Share modal with the options for changing project visibility and moving projects to another team."
+  alt="Stately Studio editor page showing the Share modal with the options for changing project visibility and moving projects to another team."
   sources={{
     light: useBaseUrl('/projects/move-projects.png'),
     dark: useBaseUrl('/projects/move-projects-dm.png'),
@@ -118,17 +118,17 @@ A project can be **public**, **unlisted**, or **private**. If the project is a s
 - Unlisted projects are visible to everyone with the project’s URL but are not findable on the Discover page or listed on your profile page.
 - Private projects are only visible to you and the team that owns the project.
 
-1. Use the **Share** button in the Studio’s top bar to open the Share dialog.
+1. Use the **Share** button in Stately Studio’s top bar to open the Share dialog.
 2. Toggle the project’s visibility between **public**, **unlisted**, or **private** from the dropdown menu in the Share dialog.
 
 ### Favorite a project
 
-You can favorite your own projects and other people’s projects. Favoriting a project gives you easy access to these projects in the future, as your **Favorites** are listed in the left sidebar of the Studio workspace. You might want to favorite projects you find inspiring or educational so that you can refer back to them later.
+You can favorite your own projects and other people’s projects. Favoriting a project gives you easy access to these projects in the future, as your **Favorites** are listed in the left sidebar of Stately Studio’s workspace. You might want to favorite projects you find inspiring or educational so that you can refer back to them later.
 
 You can favorite a project from **My Projects**, **Discover**, and team projects.
 
 1. Choose **Add to favorites** from the **...** triple dot contextual menu alongside the project’s name.
-2. Find your **Favorites** in the left sidebar of the Studio workspace.
+2. Find your **Favorites** in the left sidebar of Stately Studio’s workspace.
 
 #### Remove a project from your favorites
 

--- a/docs/projects.mdx
+++ b/docs/projects.mdx
@@ -74,7 +74,7 @@ The **Save** button will save your machine or prompt you to sign into Stately St
 
 #### Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Projects** tab on the team page.

--- a/docs/sign-up.mdx
+++ b/docs/sign-up.mdx
@@ -4,7 +4,7 @@ title: Sign up for the Stately Studio
 
 # Sign up
 
-You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the Editor](https://stately.ai/editor)’s top bar.
+You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the editor](https://stately.ai/editor)’s top bar.
 
 Sign up using your email address and password, or sign in using your GitHub, Google, or Twitter account credentials. 
 

--- a/docs/studio-community-plan.mdx
+++ b/docs/studio-community-plan.mdx
@@ -20,4 +20,4 @@ Our Community plan features include the following:
 - [Design and simulate flows](/#studio-editor)
 - [Import from code](import-from-code.mdx)
 - [Export as code](export-as-code.mdx)
-- [XState VSCode extension](tools/xstate-vscode-extension.mdx)
+- [XState VS Code extension](tools/xstate-vscode-extension.mdx)

--- a/docs/studio-pro-plan.mdx
+++ b/docs/studio-pro-plan.mdx
@@ -41,13 +41,13 @@ If you are a team member of another user’s [team](/teams), you also have acces
 
 ### How to sign up
 
-You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the Editor](https://stately.ai/editor)’s top bar.
+You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the editor](https://stately.ai/editor)’s top bar.
 
 Read more about [signing up for the Stately Studio](sign-up.mdx).
 
 ### How to upgrade
 
-You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the Editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
 
 ## Priority support
 

--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -41,7 +41,7 @@ The Stately Studio is a suite of tools for building app logic, including the Sta
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
+    alt="A dog walk machine open in Stately Studio’s editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
     sources={{
       light: useBaseUrl('/studio.png'),
       dark: useBaseUrl('/studio-dm.png'),
@@ -49,7 +49,7 @@ The Stately Studio is a suite of tools for building app logic, including the Sta
   />
 </p>
 
-You can use the [Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](tools/xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
+You can use the [Stately Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](tools/xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
 
 :::tip
 
@@ -59,13 +59,13 @@ What are state machines and statecharts? We’re glad you asked! [Check out our 
 
 ## Stately Studio editor
 
-Stately Studio’s editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; editor mode for creating your machines and simulation mode for simulating how your machine works.
+Stately Studio’s editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; **Design** mode for creating your machines and **Simulation** mode for simulating how your machine works.
 
-### editor mode
+### Design mode
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio editor in Design mode. The running state is selected, with the right panel showing options for a state."
+    alt="A dog walk machine open in Stately Studio’s editor in Design mode. The running state is selected, with the right panel showing options for a state."
     sources={{
       light: useBaseUrl('/editor.png'),
       dark: useBaseUrl('/editor-dm.png'),
@@ -79,7 +79,7 @@ Visually add, modify, and delete states, events, and transitions, as well as dat
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
+    alt="A dog walk machine open in Stately Studio’s editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
     sources={{
       light: useBaseUrl('/simulate.png'),
       dark: useBaseUrl('/simulate-dm.png'),
@@ -109,7 +109,7 @@ As a [Pro user](https://stately.ai/pricing), you can create and join teams in th
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and Admin role, Commander Chakotay with an Admin role, Lieutenant Tuvok, Lieutenant Torres, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),

--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -14,13 +14,13 @@ Here you can find all the documentation for the Stately Studio and [XState](/xst
   <li>
     <a className="link-box" href="/states/intro">
       🏁 <strong>Get started</strong> Jump straight into learning how to use the
-      Editor, starting with states.
+      editor, starting with states.
     </a>
   </li>
   <li>
     <a className="link-box" href="#studio-editor">
-      ⬇️ <strong>Editor overview</strong> Keep reading to find out more about
-      the Studio Editor.
+      ⬇️ <strong>editor overview</strong> Keep reading to find out more about
+      Stately Studio’s editor.
     </a>
   </li>
   <li>
@@ -37,11 +37,11 @@ Here you can find all the documentation for the Stately Studio and [XState](/xst
   </li>
 </ul>
 
-The Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](tools/developer-tools.mdx), and much more coming soon.
+The Stately Studio is a suite of tools for building app logic, including the Stately Studio’s editor, [developer tools for XState](tools/developer-tools.mdx), and much more coming soon.
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio Editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
+    alt="A dog walk machine open in the Stately Studio editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
     sources={{
       light: useBaseUrl('/studio.png'),
       dark: useBaseUrl('/studio-dm.png'),
@@ -49,7 +49,7 @@ The Stately Studio is a suite of tools for building app logic, including the Stu
   />
 </p>
 
-You can use the [Studio Editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](tools/xstate-vscode-extension.mdx) to use the Editor with your codebase inside your code editor, or [export](/#export) your code from the Studio into your codebase.
+You can use the [Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](tools/xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
 
 :::tip
 
@@ -57,15 +57,15 @@ What are state machines and statecharts? We’re glad you asked! [Check out our 
 
 :::
 
-## Studio Editor
+## Stately Studio editor
 
-The Studio Editor supports everything you need to visually build state machines and statecharts. The Editor currently has two modes; editor mode for creating your machines and simulation mode for simulating how your machine works.
+Stately Studio’s editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; editor mode for creating your machines and simulation mode for simulating how your machine works.
 
-### Editor mode
+### editor mode
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio Editor in Design mode. The running state is selected, with the right panel showing options for a state."
+    alt="A dog walk machine open in the Stately Studio editor in Design mode. The running state is selected, with the right panel showing options for a state."
     sources={{
       light: useBaseUrl('/editor.png'),
       dark: useBaseUrl('/editor-dm.png'),
@@ -79,7 +79,7 @@ Visually add, modify, and delete states, events, and transitions, as well as dat
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio Editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
+    alt="A dog walk machine open in the Stately Studio editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
     sources={{
       light: useBaseUrl('/simulate.png'),
       dark: useBaseUrl('/simulate-dm.png'),
@@ -109,7 +109,7 @@ As a [Pro user](https://stately.ai/pricing), you can create and join teams in th
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),
@@ -123,7 +123,7 @@ Are you seeking inspiration for your machine? Or do you want to learn from how s
 
 <p>
   <ThemedImage
-    alt="Stately Studio Discover page showing the search results for “auth”, filtered by Editor machines under 10 states, showing 173 results."
+    alt="Stately Studio Discover page showing the search results for “auth”, filtered by editor machines under 10 states, showing 173 results."
     sources={{
       light: useBaseUrl('/discover.png'),
       dark: useBaseUrl('/discover-dm.png'),

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -38,7 +38,7 @@ The following table is an overview of the capabilities of each team role:
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
-| Reassign Admin, editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
+| Reassign Admin, Editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Invite new team members                  | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Change project visibility                | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Edit the team name                       | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -10,7 +10,7 @@ You can create and join teams in the Stately Studio to share and collaborate on 
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and Admin role, Commander Chakotay with an Admin role, Lieutenant Tuvok, Lieutenant Torres, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),
@@ -27,7 +27,7 @@ We offer a **30-day free trial** on the [Stately Studio Pro account](https://sta
 
 ## Team roles
 
-Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
+Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [Editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
 
 The following table is an overview of the capabilities of each team role:
 
@@ -70,13 +70,13 @@ Users with the Admin role can:
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members editor and Viewer roles
+- Give team members Editor and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
-### editor role
+### Editor role
 
-Users with the editor role can:
+Users with the Editor role can:
 
 - View team members
 - Create team projects
@@ -84,7 +84,7 @@ Users with the editor role can:
 
 ### Viewer role
 
-Users with the viewer role can:
+Users with the Viewer role can:
 
 - View team members
 - View team projects and machines
@@ -143,11 +143,11 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
-3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an editor**, or **Make an Admin**.
+3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an Editor**, or **Make an Admin**.
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an editor,’ and ‘Remove from team.’"
+    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an Editor,’ and ‘Remove from team.’"
     sources={{
       light: useBaseUrl('/teams/edit-role.png'),
       dark: useBaseUrl('/teams/edit-role-dm.png'),
@@ -157,7 +157,7 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 ## Remove a member from a team
 
-To remove a member from a team, you must have the [owner role](/#owner-role) or [admin role](/#admin-role) for that team.
+To remove a member from a team, you must have the [owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
@@ -165,7 +165,7 @@ To remove a member from a team, you must have the [owner role](/#owner-role) or 
 
 ## Leave a team
 
-Any team member with **Admin**, **editor**, or **Viewer** roles can leave a team.
+Any team member with **Admin**, **Editor**, or **Viewer** roles can leave a team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
@@ -184,6 +184,6 @@ Only team owners can delete a team.
 
 ## Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
 
 [Read more about how to create shared team projects on the Projects page](projects.mdx#how-to-create-a-shared-team-project).

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -54,7 +54,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members Admin, editor, and Viewer roles
+- Give team members Admin, Editor, and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -10,7 +10,7 @@ You can create and join teams in the Stately Studio to share and collaborate on 
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),
@@ -27,18 +27,18 @@ We offer a **30-day free trial** on the [Stately Studio Pro account](https://sta
 
 ## Team roles
 
-Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [Editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
+Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
 
 The following table is an overview of the capabilities of each team role:
 
-| Capability                               | Owner  | Admin  | Editor | Viewer |
+| Capability                               | Owner  | Admin  | editor | Viewer |
 | ---------------------------------------- | ------ | ------ | ------ | ------ |
 | View team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | View other team members                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
-| Reassign Admin, Editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
+| Reassign Admin, editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Invite new team members                  | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Change project visibility                | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Edit the team name                       | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
@@ -54,7 +54,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members Admin, Editor, and Viewer roles
+- Give team members Admin, editor, and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
@@ -70,13 +70,13 @@ Users with the Admin role can:
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members Editor and Viewer roles
+- Give team members editor and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
-### Editor role
+### editor role
 
-Users with the Editor role can:
+Users with the editor role can:
 
 - View team members
 - Create team projects
@@ -99,14 +99,14 @@ All team members will be granted [Pro features](/studio-pro-plan#pro-features) e
 
 ## Create a team
 
-1. Use the **Create team** link in the left sidebar of the Studio workspace to open the Create team form.
+1. Use the **Create team** link in the left sidebar of Stately Studio’s workspace to open the Create team form.
 2. Name your team and use the **Create team** button to create your team.
 
 By default, teams have only one member, the creator and Owner. [Invite new members](/#invite-new-members-to-a-team) to add more members to your team.
 
 ## Edit the team name
 
-1. Select the team from the left sidebar of the Studio workspace.
+1. Select the team from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the Settings tab.
 3. Edit the team name and use the **Save changes** button to update your team name.
 
@@ -114,7 +114,7 @@ By default, teams have only one member, the creator and Owner. [Invite new membe
 
 You need to have [enough seats on your Pro plan](/#teams-members-and-pro-plan-seats) to add more members to your team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. On your team page, use the **Members** tab to view existing members and their roles and invite new members.
 3. Enter the invitee’s email address and choose their role from the dropdown menu.
 4. Use the **Invite to team** button to send the invitation.
@@ -141,13 +141,13 @@ A subscription seat is only taken up at the time of accepting the invitation. An
 
 To change a team member’s role, you must have the [Owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
-3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an Editor**, or **Make an Admin**.
+3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an editor**, or **Make an Admin**.
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an Editor,’ and ‘Remove from team.’"
+    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an editor,’ and ‘Remove from team.’"
     sources={{
       light: useBaseUrl('/teams/edit-role.png'),
       dark: useBaseUrl('/teams/edit-role-dm.png'),
@@ -159,15 +159,15 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 To remove a member from a team, you must have the [owner role](/#owner-role) or [admin role](/#admin-role) for that team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
 3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose the **Remove from team** option.
 
 ## Leave a team
 
-Any team member with **Admin**, **Editor**, or **Viewer** roles can leave a team.
+Any team member with **Admin**, **editor**, or **Viewer** roles can leave a team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
 3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose the **Leave team** option.
 
@@ -177,13 +177,13 @@ Team owners cannot leave their own teams, but they can delete the team.
 
 Only team owners can delete a team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Settings** tab on the team page.
 3. Use the **Delete team** button to delete your team.
 4. Confirm the team deletion using the **Delete** button in the Delete team dialog.
 
 ## Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
 
 [Read more about how to create shared team projects on the Projects page](projects.mdx#how-to-create-a-shared-team-project).

--- a/docs/tools/visualizer.mdx
+++ b/docs/tools/visualizer.mdx
@@ -8,7 +8,7 @@ The [Stately Visualizer](https://stately.ai/viz) is a tool for creating and insp
 
 :::studio
 
-Are you looking for the _Stately Studio_ visual _Editor_? Check out the [Stately Studio overview](/).
+Are you looking for the _Stately Studio_ visual _editor_? Check out the [Stately Studio overview](/).
 
 :::
 
@@ -16,7 +16,7 @@ Are you looking for the _Stately Studio_ visual _Editor_? Check out the [Stately
 
 :::tip
 
-Stately still supports the Stately Visualizer, but you will find many more advanced features, including the visual [Studio Editor](../#studio-editor), teams, and shared projects.
+Stately still supports the Stately Visualizer, but you will find many more advanced features, including the visual [Studio editor](../#studio-editor), teams, and shared projects.
 
 :::
 

--- a/docs/tools/visualizer.mdx
+++ b/docs/tools/visualizer.mdx
@@ -16,7 +16,7 @@ Are you looking for the _Stately Studio_ visual _editor_? Check out the [Stately
 
 :::tip
 
-Stately still supports the Stately Visualizer, but you will find many more advanced features, including the visual [Studio editor](../#studio-editor), teams, and shared projects.
+Stately still supports the Stately Visualizer, but you will find many more advanced features, including the Stately Studio [visual editor](../#studio-editor), teams, and shared projects.
 
 :::
 

--- a/docs/tools/xstate-vscode-extension.mdx
+++ b/docs/tools/xstate-vscode-extension.mdx
@@ -4,7 +4,7 @@ title: 'XState VS Code extension'
 
 # XState VS Code extension
 
-The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and Studio editor visual editing from inside VS Code.
+The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VSCode.
 
 :::tip
 
@@ -56,7 +56,7 @@ createMachine({});
 
 ## Machine layout persistence
 
-Upon opening an XState machine in the VSCode editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
+Upon opening an XState machine in the VS Code editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
 
 ```js
 const machine =
@@ -64,6 +64,6 @@ const machine =
 createMachine({...});
 ```
 
-This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in the editor.
+This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in Stately Studio’s editor.
 
 :::

--- a/docs/tools/xstate-vscode-extension.mdx
+++ b/docs/tools/xstate-vscode-extension.mdx
@@ -18,9 +18,9 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
 
-Once installed, you can run `XState: Open Visual editor` from the command palette to open any machine at your cursor’s location.
+Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
 
-If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual editor’ will also float above each `createMachine` call.
+If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual Editor’ will also float above each `createMachine` call.
 
 You can also [download the VS Code extension from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) or [download the VS Code extension from the Open VSX marketplace](https://open-vsx.org/extension/statelyai/stately-vscode).
 

--- a/docs/tools/xstate-vscode-extension.mdx
+++ b/docs/tools/xstate-vscode-extension.mdx
@@ -4,7 +4,7 @@ title: 'XState VS Code extension'
 
 # XState VS Code extension
 
-The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and Studio Editor visual editing from inside VS Code.
+The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and Studio editor visual editing from inside VS Code.
 
 :::tip
 
@@ -18,9 +18,9 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
 
-Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
+Once installed, you can run `XState: Open Visual editor` from the command palette to open any machine at your cursor’s location.
 
-If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual Editor’ will also float above each `createMachine` call.
+If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual editor’ will also float above each `createMachine` call.
 
 You can also [download the VS Code extension from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) or [download the VS Code extension from the Open VSX marketplace](https://open-vsx.org/extension/statelyai/stately-vscode).
 
@@ -56,7 +56,7 @@ createMachine({});
 
 ## Machine layout persistence
 
-Upon opening an XState machine in the VSCode Editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
+Upon opening an XState machine in the VSCode editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
 
 ```js
 const machine =
@@ -64,6 +64,6 @@ const machine =
 createMachine({...});
 ```
 
-This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in the Editor.
+This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in the editor.
 
 :::

--- a/docs/upgrade.mdx
+++ b/docs/upgrade.mdx
@@ -13,7 +13,7 @@ We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-
 
 ## Upgrade to a Pro plan
 
-You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the Editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
 
 <p>
 <ThemedImage
@@ -31,7 +31,7 @@ You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio usin
 
 ## Modify your subscription plan and seats
 
-1. Select your avatar from the header in the Studio to open your account menu.
+1. Select your avatar from the header in Stately Studio to open your account menu.
 2. Choose **Billing** from the account menu to open your billing options.
 3. Use the **Manage subscription** button to open the Stripe checkout.
 4. Make any modifications you require.

--- a/docs/xstate/model-based-testing/intro.mdx
+++ b/docs/xstate/model-based-testing/intro.mdx
@@ -177,7 +177,7 @@ cy.findByText('Model-based testing').should('not.be.visible');
 
 ## Summary
 
-You might be starting to see the power of model-based testing. You can **create a visual model of your app** using our [Studio editor](../../#studio-editor). You can **tell the model how to interact with your application**; we’ll look at the syntax in depth later. Finally, you can let the **model test your app for you**. It’ll calculate the fewest possible number of test paths through your model, then run the tests for you.
+You might be starting to see the power of model-based testing. You can **create a visual model of your app** using our [Stately Studio editor](../../#studio-editor). You can **tell the model how to interact with your application**; we’ll look at the syntax in depth later. Finally, you can let the **model test your app for you**. It’ll calculate the fewest possible number of test paths through your model, then run the tests for you.
 
 Adopting model-based testing leads to a test suite that is:
 

--- a/docs/xstate/model-based-testing/intro.mdx
+++ b/docs/xstate/model-based-testing/intro.mdx
@@ -177,7 +177,7 @@ cy.findByText('Model-based testing').should('not.be.visible');
 
 ## Summary
 
-You might be starting to see the power of model-based testing. You can **create a visual model of your app** using our [Studio Editor](../../#studio-editor). You can **tell the model how to interact with your application**; we’ll look at the syntax in depth later. Finally, you can let the **model test your app for you**. It’ll calculate the fewest possible number of test paths through your model, then run the tests for you.
+You might be starting to see the power of model-based testing. You can **create a visual model of your app** using our [Studio editor](../../#studio-editor). You can **tell the model how to interact with your application**; we’ll look at the syntax in depth later. Finally, you can let the **model test your app for you**. It’ll calculate the fewest possible number of test paths through your model, then run the tests for you.
 
 Adopting model-based testing leads to a test suite that is:
 

--- a/docs/xstate/states/other-state-attributes.mdx
+++ b/docs/xstate/states/other-state-attributes.mdx
@@ -165,7 +165,7 @@ For instance, if the machine above is in the `timedOut` state, the `meta` will b
 
 You can add descriptive text to states with the `description` attribute.
 
-This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Studio editor](../../#studio-editor) to make the diagrams more descriptive.
+This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Stately Studio editor](../../#studio-editor) to make the diagrams more descriptive.
 
 ```ts twoslash
 import { createMachine } from 'xstate';

--- a/docs/xstate/states/other-state-attributes.mdx
+++ b/docs/xstate/states/other-state-attributes.mdx
@@ -165,7 +165,7 @@ For instance, if the machine above is in the `timedOut` state, the `meta` will b
 
 You can add descriptive text to states with the `description` attribute.
 
-This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Studio Editor](../../#studio-editor) to make the diagrams more descriptive.
+This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Studio editor](../../#studio-editor) to make the diagrams more descriptive.
 
 ```ts twoslash
 import { createMachine } from 'xstate';

--- a/docs/xstate/transitions-and-choices/transition-descriptions.mdx
+++ b/docs/xstate/transitions-and-choices/transition-descriptions.mdx
@@ -8,7 +8,7 @@ title: Transition descriptions
 
 You can add descriptions to transitions to illustrate what they do.
 
-This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Studio editor](../../#studio-editor) to make the diagrams more descriptive.
+This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Stately Studio editor](../../#studio-editor) to make the diagrams more descriptive.
 
 ```ts twoslash
 import { createMachine } from 'xstate';

--- a/docs/xstate/transitions-and-choices/transition-descriptions.mdx
+++ b/docs/xstate/transitions-and-choices/transition-descriptions.mdx
@@ -8,7 +8,7 @@ title: Transition descriptions
 
 You can add descriptions to transitions to illustrate what they do.
 
-This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Studio Editor](../../#studio-editor) to make the diagrams more descriptive.
+This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Studio editor](../../#studio-editor) to make the diagrams more descriptive.
 
 ```ts twoslash
 import { createMachine } from 'xstate';

--- a/sidebars.js
+++ b/sidebars.js
@@ -26,7 +26,7 @@ const sidebars = {
         type: 'generated-index',
         title: 'Get started with Stately',
         description:
-          'Learn about state machines, statecharts, and the Stately Editor',
+          'Learn about state machines, statecharts, and Stately Studio’s editor',
         slug: '/category/get-started',
         keywords: ['guides'],
       },
@@ -74,7 +74,7 @@ const sidebars = {
             type: 'generated-index',
             title: 'Transitions and events',
             description:
-              'Learn about all the possible transitions and events in the Stately Editor.',
+              'Learn about all the possible transitions and events in Stately Studio’s editor.',
             slug: '/category/transitions-and-events',
             keywords: ['guides'],
           },
@@ -100,7 +100,7 @@ const sidebars = {
             type: 'generated-index',
             title: 'Actions and actors',
             description:
-              'Learn about actions and actors in the Stately Editor.',
+              'Learn about actions and actors in Stately Studio’s editor.',
             slug: '/category/actions-and-actors',
             keywords: ['guides'],
           },
@@ -113,11 +113,11 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Using the Studio',
+      label: 'Using Stately Studio',
       link: {
         type: 'generated-index',
-        title: 'Using the Studio',
-        description: 'Learn how to use the Stately Editor and Studio.',
+        title: 'Using Stately Studio',
+        description: 'Learn how to use Stately Studio and our editor.',
         slug: '/category/using-the-studio',
         keywords: ['guides'],
       },
@@ -130,7 +130,7 @@ const sidebars = {
           link: {
             type: 'generated-index',
             title: 'Design mode',
-            description: 'Learn how to use Design mode in the Stately Editor.',
+            description: 'Learn how to use Design mode in Stately Studio’s editor.',
             slug: '/category/design-mode',
             keywords: ['guides'],
           },
@@ -425,7 +425,7 @@ const sidebars = {
         type: 'generated-index',
         title: 'Stately Developer tools',
         description:
-          'Find all the developer tools you can use with XState and the Stately Editor.',
+          'Find all the developer tools you can use with XState and Stately Studio’s editor.',
         slug: '/category/developer-tools',
         keywords: ['guides'],
       },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,7 +27,7 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Editor’s colours */
+/* editor’s colours */
 :root {
   /* Yellow */
   --st-yellow-50: rgba(254, 253, 192, .5);

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -17,7 +17,7 @@ Examples of actions:
 
 TODO: more examples
 
-## Editor: actions
+## editor: actions
 
 :::tip
 

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -17,7 +17,7 @@ Examples of actions:
 
 TODO: more examples
 
-## editor: actions
+## Editor: using actions
 
 :::tip
 

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -14,7 +14,7 @@ Watch our [“What are invoked actors?” video on YouTube](https://www.youtube.
 
 :::
 
-## Using actors in the Studio
+## Using actors in Stately Studio
 
 Invoked actors are are labeled on their invoking state with “Invoke /” followed by the actor’s source name and ID.
 
@@ -53,7 +53,7 @@ In the actor model, actors are objects that can talk to each other. They are ind
 - State is not shared between actors. The only way for an actor to share data is by sending events.
 - Actors can spawn new actors.
 
-## Stately Editor: actors
+## Stately Studio’s editor: actors
 
 ## Creating actors
 

--- a/versioned_docs/version-5/context.mdx
+++ b/versioned_docs/version-5/context.mdx
@@ -30,7 +30,7 @@ feedbackActor.start();
 
 The `context` property is _optional_; if the state machine only specifies [finite states](#), then it may not need `context`.
 
-## Stately Editor: context
+## Stately Studio’s editor: context
 
 - Setting initial values
 - Updating context with assign

--- a/versioned_docs/version-5/delayed-transitions.mdx
+++ b/versioned_docs/version-5/delayed-transitions.mdx
@@ -29,7 +29,7 @@ Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtu
 
 In a video player, we might want the video to be *Closed* out of fullscreen mode a few seconds after the video has *Stopped*, instead of closing the fullscreen mode suddenly as soon as the video is stopped. The eventless transition above transitions from the *Stopped* state to the *Closed* state after 5 seconds.
 
-## Using delayed transitions in the Studio
+## Using delayed transitions in Stately Studio
 
 ### Make an event into a delayed transition
 

--- a/versioned_docs/version-5/discover.mdx
+++ b/versioned_docs/version-5/discover.mdx
@@ -9,7 +9,7 @@ Are you seeking inspiration for your machine? Or do you want to learn how somebo
 
 <p>
 <ThemedImage
-  alt="Stately Studio Discover page showing the search results for “auth”, filtered by Editor machines under 10 states, showing 173 results."
+  alt="Stately Studio Discover page showing the search results for “auth”, filtered by editor machines under 10 states, showing 173 results."
   sources={{
     light: useBaseUrl('/discover.png'),
     dark: useBaseUrl('/discover-dm.png'),
@@ -17,7 +17,7 @@ Are you seeking inspiration for your machine? Or do you want to learn how somebo
 />
 </p>
 
-With the search feature, you can quickly filter your results by the number of states in a machine and whether the machine’s creator used [our Studio Editor](https://stately.ai/editor) or our older [Viz](https://stately.ai/viz) tool. Each machine listed details its creator, number of states, and a link to view and edit the machine in the editor.
+With the search feature, you can quickly filter your results by the number of states in a machine and whether the machine’s creator used [our Studio editor](https://stately.ai/editor) or our older [Viz](https://stately.ai/viz) tool. Each machine listed details its creator, number of states, and a link to view and edit the machine in the editor.
 
 ## Export and fork public machines
 
@@ -40,7 +40,7 @@ You must be signed into the Stately Studio to fork a machine.
 
 :::
 
-#### Fork a public machine from the Editor
+#### Fork a public machine from the editor
 
 1. Open the left drawer menu to show the **Machines** list.
 2. Choose **Fork machine** from the **...** triple dot contextual menu alongside the machine name to open the Form machine dialog.

--- a/versioned_docs/version-5/eventless-transitions.mdx
+++ b/versioned_docs/version-5/eventless-transitions.mdx
@@ -24,7 +24,7 @@ Eventless transitions are labeled “always” and often referred to as “alway
 }
 ```
 
-## Usign eventless transitions in the Studio
+## Usign eventless transitions in Stately Studio
 
 ### Make an event into an eventless transition
 

--- a/versioned_docs/version-5/export-as-code.mdx
+++ b/versioned_docs/version-5/export-as-code.mdx
@@ -4,7 +4,7 @@ title: Export as code
 
 Exporting as code is useful if you want to use your machine with [XState](./xstate.mdx) inside your codebase or if you want to duplicate your machine without using **Fork**.
 
-You can currently export your machine as JSON, JavaScript, and TypeScript code using the code panel in the right tool menu. You can also export as code from the **Export machine** dialog using the export icon button in the Editor’s top bar.
+You can currently export your machine as JSON, JavaScript, and TypeScript code using the code panel in the right tool menu. You can also export as code from the **Export machine** dialog using the export icon button in the editor’s top bar.
 
 ## Export code from the code panel
 
@@ -15,6 +15,6 @@ You can currently export your machine as JSON, JavaScript, and TypeScript code u
 
 ## Export code from the Export machine dialog
 
-1. Use the export icon button in the Editor’s top bar to open the **Export machine** dialog.
+1. Use the export icon button in the editor’s top bar to open the **Export machine** dialog.
 2. Use the JSON, JavaScript, or TypeScript button to copy the code in your preferred format to your clipboard.
 3. Paste into your code editor.

--- a/versioned_docs/version-5/final-states.mdx
+++ b/versioned_docs/version-5/final-states.mdx
@@ -8,7 +8,7 @@ When a machine reaches the final state, it can no longer receive any events, and
 
 A machine can have multiple final states or no final states.
 
-## Editor: final states
+## editor: final states
 
 In the video player below, *Stopped* is the final child state in the *Opened* state. When the video player is *Stopped*, the video player moves to its *Closed* state.
 

--- a/versioned_docs/version-5/final-states.mdx
+++ b/versioned_docs/version-5/final-states.mdx
@@ -8,7 +8,7 @@ When a machine reaches the final state, it can no longer receive any events, and
 
 A machine can have multiple final states or no final states.
 
-## editor: final states
+## Editor: using final states
 
 In the video player below, *Stopped* is the final child state in the *Opened* state. When the video player is *Stopped*, the video player moves to its *Closed* state.
 

--- a/versioned_docs/version-5/finite-states.mdx
+++ b/versioned_docs/version-5/finite-states.mdx
@@ -69,7 +69,7 @@ console.log(feedbackActor.getSnapshot().context);
 
 TODO: `.getSnapshot()` and show `.value` and `.context`
 
-## Stately Editor: finite states
+## Stately Studio’s editor: finite states
 
 - set initial state
 - change initial states

--- a/versioned_docs/version-5/guards.mdx
+++ b/versioned_docs/version-5/guards.mdx
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 A **guard** is a condition that the machine checks when it goes through an event. If the condition is true, the machine follows the transition to the next state. If the condition is false, the machine follows the rest of the conditions to the next state. Any transition can be a guarded transition.
 
-## editor: guards
+## Editor: using guards
 
 <p>
   <ThemedImage

--- a/versioned_docs/version-5/guards.mdx
+++ b/versioned_docs/version-5/guards.mdx
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 A **guard** is a condition that the machine checks when it goes through an event. If the condition is true, the machine follows the transition to the next state. If the condition is false, the machine follows the rest of the conditions to the next state. Any transition can be a guarded transition.
 
-## Editor: guards
+## editor: guards
 
 <p>
   <ThemedImage

--- a/versioned_docs/version-5/history-states.mdx
+++ b/versioned_docs/version-5/history-states.mdx
@@ -11,7 +11,7 @@ The history state can be deep or shallow:
 
 <!--TODO: Why you might use a history state with example.-->
 
-## Using history states in the Studio
+## Using history states in Stately Studio
 
 ### Make a state a history state
 
@@ -36,7 +36,7 @@ Essentially, this allows statecharts to "remember" where they left off when exit
 - If no child state remembered, history goes to `.target` state, if it is specified
 - Otherwise, go to [initial state](initial-states.mdx)
 
-## Stately Editor: History states
+## Stately Studio’s editor: History states
 
 ## Shallow vs. deep history
 

--- a/versioned_docs/version-5/import-from-code.mdx
+++ b/versioned_docs/version-5/import-from-code.mdx
@@ -2,7 +2,7 @@
 title: Import from code
 ---
 
-Importing from code is helpful if you’ve already built machines while working with [XState](xstate.mdx), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio Editor.
+Importing from code is helpful if you’ve already built machines while working with [XState](xstate.mdx), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio editor.
 
 :::tip
 
@@ -22,7 +22,7 @@ Your code should be formatted as a [`createMachine()` factory function](https://
 
 :::
 
-You may have multiple `createMachine`s included in the code you insert in the text area, but the Studio will only import the first machine found in the code. We plan to support importing multiple machines in the future.
+You may have multiple `createMachine`s included in the code you insert in the text area, but Stately Studio will only import the first machine found in the code. We plan to support importing multiple machines in the future.
 
 ### Import code to overwrite your machine from the code panel
 

--- a/versioned_docs/version-5/input.mdx
+++ b/versioned_docs/version-5/input.mdx
@@ -26,7 +26,7 @@ const feedbackActor = interpret(feedbackMachine, {
 });
 ```
 
-## Stately Editor: input
+## Stately Studio’s editor: input
 
 _Coming soon_
 

--- a/versioned_docs/version-5/invoke.mdx
+++ b/versioned_docs/version-5/invoke.mdx
@@ -12,7 +12,7 @@ XState is based on the [actor model](actors.mdx). Invoked actors are managed by 
 
 <!-- TODO: example of invoking an actor at root -->
 
-## Stately Editor: Invoke
+## Stately Studio’s editor: Invoke
 
 ## API
 

--- a/versioned_docs/version-5/parallel-states.mdx
+++ b/versioned_docs/version-5/parallel-states.mdx
@@ -8,7 +8,7 @@ A parallel state is a state separated into multiple regions of child states, whe
 
 `{ type: 'parallel', states: ... }`
 
-## Using states in the Studio
+## Using states in Stately Studio
 
 A dashed line borders each region.
 

--- a/versioned_docs/version-5/projects.mdx
+++ b/versioned_docs/version-5/projects.mdx
@@ -72,7 +72,7 @@ The **Save** button will save your machine or prompt you to sign into Stately St
 
 #### Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Projects** tab on the team page.

--- a/versioned_docs/version-5/projects.mdx
+++ b/versioned_docs/version-5/projects.mdx
@@ -17,13 +17,13 @@ A project is a collection of machines that helps you organize your personal mach
 />
 </p>
 
-You can access your projects from **My Projects** at the left of the Studio’s top bar when you’re signed into the Stately Studio. **My Projects** lists your personal projects and is one of the locations where you can create new projects.
+You can access your projects from **My Projects** at the left of Stately Studio’s top bar when you’re signed into the Stately Studio. **My Projects** lists your personal projects and is one of the locations where you can create new projects.
 
-When you select a project, the first machine in the project will open in the Studio Editor. The other machines in your project are accessible from the **Machines** list in the left drawer menu.
+When you select a project, the first machine in the project will open in Stately Studio’s editor. The other machines in your project are accessible from the **Machines** list in the left drawer menu.
 
 <p>
 <ThemedImage
-  alt="Stately Studio Editor showing the Machines list in the left drawer for the Stately Studio Tutorials project. The selected machine is called ‘Parent states.’"
+  alt="Stately Studio editor showing the Machines list in the left drawer for the Stately Studio Tutorials project. The selected machine is called ‘Parent states.’"
   sources={{
     light: useBaseUrl('/projects/machines-list.png'),
     dark: useBaseUrl('/projects/machines-list-dm.png'),
@@ -57,24 +57,24 @@ You can create a new project when you first save a machine or from the **Create 
 
 #### Create a new project from **My Projects**
 
-1. Open **My Projects** from the link at the left of the Studio’s top bar.
+1. Open **My Projects** from the link at the left of Stately Studio’s top bar.
 2. Use the **Create project** button.
 3. Name the project. The description and keyword fields are optional.
 4. Use the **Submit** button to create the new project.
 
-#### Create a new project from the Studio Editor
+#### Create a new project from Stately Studio’s editor
 
 The **Save** button will save your machine or prompt you to sign into Stately Studio before saving. Your project will have the same name as your current machine name.
 
-1. From the Studio Editor, use the **Save** button to save your current machine in a project.
+1. From the editor, use the **Save** button to save your current machine in a project.
 2. Choose **New Project** from the dropdown menu in the Save machine dialog.
 3. Use **Save** to save your machine and create your new project.
 
 #### Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Projects** tab on the team page.
 3. Use the **Create project** button.
 3. Name the project. The description and keyword fields are optional.
@@ -84,13 +84,13 @@ Only team members with the **Owner**, **Admin**, or **Editor** roles can create 
 
 You can move projects between your teams if you have an [**Owner**](teams.mdx#owner-role) role on both teams.
 
-1. Use the **Share** button in the Studio’s top bar to open the Share dialog.
+1. Use the **Share** button in Stately Studio’s top bar to open the Share dialog.
 2. Choose the destination team from the dropdown menu in the Move project section.
 3. Confirm that you want to move the project from the project move warning dialog using the **Move to *project name*** button.
 
 <p>
 <ThemedImage
-  alt="Stately Studio Editor page showing the Share modal with the options for changing project visibility and moving projects to another team."
+  alt="Stately Studio editor page showing the Share modal with the options for changing project visibility and moving projects to another team."
   sources={{
     light: useBaseUrl('/projects/move-projects.png'),
     dark: useBaseUrl('/projects/move-projects-dm.png'),
@@ -108,17 +108,17 @@ A project can be **public**, **unlisted**, or **private**. If the project is a s
 - Unlisted projects are visible to everyone with the project’s URL but are not findable on the Discover page or listed on your profile page.
 - Private projects are only visible to you and the team that owns the project.
 
-1. Use the **Share** button in the Studio’s top bar to open the Share dialog.
+1. Use the **Share** button in Stately Studio’s top bar to open the Share dialog.
 2. Toggle the project’s visibility between **public**, **unlisted**, or **private** from the dropdown menu in the Share dialog.
 
 ### Favorite a project
 
-You can favorite your own projects and other people’s projects. Favoriting a project gives you easy access to these projects in the future, as your **Favorites** are listed in the left sidebar of the Studio workspace. You might want to favorite projects you find inspiring or educational so that you can refer back to them later.
+You can favorite your own projects and other people’s projects. Favoriting a project gives you easy access to these projects in the future, as your **Favorites** are listed in the left sidebar of Stately Studio’s workspace. You might want to favorite projects you find inspiring or educational so that you can refer back to them later.
 
 You can favorite a project from **My Projects**, **Discover**, and team projects.
 
 1. Choose **Add to favorites** from the **...** triple dot contextual menu alongside the project’s name.
-2. Find your **Favorites** in the left sidebar of the Studio workspace.
+2. Find your **Favorites** in the left sidebar of Stately Studio’s workspace.
 
 #### Remove a project from your favorites
 

--- a/versioned_docs/version-5/sign-up.mdx
+++ b/versioned_docs/version-5/sign-up.mdx
@@ -4,7 +4,7 @@ title: Sign up for the Stately Studio
 
 # Sign up
 
-You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the Editor](https://stately.ai/editor)’s top bar.
+You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the editor](https://stately.ai/editor)’s top bar.
 
 Sign up using your email address and password, or sign in using your GitHub, Google, or Twitter account credentials. 
 

--- a/versioned_docs/version-5/spawn.mdx
+++ b/versioned_docs/version-5/spawn.mdx
@@ -8,7 +8,7 @@ XState is based on the [actor model](actors.mdx). Spawned actors are managed by 
 
 <!-- TODO: example -->
 
-## Stately Editor: spawning actors
+## Stately Studio’s editor: spawning actors
 
 ## API
 

--- a/versioned_docs/version-5/states.mdx
+++ b/versioned_docs/version-5/states.mdx
@@ -33,7 +33,7 @@ In the Stately Studio, the rounded rectangle boxes are states. The **?** questio
 
 These states are “finite”; the machine can only move through the states you’ve pre-defined.
 
-## Using states in the Studio
+## Using states in Stately Studio
 
 ### Create a state
 

--- a/versioned_docs/version-5/studio-community-plan.mdx
+++ b/versioned_docs/version-5/studio-community-plan.mdx
@@ -20,4 +20,4 @@ Our Community plan features include the following:
 - [Design and simulate flows](/#studio-editor)
 - [Import from code](import-from-code.mdx)
 - [Export as code](export-as-code.mdx)
-- [XState VSCode extension](xstate-vscode-extension.mdx)
+- [XState VS Code extension](xstate-vscode-extension.mdx)

--- a/versioned_docs/version-5/studio-pro-plan.mdx
+++ b/versioned_docs/version-5/studio-pro-plan.mdx
@@ -32,13 +32,13 @@ You can choose between monthly or yearly billing on our Pro accounts and how man
 
 ### How to sign up
 
-You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the Editor](https://stately.ai/editor)’s top bar.
+You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the editor](https://stately.ai/editor)’s top bar.
 
 Read more about [signing up for the Stately Studio](sign-up.mdx).
 
 ### How to upgrade
 
-You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the Editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
 
 ## Priority support
 

--- a/versioned_docs/version-5/studio.mdx
+++ b/versioned_docs/version-5/studio.mdx
@@ -14,13 +14,13 @@ Here you can find all the documentation for the Stately Studio and [XState](./xs
   <li>
     <a className="link-box" href="/states/intro">
       🏁 <strong>Get started</strong> Jump straight into learning how to use the
-      Editor, starting with states.
+      editor, starting with states.
     </a>
   </li>
   <li>
     <a className="link-box" href="#studio-editor">
-      ⬇️ <strong>Editor overview</strong> Keep reading to find out more about
-      the Studio Editor.
+      ⬇️ <strong>editor overview</strong> Keep reading to find out more about
+      Stately Studio’s editor.
     </a>
   </li>
   <li>
@@ -37,11 +37,11 @@ Here you can find all the documentation for the Stately Studio and [XState](./xs
   </li>
 </ul>
 
-The Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](developer-tools.mdx), and much more coming soon.
+The Stately Studio is a suite of tools for building app logic, including Stately Studio’s editor, [developer tools for XState](developer-tools.mdx), and much more coming soon.
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio Editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
+    alt="A dog walk machine open in the Stately Studio editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
     sources={{
       light: useBaseUrl('/studio.png'),
       dark: useBaseUrl('/studio-dm.png'),
@@ -49,7 +49,7 @@ The Stately Studio is a suite of tools for building app logic, including the Stu
   />
 </p>
 
-You can use the [Studio Editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](xstate-vscode-extension.mdx) to use the Editor with your codebase inside your code editor, or [export](/#export) your code from the Studio into your codebase.
+You can use the [Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
 
 :::tip
 
@@ -57,15 +57,15 @@ What are state machines and statecharts? We’re glad you asked! [Check out our 
 
 :::
 
-## Studio Editor
+## Stately Studio’s editor
 
-The Studio Editor supports everything you need to visually build state machines and statecharts. The Editor currently has two modes; editor mode for creating your machines and simulation mode for simulating how your machine works.
+Stately Studio editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; editor mode for creating your machines and simulation mode for simulating how your machine works.
 
-### Editor mode
+### editor mode
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio Editor in Edit mode. The running state is selected, with the right panel showing options for a state."
+    alt="A dog walk machine open in the Stately Studio editor in Edit mode. The running state is selected, with the right panel showing options for a state."
     sources={{
       light: useBaseUrl('/editor.png'),
       dark: useBaseUrl('/editor-dm.png'),
@@ -79,7 +79,7 @@ Visually add, modify, and delete states, events, and transitions, as well as dat
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio Editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
+    alt="A dog walk machine open in the Stately Studio editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
     sources={{
       light: useBaseUrl('/simulate.png'),
       dark: useBaseUrl('/simulate-dm.png'),
@@ -109,7 +109,7 @@ As a [Pro user](https://stately.ai/pricing), you can create and join teams in th
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),
@@ -123,7 +123,7 @@ Are you seeking inspiration for your machine? Or do you want to learn from how s
 
 <p>
   <ThemedImage
-    alt="Stately Studio Discover page showing the search results for “auth”, filtered by Editor machines under 10 states, showing 173 results."
+    alt="Stately Studio Discover page showing the search results for “auth”, filtered by editor machines under 10 states, showing 173 results."
     sources={{
       light: useBaseUrl('/discover.png'),
       dark: useBaseUrl('/discover-dm.png'),

--- a/versioned_docs/version-5/studio.mdx
+++ b/versioned_docs/version-5/studio.mdx
@@ -41,7 +41,7 @@ The Stately Studio is a suite of tools for building app logic, including Stately
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
+    alt="A dog walk machine open in Stately Studio’s editor. The dog walk machine has cute puppy images for each state, showing a dog walking and running. The speed up event is selected, and information and options for that transition is shown in an inspector panel on the right."
     sources={{
       light: useBaseUrl('/studio.png'),
       dark: useBaseUrl('/studio-dm.png'),
@@ -49,7 +49,7 @@ The Stately Studio is a suite of tools for building app logic, including Stately
   />
 </p>
 
-You can use the [Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
+You can use the [Stately Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
 
 :::tip
 
@@ -59,13 +59,13 @@ What are state machines and statecharts? We’re glad you asked! [Check out our 
 
 ## Stately Studio’s editor
 
-Stately Studio editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; editor mode for creating your machines and simulation mode for simulating how your machine works.
+Stately Studio editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; **Design** mode for creating your machines and **Simulation** mode for simulating how your machine works.
 
-### editor mode
+### Design mode
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio editor in Edit mode. The running state is selected, with the right panel showing options for a state."
+    alt="A dog walk machine open in Stately Studio’s editor in Edit mode. The running state is selected, with the right panel showing options for a state."
     sources={{
       light: useBaseUrl('/editor.png'),
       dark: useBaseUrl('/editor-dm.png'),
@@ -79,7 +79,7 @@ Visually add, modify, and delete states, events, and transitions, as well as dat
 
 <p>
   <ThemedImage
-    alt="A dog walk machine open in the Stately Studio editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
+    alt="A dog walk machine open in Stately Studio’s editor in Simulate mode. The walking state is active, with the speed up and arrive home events both highlighted showing which events could be triggered next. The right panel shows an event log of the states and events taken."
     sources={{
       light: useBaseUrl('/simulate.png'),
       dark: useBaseUrl('/simulate-dm.png'),
@@ -109,7 +109,7 @@ As a [Pro user](https://stately.ai/pricing), you can create and join teams in th
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and Admin role, Commander Chakotay with an Admin role, Lieutenant Tuvok, Lieutenant Torres, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),

--- a/versioned_docs/version-5/system.mdx
+++ b/versioned_docs/version-5/system.mdx
@@ -21,7 +21,7 @@ const actor = interpret(machine).start();
 actor.system;
 ```
 
-## Stately Editor: systems
+## Stately Studio’s editor: systems
 
 ## Actor registration
 

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -10,7 +10,7 @@ You can create and join teams in the Stately Studio to share and collaborate on 
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),
@@ -26,18 +26,18 @@ Teams and shared projects are Pro features of the Stately Studio. [Check out the
 
 ## Team roles
 
-Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [Editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
+Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
 
 The following table is an overview of the capabilities of each team role:
 
-| Capability                               | Owner  | Admin  | Editor | Viewer |
+| Capability                               | Owner  | Admin  | editor | Viewer |
 | ---------------------------------------- | ------ | ------ | ------ | ------ |
 | View team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | View other team members                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
-| Reassign Admin, Editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
+| Reassign Admin, editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Invite new team members                  | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Change project visibility                | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Edit the team name                       | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
@@ -53,7 +53,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members Admin, Editor, and Viewer roles
+- Give team members Admin, editor, and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
@@ -69,13 +69,13 @@ Users with the Admin role can:
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members Editor and Viewer roles
+- Give team members editor and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
-### Editor role
+### editor role
 
-Users with the Editor role can:
+Users with the editor role can:
 
 - View team members
 - Create team projects
@@ -90,14 +90,14 @@ Users with the viewer role can:
 
 ## Create a team
 
-1. Use the **Create team** link in the left sidebar of the Studio workspace to open the Create team form.
+1. Use the **Create team** link in the left sidebar of Stately Studio’s workspace to open the Create team form.
 2. Name your team and use the **Create team** button to create your team.
 
 By default, teams have only one member, the creator and Owner. [Invite new members](/#invite-new-members-to-a-team) to add more members to your team.
 
 ## Edit the team name
 
-1. Select the team from the left sidebar of the Studio workspace.
+1. Select the team from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the Settings tab.
 3. Edit the team name and use the **Save changes** button to update your team name.
 
@@ -105,7 +105,7 @@ By default, teams have only one member, the creator and Owner. [Invite new membe
 
 You need to have [enough seats on your Pro plan](/#teams-members-and-pro-plan-seats) to add more members to your team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. On your team page, use the **Members** tab to view existing members and their roles and invite new members.
 3. Enter the invitee’s email address and choose their role from the dropdown menu.
 4. Use the **Invite to team** button to send the invitation.
@@ -132,13 +132,13 @@ A subscription seat is only taken up at the time of accepting the invitation. An
 
 To change a team member’s role, you must have the [Owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
-3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an Editor**, or **Make an Admin**.
+3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an editor**, or **Make an Admin**.
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an Editor,’ and ‘Remove from team.’"
+    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an editor,’ and ‘Remove from team.’"
     sources={{
       light: useBaseUrl('/teams/edit-role.png'),
       dark: useBaseUrl('/teams/edit-role-dm.png'),
@@ -150,15 +150,15 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 To remove a member from a team, you must have the [owner role](/#owner-role) or [admin role](/#admin-role) for that team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
 3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose the **Remove from team** option.
 
 ## Leave a team
 
-Any team member with **Admin**, **Editor**, or **Viewer** roles can leave a team.
+Any team member with **Admin**, **editor**, or **Viewer** roles can leave a team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
 3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose the **Leave team** option.
 
@@ -168,13 +168,13 @@ Team owners cannot leave their own teams, but they can delete the team.
 
 Only team owners can delete a team.
 
-1. Navigate to the team page from the left sidebar of the Studio workspace.
+1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Settings** tab on the team page.
 3. Use the **Delete team** button to delete your team.
 4. Confirm the team deletion using the **Delete** button in the Delete team dialog.
 
 ## Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
 
 [Read more about how to create shared team projects on the Projects page](projects.mdx#how-to-create-a-shared-team-project).

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -30,7 +30,7 @@ Team members can have one of the following roles: [Owner](/#owner-role), [Admin]
 
 The following table is an overview of the capabilities of each team role:
 
-| Capability                               | Owner  | Admin  | editor | Viewer |
+| Capability                               | Owner  | Admin  | Editor | Viewer |
 | ---------------------------------------- | ------ | ------ | ------ | ------ |
 | View team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | View other team members                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -10,7 +10,7 @@ You can create and join teams in the Stately Studio to share and collaborate on 
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and admin role, Commander Chakotay with an admin role, Lieutenant Tuvok, Lieutenant Torees, and Lieutenant Paris with editor roles, and Ensign Kim with a Viewer role."
+    alt="Stately Studio Team page for the Voyager team, showing Captain Janeway with the owner and Admin role, Commander Chakotay with an Admin role, Lieutenant Tuvok, Lieutenant Torres, and Lieutenant Paris with Editor roles, and Ensign Kim with a Viewer role."
     sources={{
       light: useBaseUrl('/teams.png'),
       dark: useBaseUrl('/teams-dm.png'),
@@ -26,7 +26,7 @@ Teams and shared projects are Pro features of the Stately Studio. [Check out the
 
 ## Team roles
 
-Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
+Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [Editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
 
 The following table is an overview of the capabilities of each team role:
 
@@ -37,7 +37,7 @@ The following table is an overview of the capabilities of each team role:
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
-| Reassign Admin, editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
+| Reassign Admin, Editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Invite new team members                  | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Change project visibility                | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Edit the team name                       | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
@@ -53,7 +53,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members Admin, editor, and Viewer roles
+- Give team members Admin, Editor, and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
@@ -69,13 +69,13 @@ Users with the Admin role can:
 - Change project visibility
 - Invite new team members
 - View team members
-- Give team members editor and Viewer roles
+- Give team members Editor and Viewer roles
 - Create team projects
 - Edit, fork, and view team projects and machines
 
-### editor role
+### Editor role
 
-Users with the editor role can:
+Users with the Editor role can:
 
 - View team members
 - Create team projects
@@ -83,7 +83,7 @@ Users with the editor role can:
 
 ### Viewer role
 
-Users with the viewer role can:
+Users with the Viewer role can:
 
 - View team members
 - View team projects and machines
@@ -134,11 +134,11 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
-3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an editor**, or **Make an Admin**.
+3. Use the **...** triple dot contextual menu alongside the team member’s name in the **Members** list to choose from the options **Make a Viewer**, **Make an Editor**, or **Make an Admin**.
 
 <p>
   <ThemedImage
-    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an editor,’ and ‘Remove from team.’"
+    alt="Stately Studio Team page for the Voyager team, showing the options for Lieutenant Tuvok as ‘Make a Viewer’, ‘Make an Editor,’ and ‘Remove from team.’"
     sources={{
       light: useBaseUrl('/teams/edit-role.png'),
       dark: useBaseUrl('/teams/edit-role-dm.png'),
@@ -148,7 +148,7 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 ## Remove a member from a team
 
-To remove a member from a team, you must have the [owner role](/#owner-role) or [admin role](/#admin-role) for that team.
+To remove a member from a team, you must have the [owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
@@ -156,7 +156,7 @@ To remove a member from a team, you must have the [owner role](/#owner-role) or 
 
 ## Leave a team
 
-Any team member with **Admin**, **editor**, or **Viewer** roles can leave a team.
+Any team member with **Admin**, **Editor**, or **Viewer** roles can leave a team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
@@ -175,6 +175,6 @@ Only team owners can delete a team.
 
 ## Create a shared team project
 
-Only team members with the **Owner**, **Admin**, or **editor** roles can create team projects.
+Only team members with the **Owner**, **Admin**, or **Editor** roles can create team projects.
 
 [Read more about how to create shared team projects on the Projects page](projects.mdx#how-to-create-a-shared-team-project).

--- a/versioned_docs/version-5/transitions.mdx
+++ b/versioned_docs/version-5/transitions.mdx
@@ -19,7 +19,7 @@ Transitions are represented by `on:` in a state:
 
 TODO: full feedback example
 
-## Using transitions and events in the Studio
+## Using transitions and events in Stately Studio
 
 The arrows are transitions, and the rounded rectangles on the arrow’s lines are events. Each transition has a **source** state which comes before the transition, and a **target** state, which comes after the transition. The transition’s arrow starts from the source state and points to the target state.
 
@@ -108,7 +108,7 @@ A state can transition to itself. This is known as a **self-transition**, and is
 
 TODO: Why you might use self-transitions with example.
 
-## Using self-transitions in the Studio
+## Using self-transitions in Stately Studio
 
 ### Make an event into a self-transition
 

--- a/versioned_docs/version-5/upgrade.mdx
+++ b/versioned_docs/version-5/upgrade.mdx
@@ -13,7 +13,7 @@ We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-
 
 ## Upgrade to a Pro plan
 
-You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the Editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
 
 <p>
 <ThemedImage
@@ -31,7 +31,7 @@ You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio usin
 
 ## Modify your subscription plan and seats
 
-1. Select your avatar from the header in the Studio to open your account menu.
+1. Select your avatar from the header in Stately Studio to open your account menu.
 2. Choose **Billing** from the account menu to open your billing options.
 3. Use the **Manage subscription** button to open the Stripe checkout.
 4. Make any modifications you require.

--- a/versioned_docs/version-5/visualizer.mdx
+++ b/versioned_docs/version-5/visualizer.mdx
@@ -6,7 +6,7 @@ title: Visualizer
 
 :::studio
 
-Are you looking for the _Stately Studio_ visual _Editor_? Check out the [Stately Studio overview](/).
+Are you looking for the _Stately Studio_ visual _editor_? Check out the [Stately Studio overview](/).
 
 :::
 
@@ -16,7 +16,7 @@ The [Stately Visualizer](https://stately.ai/viz) is a tool for creating and insp
 
 :::tip
 
-Stately still supports the Stately Visualizer, but you will find many more advanced features, including the visual [Studio Editor](../#studio-editor), teams, and shared projects.
+Stately still supports the Stately Visualizer, but you will find many more advanced features, including the visual [Studio editor](../#studio-editor), teams, and shared projects.
 
 :::
 

--- a/versioned_docs/version-5/visualizer.mdx
+++ b/versioned_docs/version-5/visualizer.mdx
@@ -16,7 +16,7 @@ The [Stately Visualizer](https://stately.ai/viz) is a tool for creating and insp
 
 :::tip
 
-Stately still supports the Stately Visualizer, but you will find many more advanced features, including the visual [Studio editor](../#studio-editor), teams, and shared projects.
+Stately still supports the Stately Visualizer, but you will find many more advanced features, including the Stately Studio [visual editor](../#studio-editor), teams, and shared projects.
 
 :::
 

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -4,7 +4,7 @@ title: 'XState VS Code extension'
 
 # XState VS Code extension
 
-The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VSCode.
+The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VS Code.
 
 :::tip
 

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -56,7 +56,7 @@ createMachine({});
 
 ## Machine layout persistence
 
-Upon opening an XState machine in the VS Code editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
+Upon opening an XState machine in VS Code, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
 
 ```js
 const machine =

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -4,7 +4,7 @@ title: 'XState VS Code extension'
 
 # XState VS Code extension
 
-The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and Studio editor visual editing from inside VS Code.
+The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VSCode.
 
 :::tip
 
@@ -56,7 +56,7 @@ createMachine({});
 
 ## Machine layout persistence
 
-Upon opening an XState machine in the VSCode editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
+Upon opening an XState machine in the VS Code editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
 
 ```js
 const machine =
@@ -64,6 +64,6 @@ const machine =
 createMachine({...});
 ```
 
-This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in the editor.
+This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in Stately Studio’s editor.
 
 :::

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -18,9 +18,9 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
 
-Once installed, you can run `XState: Open Visual editor` from the command palette to open any machine at your cursor’s location.
+Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
 
-If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual editor’ will also float above each `createMachine` call.
+If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual Editor’ will also float above each `createMachine` call.
 
 You can also [download the VS Code extension from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) or [download the VS Code extension from the Open VSX marketplace](https://open-vsx.org/extension/statelyai/stately-vscode).
 

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -4,7 +4,7 @@ title: 'XState VS Code extension'
 
 # XState VS Code extension
 
-The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and Studio Editor visual editing from inside VS Code.
+The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and Studio editor visual editing from inside VS Code.
 
 :::tip
 
@@ -18,9 +18,9 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
 
-Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
+Once installed, you can run `XState: Open Visual editor` from the command palette to open any machine at your cursor’s location.
 
-If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual Editor’ will also float above each `createMachine` call.
+If you have code lens enabled (this can be enabled using `editor.codeLens` setting), ‘Open Visual editor’ will also float above each `createMachine` call.
 
 You can also [download the VS Code extension from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) or [download the VS Code extension from the Open VSX marketplace](https://open-vsx.org/extension/statelyai/stately-vscode).
 
@@ -56,7 +56,7 @@ createMachine({});
 
 ## Machine layout persistence
 
-Upon opening an XState machine in the VSCode Editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
+Upon opening an XState machine in the VSCode editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
 
 ```js
 const machine =
@@ -64,6 +64,6 @@ const machine =
 createMachine({...});
 ```
 
-This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in the Editor.
+This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in the editor.
 
 :::

--- a/versioned_sidebars/version-5-sidebars.json
+++ b/versioned_sidebars/version-5-sidebars.json
@@ -76,11 +76,11 @@
     },
     {
       "type": "category",
-      "label": "Using the Studio",
+      "label": "Using Stately Studio",
       "link": {
         "type": "generated-index",
-        "title": "Using the Stately Studio",
-        "description": "Learn how to use the Stately Editor and Studio.",
+        "title": "Using Stately Studio",
+        "description": "Learn how to use the Stately Studio and our editor.",
         "slug": "/category/studio",
         "keywords": ["guides"]
       },
@@ -93,7 +93,7 @@
           "link": {
             "type": "generated-index",
             "title": "Design mode",
-            "description": "Learn how to use Design mode in the Stately Editor.",
+            "description": "Learn how to use Design mode in the Stately Studio’s editor.",
             "slug": "/category/design-mode",
             "keywords": ["guides"]
           },
@@ -243,7 +243,7 @@
       "link": {
         "type": "generated-index",
         "title": "Stately developer tools",
-        "description": "Find all the developer tools you can use with XState and the Stately Editor.",
+        "description": "Find all the developer tools you can use with XState and Stately Studio’s editor.",
         "slug": "/category/developer-tools",
         "keywords": ["guides"]
       },


### PR DESCRIPTION
This PR replaces:
- `the Stately Studio` with `Stately Studio` as Stately Studio is the name.
- `Stately Studio Editor` with `Stately Studio’s editor` as the editor is not a proper noun.
- `the Editor` with `the editor` for the same reason as above.