### PR TITLE
v5 docs updates April 20

### DIFF
--- a/docs/tools/inspector.mdx
+++ b/docs/tools/inspector.mdx
@@ -26,7 +26,7 @@ npm install @xstate/inspect
 
 2. Import @xstate/inspect at the beginning of your project before any other code is called:
 
-```ts twoslash
+```ts
 import { inspect } from '@xstate/inspect';
 
 inspect({
@@ -38,11 +38,7 @@ inspect({
 
 3. Add `{ devTools: true }` to any interpreted machines you want to visualize:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-const someMachine = createMachine({});
-
-// ---cut---
+```ts
 import { interpret } from 'xstate';
 import { inspect } from '@xstate/inspect';
 
@@ -100,7 +96,7 @@ Use the `url` property (string) to specify the URL of the inspector you want to 
 
 `inspect` returns a function, `disconnect`, you can use to disconnect the inspector.
 
-```ts twoslash
+```ts
 import { inspect } from '@xstate/inspect';
 
 const inspector = inspect();

--- a/docs/xstate/actions/actions.mdx
+++ b/docs/xstate/actions/actions.mdx
@@ -40,7 +40,7 @@ Some examples of actions are:
 
 You can fire an action upon entering or exiting a state by using the `entry` and `exit` attributes on that state.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -72,7 +72,7 @@ const machine = createMachine(
 
 You can also fire an action on a transition:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -109,7 +109,7 @@ const machine = createMachine(
 
 Anywhere you can use an action, you can also declare it as an array to express multiple actions.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -154,7 +154,7 @@ In a **dog begging** process, there would be a **begging** state with a **gets t
 
 Self-transitions are helpful when you want to fire an action, but not leave your current state. You can use an action on the transition to fire it whenever that event is received.
 
-```ts twoslash
+```ts 
 import { createMachine } from 'xstate';
 
 createMachine(

--- a/docs/xstate/actions/built-in-actions.mdx
+++ b/docs/xstate/actions/built-in-actions.mdx
@@ -17,7 +17,7 @@ When the send action is executed, it sends an event back to the machine _as if i
 
 This pattern can help compose different flows together. In the example below, the user can either press the `copy` button or press `ctrl + c` to fire a `COPY` event to the machine. Using the `send` action to fire the same event from both actions reduces duplication.
 
-```ts twoslash
+```ts
 import { createMachine, send } from 'xstate';
 
 const keyboardShortcutMachine = createMachine({
@@ -37,9 +37,7 @@ const keyboardShortcutMachine = createMachine({
 
 You can also dynamically specify the event to send by passing a function to `send`:
 
-```ts twoslash
-import { send } from 'xstate';
-// ---cut---
+```ts
 send((context, event) => {
   return {
     type: 'SOME_EVENT',
@@ -50,8 +48,7 @@ send((context, event) => {
 ### Sending events to actors
 With the `sendTo` action, events can be sent to actors:
 
-```ts twoslash {13-14}
-// @noErrors
+```ts
 import { actions, AnyActorRef, assign, createMachine, spawn } from 'xstate';
 const { sendTo } = actions;
 
@@ -63,10 +60,12 @@ const machine = createMachine({
         someRef: () => spawn(someMachine),
       }),
       on: {
+        // highlight-start
         SOME_EVENT: {
           actions: (context) =>
             sendTo(context.someRef, { type: 'PING' }),
         },
+        // highlight-end
       },
     },
   },
@@ -77,7 +76,7 @@ const machine = createMachine({
 The `raise` action creator queues an event to the statechart, in the internal event queue.
 This means the event is sent immediately on the current “step” of the interpreter.
 
-```ts twoslash {17-18}
+```ts
 import { createMachine, actions } from "xstate";
 const { raise } = actions;
 
@@ -94,8 +93,10 @@ const raiseActionDemo = createMachine({
         RAISE: {
           target: 'middle',
 
+          // highlight-start
           // immediately invoke the NEXT event in 'middle'
           actions: raise('NEXT')
+          // highlight-end
         },
       },
     },
@@ -127,8 +128,7 @@ In the example below, we check `context` to find which actions the machine shoul
 
 <!-- Remove noErrors when pure TS issue (https://github.com/statelyai/xstate/pull/3233) is fixed-->
 
-```ts twoslash
-// @noErrors
+```ts
 import { actions, createMachine } from 'xstate';
 
 const { pure } = actions;
@@ -152,8 +152,7 @@ createMachine({
 
 The `log` action creator is a declarative way of logging anything related to the current state `context` and/or `event`.                          |
 
-```ts twoslash {9,14-18,29-37}
-// @noErrors
+```ts
 import { createMachine, actions } from 'xstate';
 const { log } = actions;
 
@@ -162,17 +161,21 @@ const loggingMachine = createMachine({
   context: { count: 42 },
   initial: 'start',
   states: {
+    // highlight-start
     start: {
+    // highlight-end
       entry: log('started!'),
       on: {
         FINISH: {
           target: 'end',
+          // highlight-start
           actions: log(
             (context, event) =>
             `count: ${context.count}, event: ${event.type}`,
 
             'Finish label'
           )
+          // highlight-end
         }
       }
     },
@@ -181,7 +184,7 @@ const loggingMachine = createMachine({
 });
 
 const endState = loggingMachine.transition('start', 'FINISH');
-
+// highlight-start
 endState.actions;
 // the endState.actions array will now contain our log action:
 // [
@@ -194,6 +197,7 @@ endState.actions;
 
 // The interpreter would log the action's evaluated expression
 // based on the current state context and event.
+// highlight-end
 ```
 
 Without any arguments, `log` is an action that logs an object with `context` and `event` properties, containing the current context and triggering event, respectively.
@@ -205,8 +209,7 @@ The `choose` action creator creates an action that specifies which actions shoul
 Do not use the `choose` action creator to execute actions that can otherwise be represented as non-conditional actions executed in certain states/transitions via `entry`, `exit`, or `actions`.
 :::
 
-```ts twoslash
-// @noErrors
+```ts
 import { actions } from "xstate";
 const { choose, log } = actions;
 
@@ -253,13 +256,11 @@ This is analogous to the SCXML `<if>`, `<elseif>`, and `<else>` elements: www.w3
 
 ## Rules of built-in actions
 
-<!-- deps: ["actions", "assign-action"] -->
-
 Built-in actions are _pure functions_. Pure functions don’t execute anything themselves but instead return instructions that tells XState what to do.
 
 For example, the assign function returns an object containing `type: 'xstate.assign'` and an `assigner` function.
 
-```ts twoslash
+```ts
 import { assign } from 'xstate';
 
 const assignResult = assign((context, event) => ({
@@ -274,8 +275,7 @@ The instruction set above is interpreted by XState, which executes the code. The
 
 For example, the following code won’t work correctly because the result of the `assign` isn’t being passed into `assignToContext`.
 
-```ts twoslash {8-14}
-// @noErrors
+```ts
 import { createMachine, assign } from 'xstate';
 
 const machine = createMachine(
@@ -284,12 +284,14 @@ const machine = createMachine(
   },
   {
     actions: {
+      // highlight-start
       assignToContext: (context, event) => {
         // 🚫 This won’t work!
         // The result of the assign isn’t being passed
         // into assignToContext
         assign({
           message: 'Hello!',
+      // highlight-end
         });
       },
     },
@@ -299,8 +301,7 @@ const machine = createMachine(
 
 The following example works correctly because the result of the `assign` is passed into `assignToContext`:
 
-```ts twoslash {7-11}
-// @noErrors
+```ts
 import { createMachine, assign } from 'xstate';
 
 const machine = createMachine(
@@ -308,9 +309,11 @@ const machine = createMachine(
     // ...config
   },
   {
+  // highlight-start
     actions: {
       assignToContext: assign((context) => ({
         message: 'Hello!',
+  // highlight-end
       })),
     },
   }

--- a/docs/xstate/actions/context.mdx
+++ b/docs/xstate/actions/context.mdx
@@ -16,12 +16,12 @@ This “infinite” state can be stored in a statechart’s **context**, a data 
 
 You can pass a machine its context using the `context` property:
 
-```ts twoslash {2-4}
-import { createMachine } from 'xstate';
-// ---cut---
+```ts
 const machine = createMachine({
+  // highlight-start
   context: {
     count: 0,
+  // highlight-end
   },
 });
 ```
@@ -36,8 +36,7 @@ Assigning new values to the context in XState is done through the `assign` actio
 
 The `assign` action takes the context _assigner_, representing how values should be assigned in the current context. The _assigner_ can be an object:
 
-```ts twoslash {22-40}
-// @noErrors
+```ts
 import { createMachine, assign } from 'xstate';
 
 const machine = createMachine(
@@ -59,6 +58,7 @@ const machine = createMachine(
   },
   {
     actions: {
+      // highlight-start
       assignToContext: assign({
         // increment the current count by the event value
         count: (context, event) => context.count + event.value,
@@ -78,6 +78,7 @@ const machine = createMachine(
          */
         message: (_) => 'Count changed',
       }),
+      // highlight-end
     },
   }
 );
@@ -85,8 +86,7 @@ const machine = createMachine(
 
 Or the _assigner_ can be a function that returns the updated state:
 
-```ts twoslash {16-23}
-// @noErrors
+```ts
 import { createMachine, assign } from 'xstate';
 
 const machine = createMachine(
@@ -102,6 +102,7 @@ const machine = createMachine(
     },
   },
   {
+  // highlight-start
     actions: {
       assignToContext: assign((context) => {
         return {
@@ -112,6 +113,7 @@ const machine = createMachine(
         };
       }),
     },
+  // highlight-end
   }
 );
 ```
@@ -136,7 +138,7 @@ You can pass several `assign` actions in an array and they’ll be executed sequ
 
 When XState fires an action, the action receives several arguments. The first argument is the current `context` of the machine. The second argument is the most recent `event` sent to the machine.
 
-```ts twoslash {15-19}
+```ts
 import { createMachine } from 'xstate';
 
 createMachine(
@@ -151,6 +153,7 @@ createMachine(
     },
   },
   {
+    // highlight-start
     actions: {
       logCountToConsole: (context, event) => {
         console.log(`Count is ${context.count}`);
@@ -158,6 +161,7 @@ createMachine(
         console.log(event.type); // Logs 'LOG_COUNT'
       },
     },
+    // highlight-end
   }
 );
 ```
@@ -170,9 +174,7 @@ createMachine(
 
 In TypeScript, you can strongly type your context by passing a type to the `schema` property, which means that wherever you access the context, whether inside actions or when running your machine, the context will be strongly typed.
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
+```ts
 const lightMachine = createMachine({
   schema: {
     context: {} as { value: number },

--- a/docs/xstate/actors/actions-vs-actors.mdx
+++ b/docs/xstate/actors/actions-vs-actors.mdx
@@ -10,11 +10,7 @@ Sometimes it’s unclear whether you should use an action or an actor. Both appe
 
 Actions are “fire-and-forget”; as soon as their execution starts, the statechart running the actions forgets about them. If you specify an action as `async`, **the action won’t be awaited before moving to the next state**. Below is an example:
 
-```ts twoslash
-const createUser = async (userName: string) => {};
-// ---cut---
-import { createMachine } from 'xstate';
-
+```ts
 const machine = createMachine(
   {
     context: {
@@ -57,11 +53,7 @@ Instead, the sequence works like this:
 
 To handle `submitForm` properly, we need to use an actor:
 
-```ts twoslash {13, 17-27}
-const createUser = async (userName: string) => {};
-// ---cut---
-import { createMachine } from 'xstate';
-
+```ts
 const machine = createMachine(
   {
     context: {
@@ -72,10 +64,13 @@ const machine = createMachine(
       collectingFormDetails: {
         on: {
           SUBMIT: {
+            // highlight-start
             target: 'submitting',
+            // highlight-end
           },
         },
       },
+      // highlight-start
       submitting: {
         invoke: {
           src: 'submitForm',
@@ -87,6 +82,7 @@ const machine = createMachine(
           },
         },
       },
+      // highlight-end
       errored: {},
       submitted: {},
     },

--- a/docs/xstate/actors/callbacks.mdx
+++ b/docs/xstate/actors/callbacks.mdx
@@ -14,7 +14,7 @@ Promise actors let you model promises declaratively but not every actor will be 
 
 Callback actors are declared using the `() => () => {}` syntax, which is how XState distinguishes them from promise actors, which are declared as: `() => {}`.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 createMachine(
@@ -52,7 +52,7 @@ Callbacks are called with:
 
 Callbacks also receive a `sendBack` function, which you can use to send events back to its parent machine.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 createMachine(

--- a/docs/xstate/actors/intro.mdx
+++ b/docs/xstate/actors/intro.mdx
@@ -10,7 +10,7 @@ When you run a statechart, it becomes an _actor_, a running process that can rec
 
 We use the `invoke` attribute on a state to _invoke_ an actor in our machine. You can invoke an actor on any state, including the root node.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -39,7 +39,7 @@ XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/
 
 You can also run several invocations at the same time by specifying `invoke` as an array:
 
-```ts twoslash
+```ts 
 import { createMachine } from 'xstate';
 
 const machine = createMachine(

--- a/docs/xstate/actors/machines.mdx
+++ b/docs/xstate/actors/machines.mdx
@@ -10,7 +10,7 @@ Callback actors are one way to start invoking long-lived actors and are useful f
 
 _Machine actors_ are valuable for such use cases. You can pass a machine directly to the `invoke` `src` property to invoke the machine in that state.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const childMachine = createMachine({
@@ -34,7 +34,7 @@ Machine actors enable you to create machines that can act as reusable modules ac
 
 Child machines can communicate to the parent that invoked them via the `sendParent` action.
 
-```ts twoslash
+```ts
 import { createMachine, sendParent } from 'xstate';
 
 const childMachine = createMachine({
@@ -79,10 +79,7 @@ If the child machine doesn’t have a parent, for instance, if the machine is ru
 
 When a child machine reaches a final state, it reports that it’s done to its parent. The parent can listen for this event with the `invoke.onDone` property:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const childMachine = createMachine({
   initial: 'waiting',
   states: {
@@ -120,13 +117,8 @@ const parentMachine = createMachine(
 
 You can also send data along with this `onDone` event. This “done data” is specified on the final state’s `data` property:
 
-<!-- TODO: remove @noErrors when this is fixed: https://github.com/statelyai/xstate/pull/3217-->
 
-```ts twoslash {15-17, 29-34}
-// @noErrors
-import { createMachine, assign } from 'xstate';
-
-// ---cut---
+```ts
 
 const secretMachine = createMachine({
   initial: 'wait',
@@ -141,9 +133,11 @@ const secretMachine = createMachine({
     },
     reveal: {
       type: 'final',
+      // highlight-start
       data: {
         secret: (context, event) => context.secret,
       },
+      // highlight-end
     },
   },
 });
@@ -155,12 +149,14 @@ const parentMachine = createMachine({
   invoke: {
     src: secretMachine,
     onDone: {
+      // highlight-start
       actions: assign({
         revealedSecret: (context, event) => {
           // { type: 'done.invoke.<id>', data: { secret: '42' } }
           return event.data.secret;
         },
       }),
+      // highlight-end
     },
   },
 });

--- a/docs/xstate/actors/observables.mdx
+++ b/docs/xstate/actors/observables.mdx
@@ -12,7 +12,7 @@ Observables can be invoked, sending events to the parent machine. An observable 
 
 In the example below, the `intervalMachine` will receive the events from `interval(...)` mapped to event objects until the observable is “completed” when it’s done emitting values. If the `CANCEL` event happens, the observable will be disposed of as `.unsubscribe()` will be called internally.
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 import { interval } from 'rxjs';
 import { map, take } from 'rxjs/operators';
@@ -46,7 +46,7 @@ const intervalMachine = createMachine({
 
 You don’t necessarily need to create observables for every invocation. You could reference a “hot observable” instead:
 
-```ts twoslash
+```ts
 import { fromEvent } from 'rxjs';
 import { createMachine } from 'xstate';
 

--- a/docs/xstate/actors/parent-child-communication.mdx
+++ b/docs/xstate/actors/parent-child-communication.mdx
@@ -10,17 +10,16 @@ We’ve learned that invoked actors can send events to their parent via the invo
 
 You must give invoked actors a unique id with `invoke.id` to enable parent to child communication:
 
-```ts twoslash {9}
-// @noErrors
-import { createMachine } from 'xstate';
-
+```ts
 const childMachine = createMachine({
   /* ... */
 });
 
 const parentMachine = createMachine({
   invoke: {
+    // highlight-start
     id: 'child',
+    // highlight-end
     src: childMachine,
   },
 });
@@ -30,7 +29,7 @@ Once the invoked actor has an id, you can use that ID to send it events via the 
 
 In the example below, we specify that we want to send the `HELLO_FROM_PARENT` event to the `child` invocation after 3 seconds. The child then logs a message to the console.
 
-```ts twoslash {31-33}
+```ts
 import { createMachine, send } from 'xstate';
 
 const childMachine = createMachine(
@@ -61,9 +60,11 @@ const parentMachine = createMachine({
         {
           type: 'HELLO_FROM_PARENT',
         },
+        // highlight-start
         {
           to: 'child',
         }
+        // highlight-end
       ),
     },
   },
@@ -78,7 +79,7 @@ Invoked callbacks can listen to events from the parent. To manage this, they rec
 
 In the example below, the parent machine sends the child `ponger` actor a `PING` event. The child actor can listen for that event using `onReceive(listener)` and send a `PONG` event back to the parent in response.
 
-```ts twoslash
+```ts
 import { createMachine, send } from 'xstate';
 
 const pingPongMachine = createMachine(
@@ -127,7 +128,7 @@ XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/
 
 You’ll often want to use the parent machine to “forward” events to the child machine. To handle this, XState provides a built-in `forwardTo` action:
 
-```ts twoslash
+```ts
 import { createMachine, forwardTo } from 'xstate';
 
 const alertMachine = createMachine(
@@ -167,7 +168,7 @@ If you want _all_ events sent to the parent to be forwarded to the child, you ca
 
 In the example below, _any_ event the machine receives will be sent on to the `eventHandler`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -200,7 +201,7 @@ In the parent, you can listen for the `escalate` action via the `invoke.onError`
 
 In the example below, the child machine immediately escalates an error to its parent on `entry`. The parent machine then processes the error in an `onError` handler by logging it to the console.
 
-```ts twoslash
+```ts
 import { createMachine, actions } from 'xstate';
 
 const { escalate } = actions;

--- a/docs/xstate/actors/promises.mdx
+++ b/docs/xstate/actors/promises.mdx
@@ -8,7 +8,7 @@ title: Promises
 
 The most common type of actors you’ll invoke are **promise actors**. Promise actors allow you to await the result of a promise before deciding what to do next.
 
-```ts twoslash
+```ts
 import { createMachine, assign } from 'xstate';
 
 // Function that returns a promise
@@ -55,7 +55,7 @@ When a promise actor is resolved, a `done.invoke` event is sent back to the mach
 
 You can listen for this event by providing an `onDone` to the invoke attribute:
 
-```ts twoslash
+```ts
 import { createMachine, assign } from 'xstate';
 
 // Function that returns a promise
@@ -63,8 +63,6 @@ import { createMachine, assign } from 'xstate';
 // { name: 'David', location: 'Florida' }
 const fetchUser = (userId: number) =>
   fetch(`url/to/user/${userId}`).then((response) => response.json());
-
-// ---cut---
 
 const userMachine = createMachine(
   {
@@ -106,7 +104,7 @@ If the state where the invoked promise is active is exited before the promise se
 
 If the promise errors, an `error.platform.<id>` event will be fired, with the error on the `data` attribute. You can listen for this error by adding `onError` to your `invoke` attribute:
 
-```ts twoslash
+```ts
 import { createMachine, assign } from 'xstate';
 
 // Function that returns a promise
@@ -114,8 +112,6 @@ import { createMachine, assign } from 'xstate';
 // { name: 'David', location: 'Florida' }
 const fetchUser = (userId: number) =>
   fetch(`url/to/user/${userId}`).then((response) => response.json());
-
-// ---cut---
 
 const userMachine = createMachine(
   {

--- a/docs/xstate/actors/spawn.mdx
+++ b/docs/xstate/actors/spawn.mdx
@@ -16,7 +16,7 @@ You can use a powerful tool called `spawn` to run these actors in these cases. A
 
 Spawning actors puts a reference to the machine in `context`, which means that you must always assign a spawned actor to context via `assign`:
 
-```ts twoslash
+```ts
 import { createMachine, spawn, assign } from 'xstate';
 
 const childMachine = createMachine({
@@ -34,21 +34,22 @@ const parentMachine = createMachine({
 
 In the example above, the spawned actor can now be referenced on the `context` of the machine. You can spawn as many actors as you need:
 
-```ts twoslash {5-7}
+```ts
 import { createMachine, spawn, assign } from 'xstate';
 
 const childMachine = createMachine({
   /* ... */
 });
 
-// ---cut---
 const parentMachine = createMachine({
   entry: [
     assign({
       childMachineRefs: () => [
+        // highlight-start
         spawn(childMachine),
         spawn(childMachine),
         spawn(childMachine),
+        // highlight-end
       ],
     }),
   ],
@@ -71,12 +72,11 @@ forwardTo(context => context.counterRef);
 
 You can also forward _all_ events to the child by passing `autoForward` as an option to `spawn`:
 
-```ts twoslash
+```ts
 import { spawn, createMachine, assign } from 'xstate';
 
 const childMachine = createMachine({});
 
-// ---cut---
 const machine = createMachine({
   entry: assign((context) => ({
     counterRef: spawn(childMachine, {
@@ -94,15 +94,15 @@ Passing `autoForward` will ensure that every event sent to the `machine` also ge
 
 When you want to stop a spawned actor, you can either stop the parent machine, which will stop all child actors automatically, or stop the actor via the `stop` action.
 
-```ts twoslash {9, 35-37}
+```ts
 const childMachine = createMachine({
   /* ... */
 });
 
-// ---cut---
 import { createMachine, spawn, assign, actions, ActorRefFrom } from 'xstate';
-
+// highlight-start
 const { stop } = actions;
+// highlight-end
 
 const parentMachine = createMachine(
   {
@@ -121,9 +121,11 @@ const parentMachine = createMachine(
       }),
     ],
     on: {
+      // highlight-start
       STOP: {
         actions: 'stopMachine',
       },
+      // highlight-end
     },
   },
   {
@@ -140,13 +142,15 @@ const parentMachine = createMachine(
 
 Just like invoking callbacks, callbacks can be spawned as actors.
 
-```ts twoslash {22}
+```ts
 import { createMachine, assign, spawn } from 'xstate';
 
 const machine = createMachine({
   entry: assign({
     counterRef: (context, event) =>
+      // highlight-start
       spawn((sendBack, receive) => {
+      // highlight-end
         // Run any code you want inside here
 
         return () => {
@@ -166,7 +170,7 @@ Spawned callbacks behave exactly the same as invoked callbacks but with all the 
 
 Just like invoking observables, observables can be spawned as actors:
 
-```ts twoslash
+```ts
 import { createMachine, assign, spawn } from 'xstate';
 import { interval } from 'rxjs';
 import { map } from 'rxjs/operators';

--- a/docs/xstate/basics/inline-vs-named-options.mdx
+++ b/docs/xstate/basics/inline-vs-named-options.mdx
@@ -9,10 +9,7 @@ description: 'Named actions are when you pass options into the config using name
 
 In the examples so far, we’ve passed options into the config using names:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const machine = createMachine({
   entry: ['sayHello'],
 });
@@ -22,10 +19,7 @@ These are called **named** actions. You can do the same with named guards, actor
 
 However, if you don’t want to name your actions, you can also declare them inline:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const machine = createMachine({
   entry: [
     () => {
@@ -37,10 +31,7 @@ const machine = createMachine({
 
 The difference between named and inline options is mostly stylistic. We support both approaches, and you can mix-and-match named and inline options within the same machine:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const machine = createMachine(
   {
     entry: [

--- a/docs/xstate/basics/options.mdx
+++ b/docs/xstate/basics/options.mdx
@@ -25,9 +25,7 @@ In XState, the separation is divided between:
 
 Below is an example where we describe in our config that when the machine first starts, it 'says hello', using the `sayHello` action.
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
+```ts
 const helloMachine = createMachine({
   /**
    * Below is an 'action' — we’ll
@@ -43,9 +41,7 @@ As a visualization, the config is readable. But the machine doesn’t _do_ anyth
 
 **Options** let us pass an implementation for the `sayHello` action.
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
+```ts
 const helloMachine = createMachine(
   {
     entry: ['sayHello'],
@@ -75,7 +71,7 @@ Guards allow you to check something before you proceed, enabling you to implemen
 
 Below is an example of a guard:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 let iAmHappyAndIKnowIt = true;
@@ -117,7 +113,7 @@ In the example above, the guard is activated when the machine is in the `notClap
 
 Actions allow you to perform simple actions, such as assigning to a variable or calling synchronous actions:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -156,7 +152,7 @@ Delays are used in XState to represent timers and intervals. We’ll revisit del
 
 You can specify machine options in several places. Firstly, you can set options inside the machine itself:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine(
@@ -182,7 +178,7 @@ XState v5 is in alpha. [Check out XState v5 Alpha on NPM](https://www.npmjs.com/
 
 Or, you can specify options later with a `.withConfig` call:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({});

--- a/docs/xstate/basics/what-is-a-statechart.mdx
+++ b/docs/xstate/basics/what-is-a-statechart.mdx
@@ -6,7 +6,7 @@ title: XState statechart basics
 
 [Install XState](xstate/installation.mdx) and create a statechart by importing `createMachine` from `xstate`.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
@@ -18,16 +18,15 @@ const machine = createMachine({
 
 You can create these states in XState using the `states` property:
 
-```ts twoslash {2-5}
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const machine = createMachine({
   initial: 'asleep',
+  // highlight-start
   states: {
     asleep: {},
     awake: {},
   },
+  // highlight-end
 });
 ```
 
@@ -43,12 +42,11 @@ When a state machine starts, it enters the [**initial state**](states/initial-st
 
 In a statechart describing the process of walking the dog, the initial state would be **waiting** to walk:
 
-```ts twoslash {2}
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const machine = createMachine({
+  // highlight-start
   initial: 'waiting',
+  // highlight-end
   states: {
     waiting: {},
   },
@@ -67,26 +65,29 @@ A machine moves from state to state through [transitions](transitions-and-event
 
 Use the `on` property inside the desired state to represent its transitions.
 
-```ts twoslash {5-9, 12-16}
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const machine = createMachine({
   initial: 'asleep',
   states: {
     asleep: {
+      // highlight-start
       on: {
         'wakes up': {
           target: 'awake',
         },
       },
+      // highlight-end
     },
     awake: {
+      // highlight-start
       on: {
         'falls asleep': {
           target: 'asleep',
         },
       },
+      // highlight-end
     },
   },
 });
@@ -96,7 +97,7 @@ const machine = createMachine({
 
 Define an event with an object using the `type` attribute to describe the event’s name. Events can also pass in other properties along with their type.
 
-```ts twoslash
+```ts
 const VALID_EVENTS = [
   {
     type: 'LOG_OUT',
@@ -143,7 +144,7 @@ const INVALID_EVENTS = [
 
 In TypeScript, you can strongly type your events by passing a _[union type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types)_ of all the events to the `schema` property.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({

--- a/docs/xstate/model-based-testing/when-to-use.mdx
+++ b/docs/xstate/model-based-testing/when-to-use.mdx
@@ -18,7 +18,7 @@ In these situations, `@xstate/test` shines because it can automate a lot of the 
 
 However, many tests require no setup at all. Take the following function for example:
 
-```ts twoslash
+```ts
 const add = (a: number, b: number) => {
   return a + b;
 };

--- a/docs/xstate/running-machines/intro.mdx
+++ b/docs/xstate/running-machines/intro.mdx
@@ -15,7 +15,7 @@ Next, we need to learn how to _execute_ our machines in code. Depending on where
 
 The `interpret` interpreter provides us with a “running” and _interactive_ version of our machine.
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine({});
@@ -25,7 +25,7 @@ const actor = interpret(machine).start();
 
 In XState, we call that “running” machine an **actor**. The most common way to interact with an actor is to send it events:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine(
@@ -56,7 +56,7 @@ actor.send({
 
 You can also subscribe to the actor via `actor.subscribe`:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine(
@@ -77,8 +77,6 @@ const machine = createMachine(
 );
 
 const actor = interpret(machine).start();
-
-// ---cut---
 
 // Fires whenever the state changes
 const { unsubscribe } = actor.subscribe((state) => {
@@ -91,7 +89,7 @@ const { unsubscribe } = actor.subscribe((state) => {
 
 You can also stop the actor by running `actor.stop()` which cleans up the actor and runs any relevant exit actions:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine(
@@ -112,8 +110,6 @@ const machine = createMachine(
 );
 
 const actor = interpret(machine).start();
-
-// ---cut---
 
 actor.stop();
 ```
@@ -132,12 +128,10 @@ Check out the reference docs on the interpret API for a full deep dive into ever
 
 When running your machine, you’ll want to query the machine to understand which state it’s in. When you run a machine using `interpret`, you can find the state as follows:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine({});
-
-// ---cut---
 
 const actor = interpret(machine).start();
 
@@ -146,14 +140,12 @@ const state = actor.state;
 
 You can also get an updated version when you subscribe to the state:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine({});
 
 const actor = interpret(machine).start();
-
-// ---cut---
 
 actor.subscribe((state) => {
   console.log(state);
@@ -166,7 +158,7 @@ This `State` class has a bunch of useful attributes and methods.
 
 First, you can find the state’s context using `state.context`.
 
-```ts twoslash
+```ts
 import { createMachine, interpret, assign } from 'xstate';
 
 const machine = createMachine(
@@ -204,7 +196,7 @@ actor.send({ type: 'INCREMENT' });
 
 You can query which state the machine is in by running `state.matches()`. `state.matches()` returns a boolean depending on whether you’re in a matching state.
 
-```ts twoslash
+```ts
 import { createMachine, interpret, assign } from 'xstate';
 
 const machine = createMachine({

--- a/docs/xstate/running-machines/node.mdx
+++ b/docs/xstate/running-machines/node.mdx
@@ -11,7 +11,7 @@ When running machines in Node, a few common patterns emerge.
 
 The first pattern is running XState to coordinate a long-running process, for instance, a file watcher in a CLI (Command Line Interface):
 
-```ts twoslash
+```ts
 import { interpret, createMachine } from "xstate";
 import { watch } from "chokidar";
 
@@ -54,13 +54,13 @@ Lots of backend code relies on short-running processes, such as backend function
 
 Much of this type of code relies on `async` functions:
 
-```ts twoslash
+```ts
 const myFunc = async () => {};
 ```
 
 The best pattern to use for async functions is `waitFor`, which allows you to `await` a state machine being in a particular state.
 
-```ts twoslash
+```ts
 import { interpret, createMachine } from "xstate";
 import { waitFor } from "xstate/lib/waitFor";
 
@@ -93,7 +93,7 @@ In the example above, the machine waits for three seconds before moving on to it
 
 By default, `waitFor` will time out after 10 seconds if the desired state is not reached. You can customize this timeout by passing `timeout` in the options:
 
-```ts twoslash {8-11}
+```ts
 import { interpret, createMachine } from "xstate";
 import { waitFor } from "xstate/lib/waitFor";
 
@@ -111,18 +111,18 @@ const machine = createMachine({
   },
 });
 
-// ---cut---
-
 const myFunc = async () => {
   const actor = interpret(machine).start();
 
   const doneState = await waitFor(
     actor,
     (state) => state.matches("done"),
+    // highlight-start
     {
       // 20 seconds in ms
       timeout: 20_000,
     },
+    // highlight-end
   );
 };
 ```

--- a/docs/xstate/running-machines/react.mdx
+++ b/docs/xstate/running-machines/react.mdx
@@ -29,7 +29,7 @@ npm install xstate @xstate/react
 
 The simplest way to get started with interpreting actors in React is `useMachine`. `useMachine` is a [React hook](https://reactjs.org/hooks) that interprets the given `machine` and starts an actor that runs for the lifetime of the component.
 
-```tsx twoslash
+```tsx
 import { createMachine } from 'xstate';
 import { useMachine } from '@xstate/react';
 
@@ -51,9 +51,8 @@ const Component = () => {
 
 You can also pass machine options to the second argument of `useMachine`. These options will be kept up to date when the component re-renders, which means they can safely access variables inside the component’s scope:
 
-```tsx twoslash
+```tsx
 const useLoggedInUserId = (): string => '123';
-// ---cut---
 
 import { createMachine } from 'xstate';
 import { useMachine } from '@xstate/react';
@@ -85,7 +84,7 @@ const Component = () => {
 
 `useInterpret` allows you to interpret a machine without subscribing to its updates, which means that by default, it won’t cause any re-rendering in the component.
 
-```tsx twoslash
+```tsx
 import { createMachine } from 'xstate';
 import { useInterpret } from '@xstate/react';
 
@@ -100,9 +99,8 @@ const Component = () => {
 
 `useInterpret` accepts the same arguments as `useMachine`, and follows the same rules with `options`:
 
-```tsx twoslash
+```tsx
 const useLoggedInUserId = (): string => '123';
-// ---cut---
 
 import { createMachine } from 'xstate';
 import { useInterpret } from '@xstate/react';
@@ -132,7 +130,7 @@ const Component = () => {
 
 You can use `useSelector` to subscribe to a machine created with `useInterpret` or `interpret`. `useSelector` gives you fine-grained control over when your components should re-render and is particularly valuable for good performance.
 
-```tsx twoslash
+```tsx
 import { createMachine, StateFrom } from 'xstate';
 import { useInterpret, useSelector } from '@xstate/react';
 
@@ -161,7 +159,7 @@ Internally, `useSelector` compares the previous value (`prev`) and the next valu
 
 You can customize the check by passing a `compare` function to `useSelector`:
 
-```tsx twoslash
+```tsx
 import { createMachine, StateFrom } from 'xstate';
 import { useInterpret, useSelector } from '@xstate/react';
 
@@ -195,7 +193,7 @@ The compare function is needed in the example above because comparing two arrays
 
 Use `useActor` if you want to subscribe to _all_ updates to an actor from `useInterpret`:
 
-```tsx twoslash
+```tsx
 import { createMachine, StateFrom } from 'xstate';
 import { useInterpret, useActor } from '@xstate/react';
 

--- a/docs/xstate/states/advanced-transitions.mdx
+++ b/docs/xstate/states/advanced-transitions.mdx
@@ -14,7 +14,7 @@ Use the `.target` syntax to transition to a child state from a parent state.
 
 The following machine uses the `.target` syntax for `.hovered`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
@@ -40,7 +40,7 @@ Transition directly into a node’s children using the `a.b` syntax.
 
 The following machine uses the `a.b` syntax for `.hovered`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
@@ -79,7 +79,7 @@ The approach above works for transitioning to any state node from any state node
 
 The example below shows the `paused` state with an `id` of `playerPaused` and that `id` targeted using `#playerPaused`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const musicMachine = createMachine({
@@ -108,7 +108,7 @@ You can also give the root of your machine an `id` and combine the use of the ro
 
 The example below shows the machine’s root with an `id` of `player` and the `paused` state targeted using `#player.paused`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const musicMachine = createMachine({

--- a/docs/xstate/states/final-states.mdx
+++ b/docs/xstate/states/final-states.mdx
@@ -14,7 +14,7 @@ When a machine reaches the [final state](../../states/final-states.mdx), it can 
 
 To indicate that a state node is final, set its `type` property to `final`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
@@ -49,7 +49,7 @@ Final states can be used with parent states to make elegant, modular statecharts
 
 Inside a parent state, reaching a final child state node will fire a `done` event back to the machine. The machine can listen for the `done` event by declaring `onDone` on the state:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
@@ -101,7 +101,7 @@ The `onDone` transition cannot be defined on the machine’s root because `onDon
 
 When running a machine, you can check `state.done` to find out if an actor has reached its final state.
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const answeringMachine = createMachine({

--- a/docs/xstate/states/history-states.mdx
+++ b/docs/xstate/states/history-states.mdx
@@ -10,7 +10,7 @@ When using statecharts, sometimes you’ll want to relaunch a process in a previ
 
 In the example below, when you turn the fan off via `POWER_OFF`, then turn it back on, it will _always_ start in the `lowPower` state.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const fanMachine = createMachine({
@@ -53,7 +53,7 @@ The example above isn’t a great user experience. Ideally, the fan would start 
 
 We can use a **history state** inside the `powerOn` state to enable that behavior. A history state, when reached, tells the machine to go to the last recorded child of its parent. In our case, when the machine returns to `powerOn`, it will select `lowPower`, `mediumPower` or `highPower`.
 
-```ts twoslash {23-25, 33-38}
+```ts
 import { createMachine } from 'xstate';
 
 const fanMachine = createMachine({
@@ -76,9 +76,11 @@ const fanMachine = createMachine({
       },
       initial: 'lowPower',
       states: {
+        // highlight-start
         hist: {
           type: 'history',
         },
+        // highlight-end
         lowPower: {},
         mediumPower: {},
         highPower: {},
@@ -86,12 +88,14 @@ const fanMachine = createMachine({
     },
     powerOff: {
       on: {
+        // highlight-start
         TURN_ON: {
           /**
            * Target the history node directly
            */
           target: 'powerOn.hist',
         },
+        // highlight-end
       },
     },
   },
@@ -126,7 +130,7 @@ The default behavior of the history state is `shallow`, but `deep` is useful whe
 
 In the example below, the user can hide/show their video AND mute/unmute their microphone. When they leave the call to go to the `notOnCall` state, they can then rejoin the call via `JOIN_CALL`, which targets `onCall.hist`.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const callMachine = createMachine({

--- a/docs/xstate/states/in-state-guards.mdx
+++ b/docs/xstate/states/in-state-guards.mdx
@@ -10,7 +10,7 @@ You can check if the machine is in a certain state using an `in` property on a t
 
 In the example below, when the machine receives the `LOG_WHEN_ACTIVE` event, we check if the machine is in the `active` state, specified by id, then `logIsActive`.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const lightMachine = createMachine(

--- a/docs/xstate/states/other-state-attributes.mdx
+++ b/docs/xstate/states/other-state-attributes.mdx
@@ -12,7 +12,7 @@ States can have various other attributes, most of which are useful for narrower 
 
 State nodes can have **tags**, a list of strings that help describe the state node. Tags can be useful when categorizing different state nodes. For example, you can signify which state nodes represent “loading data” using a `"loading"` tag and determine if a state contains those tagged state nodes with `state.hasTag(tag)`:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine({
@@ -44,7 +44,7 @@ actor.state.hasTag('loading'); // true
 
 Using tags can help you write more concise code. Instead of matching each actor individually:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine({
@@ -66,8 +66,6 @@ const machine = createMachine({
 });
 
 const actor = interpret(machine).start();
-
-// ---cut---
 
 const isLoading =
   actor.state.matches('loadingUser') || actor.state.matches('loadingFriends');
@@ -75,7 +73,7 @@ const isLoading =
 
 You can group the actors by tag:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine({
@@ -97,8 +95,6 @@ const machine = createMachine({
 });
 
 const actor = interpret(machine).start();
-
-// ---cut---
 
 const isLoading = actor.state.hasTag('loading');
 ```
@@ -114,7 +110,7 @@ const isLoading = actor.state.hasTag('loading');
 
 You can attach arbitrary data to any state by specifying it as `meta` on the state node:
 
-```ts twoslash
+```ts
 import { createMachine, interpret } from 'xstate';
 
 const fetchMachine = createMachine({
@@ -167,7 +163,7 @@ You can add descriptive text to states with the `description` attribute.
 
 This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Stately Studio editor](../../#studio-editor) to make the diagrams more descriptive.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({

--- a/docs/xstate/states/parallel-states.mdx
+++ b/docs/xstate/states/parallel-states.mdx
@@ -16,13 +16,17 @@ You can specify a parallel state node on the machine and/or any nested child sta
 
 For example, the machine below allows the `upload` and `download` child states to be simultaneously active. This example represents an application where you can download and upload files at the same time:
 
-```ts twoslash {4,6,22}
+```ts
 import { createMachine } from 'xstate';
 
 const fileMachine = createMachine({
+  // highlight-start
   type: 'parallel',
+  // highlight-end
   states: {
+    // highlight-start
     upload: {
+    // highlight-end
       initial: 'idle',
       states: {
         idle: {
@@ -38,7 +42,9 @@ const fileMachine = createMachine({
         success: {},
       },
     },
+    // highlight-start
     download: {
+    // highlight-end
       initial: 'idle',
       states: {
         idle: {
@@ -68,13 +74,12 @@ The `state.matches` syntax checks if an actor is in a particular state when the 
 
 ### `state.matches` string argument
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({});
 const state = machine.initialState;
 
-// ---cut---
 /**
  * Checks if the machine is in the red.stop
  * state
@@ -84,13 +89,12 @@ console.log(state.matches('red.stop'));
 
 ### `state.matches` object argument
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({});
 const state = machine.initialState;
 
-// ---cut---
 /**
  * Checks if the machine is in the red.stop
  * state
@@ -102,13 +106,12 @@ state.matches({
 
 You can also use the object method to check if your machine is in two parallel states at once:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({});
 const state = machine.initialState;
 
-// ---cut---
 /**
  * Checks if the machine is in the wind.blowing
  * state AND the rain.raining state
@@ -123,13 +126,12 @@ state.matches({
 
 If you want to match one of multiple states, you can use [`.some()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) on an array of state values:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({});
 const state = machine.initialState;
 
-// ---cut---
 const isMatch = [{ customer: 'deposit' }, { customer: 'withdrawal' }].some(
   state.matches
 );
@@ -143,7 +145,7 @@ Sometimes you’ll need a transition to target multiple parts of a parallel stat
 
 Multiple targets are specified as an array in `target: [...]`.
 
-```ts twoslash {24-26}
+```ts
 import { createMachine } from 'xstate';
 
 const settingsMachine = createMachine({
@@ -167,9 +169,11 @@ const settingsMachine = createMachine({
   },
   on: {
     // Multiple targets
+    // highlight-start
     DEACTIVATE: {
       target: ['.mode.inactive', '.status.disabled'],
     },
+    // highlight-end
   },
 });
 ```
@@ -184,7 +188,7 @@ When every child state node in a parallel state node is _done_, the parent paral
 
 `onDone` is very useful in modeling parallel tasks. For example, below there is a shopping machine where `user` and `items` represent two parallel tasks of the `cart` state:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const shoppingMachine = createMachine({

--- a/docs/xstate/states/parent-and-child-states.mdx
+++ b/docs/xstate/states/parent-and-child-states.mdx
@@ -14,8 +14,7 @@ States can contain more states, also known as [child states](../../states/paren
 
 In XState, you can specify a parent state using the `states` attribute on child nodes:
 
-```ts twoslash
-import { createMachine } from 'xstate';
+```ts
 
 const machine = createMachine({
   initial: 'waiting',
@@ -76,9 +75,7 @@ After learning about parent states, you might have noticed that all statecharts 
 
 For example, you can listen to events on the root state:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
+```ts
 const machine = createMachine({
   on: {
     GREETED: {
@@ -97,10 +94,7 @@ Any time the machine receives the `GREETED` event, no matter which state it’s 
 
 Entry and exit actions are also useful in the root state:
 
-```ts twoslash
-import { createMachine } from 'xstate';
-
-// ---cut---
+```ts
 const machine = createMachine({
   entry: ['sayHello'],
   exit: ['sayGoodbye'],
@@ -116,10 +110,9 @@ In the example above, the machine will `sayHello` when it starts running and `sa
 
 You can also omit all states altogether! Sometimes you just need a root state, some events and some actions:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const machine = createMachine({
   entry: ['sayHello'],
   exit: ['sayGoodbye'],
@@ -136,7 +129,7 @@ When a child state cannot handle an `event`, that `event` is propagated up to it
 
 In the example below, when you wave at your friend and the machine is in the `friendIsLookingAtYou` state, the `friendWavesBack` action is fired.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const waveMachine = createMachine({
@@ -170,7 +163,7 @@ A transition specified with a wildcard `*` is triggered by any event not already
 
 The following example shows a few different cases of when the wildcard `*` is triggered or not.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({

--- a/docs/xstate/transitions-and-choices/after.mdx
+++ b/docs/xstate/transitions-and-choices/after.mdx
@@ -10,19 +10,21 @@ Timeouts and intervals can be hard to manage in application code. Statecharts ma
 
 The example below is a statechart for a game where you need to push a button within 5 seconds, or you get timed out:
 
-```ts twoslash {7-12}
+```ts
 import { createMachine } from 'xstate';
 
 const pushTheButtonGame = createMachine({
   initial: 'waitingForButtonPush',
   states: {
     waitingForButtonPush: {
+      // highlight-start
       after: {
         5000: {
           target: 'timedOut',
           actions: 'logThatYouGotTimedOut',
         },
       },
+      // highlight-end
       on: {
         PUSH_BUTTON: {
           actions: 'logSuccess',
@@ -42,18 +44,19 @@ One useful feature of the `after` declaration is that you don’t need to cancel
 
 You can also specify multiple delayed events on the same `after` declaration:
 
-```ts twoslash {6-8}
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const pushTheButtonGame = createMachine({
   initial: 'waitingForButtonPush',
   states: {
     waitingForButtonPush: {
       after: {
+        // highlight-start
         4000: {
           actions: 'warnThatYouAreAboutToLose',
         },
+        // highlight-end
         5000: {
           target: 'timedOut',
           actions: 'logThatYouGotTimedOut',
@@ -84,7 +87,7 @@ Dynamic delays can either pass in a number or pass a function that returns the d
 
 In the example below, `YELLOW_DELAY` passes a number, and `GREEN_DELAY` passes a function.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const lightDelayMachine = createMachine(

--- a/docs/xstate/transitions-and-choices/always.mdx
+++ b/docs/xstate/transitions-and-choices/always.mdx
@@ -12,10 +12,8 @@ Eventless transitions are transitions without events. These transitions are **al
 
 A simple example is a state that always transitions from `a` to `b`:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
-
-// ---cut---
 
 const machine = createMachine({
   initial: 'a',
@@ -38,23 +36,22 @@ Using the `always` transition means that `a` will _instantly_ transition to `b` 
 
 You can also pair `always` transitions with a guard:
 
-```ts twoslash {7-12}
-// @noErrors
+```ts
 import { createMachine } from 'xstate';
-
-// ---cut---
 
 const machine = createMachine(
   {
     initial: 'a',
     states: {
       a: {
+        // highlight-start
         always: [
           {
             cond: 'shouldTransition',
             target: 'b',
           },
         ],
+        // highlight-end
       },
       b: {},
     },
@@ -77,8 +74,7 @@ In the example above, the transition will only happen when `shouldTransition` re
 
 Example without `always`:
 
-```ts twoslash {11-14}
-// @noErrors
+```ts
 
 import { createMachine, assign } from 'xstate';
 
@@ -89,9 +85,11 @@ const gameMachine = createMachine(
       points: 0,
     },
     states: {
+      // highlight-start
       playing: {
         on: {
           AWARD_POINTS: [
+          // highlight-end
             {
               cond: 'didPlayerWin',
               actions: 'awardPoints',
@@ -150,8 +148,7 @@ const gameMachine = createMachine(
 
 Example with `always`:
 
-```ts twoslash {11-14}
-// @noErrors
+```ts
 
 import { createMachine, assign } from 'xstate';
 
@@ -162,11 +159,13 @@ const gameMachine = createMachine(
       points: 0,
     },
     states: {
+      // highlight-start
       playing: {
         always: [
           { target: 'win', cond: 'didPlayerWin' },
           { target: 'lose', cond: 'didPlayerLose' },
         ],
+      // highlight-end
         on: {
           AWARD_POINTS: {
             actions: 'awardPoints',
@@ -207,7 +206,7 @@ Since unguarded “always” transitions always run, you should be careful not t
 
 Let’s revisit our initial example and add a transition back to `a` from `b`. Here we add it using an “always” transition, which is not good. This machine will run forever and just keep transitioning between the two states.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 /* 🚨 Don't do this at home 🚨 */

--- a/docs/xstate/transitions-and-choices/guarded-actions.mdx
+++ b/docs/xstate/transitions-and-choices/guarded-actions.mdx
@@ -8,7 +8,7 @@ title: Guarded actions
 
 You can use actions and guards together to run actions conditionally on transitions.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const atmMachine = createMachine(
@@ -47,10 +47,8 @@ In the example above, when the user withdraws ten dollars via `WITHDRAW_TEN_DOLL
 
 We can add an else condition to `WITHDRAW_TEN_DOLLARS` too:
 
-```ts twoslash {11-19}
+```ts
 import { createMachine } from 'xstate';
-
-// ---cut---
 
 const atmMachine = createMachine(
   {
@@ -61,6 +59,7 @@ const atmMachine = createMachine(
     states: {
       showingBalance: {
         on: {
+          // highlight-start
           WITHDRAW_TEN_DOLLARS: [
             {
               cond: 'hasAtLeastTenDollars',
@@ -70,6 +69,7 @@ const atmMachine = createMachine(
               actions: 'sayThereIsNotEnoughInTheAccount',
             },
           ],
+          // highlight-end
         },
       },
     },
@@ -106,7 +106,7 @@ The `choose()` built-in action is an alternative API for guarded actions. `choos
 
 The `choose()` approach helps you be more flexible with where you run actions. For example, you can run actions inside an entry action:
 
-```ts twoslash
+```ts
 import { actions, createMachine } from 'xstate';
 
 const logMachine = createMachine(
@@ -141,10 +141,8 @@ const logMachine = createMachine(
 
 Like all built-in actions, you must apply the result of `choose()` directly to an `actions` attribute. The following example will not work:
 
-```ts twoslash
+```ts
 import { actions, createMachine } from 'xstate';
-
-// ---cut---
 const logMachine = createMachine({
   entry: () => {
     // 🚫 The following action just returns an object,

--- a/docs/xstate/transitions-and-choices/guards.mdx
+++ b/docs/xstate/transitions-and-choices/guards.mdx
@@ -12,7 +12,7 @@ A common pattern in any program is if/else logic — the ability to make decisio
 
 In the following example, we’ll imagine you want to order a decaf coffee at a cafe. You can send the `ORDER_DECAF` event to the barista, but the cafe might not have decaf coffee available! The machine for the ordering process could be as follows:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const baristaMachine = createMachine(
@@ -54,10 +54,9 @@ The machine above will only go to the `makingDecafCoffee` state if the `hasDecaf
 
 You can also provide multiple guards to the same transition. In the example below, the machine checks if the customer is okay with regular coffee if decaf is unavailable:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const baristaMachine = createMachine(
   {
     initial: 'receivingOrder',
@@ -91,13 +90,12 @@ const baristaMachine = createMachine(
 
 The code above is similar to a normal JavaScript function:
 
-```ts twoslash
+```ts
 const makeDecafCoffee = () => {};
 const makeRegularCoffee = () => {};
 const hasDecaf = false;
 const customerIsOKWithRegularCoffee = false;
 
-// ---cut---
 
 if (hasDecaf) {
   makeDecafCoffee();
@@ -108,10 +106,9 @@ if (hasDecaf) {
 
 To add an `else` condition, you can create a transition without a `cond` at the end of the array:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const baristaMachine = createMachine(
   {
     initial: 'receivingOrder',

--- a/docs/xstate/transitions-and-choices/internal-external.mdx
+++ b/docs/xstate/transitions-and-choices/internal-external.mdx
@@ -10,7 +10,7 @@ Transitions in statecharts can be one of two types: **internal** or **external**
 
 In the example below, `a -> FOO -> b` is an external transition.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 createMachine({
@@ -30,7 +30,7 @@ The transition leaves the `a` state and goes to the `b` state, making it an exte
 
 Internal transitions do not leave the current state. For example, self-transitions are internal transitions:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 createMachine(
@@ -60,7 +60,7 @@ The `FOO` transition never leaves the `a` state, which makes it an internal tran
 
 However, you can _force_ an internal transition to become an external transition. For self-transitions, you can specify the target on the transition to force it to be an external transition:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 createMachine(

--- a/docs/xstate/transitions-and-choices/transition-descriptions.mdx
+++ b/docs/xstate/transitions-and-choices/transition-descriptions.mdx
@@ -10,7 +10,7 @@ You can add descriptions to transitions to illustrate what they do.
 
 This text is used by the [Visualizer](../../tools/visualizer.mdx) and the [Stately Studio editor](../../#studio-editor) to make the diagrams more descriptive.
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({

--- a/docs/xstate/typescript/troubleshooting.mdx
+++ b/docs/xstate/typescript/troubleshooting.mdx
@@ -12,8 +12,7 @@ Here are some known issues, all of which have workarounds:
 
 When you use `createMachine`, you can pass in implementations to named actions, actors and guards in your config. For example:
 
-```ts twoslash
-// @errors: 2339
+```ts
 import { createMachine } from 'xstate';
 
 interface Context {}
@@ -49,7 +48,7 @@ createMachine(
 
 The example above errors because inside the `consoleLogData` function, XState doesn’t know which event caused it to fire. The cleanest way to manage this issue is to assert the event type yourself:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
 interface Context {}
@@ -72,14 +71,12 @@ const config = {
   },
 };
 
-// ---cut---
 
 createMachine(config, {
   actions: {
     consoleLogData: (context, event) => {
       if (event.type !== 'EVENT_WITH_FLAG') return;
       console.log(event.flag);
-      //                ^?
     },
   },
 });
@@ -89,8 +86,7 @@ Sometimes it’s also possible to move the implementation inline.
 
 <!-- TODO - remove the noErrors tag below when https://github.com/statelyai/xstate/pull/3217 is fixed-->
 
-```ts twoslash
-// @noErrors
+```ts
 import { createMachine } from 'xstate';
 interface Context {}
 
@@ -100,7 +96,6 @@ type Event =
       type: 'EVENT_WITHOUT_FLAG';
     };
 
-// ---cut---
 
 createMachine({
   schema: {
@@ -111,7 +106,7 @@ createMachine({
     EVENT_WITH_FLAG: {
       actions: (context, event) => {
         console.log(event.flag);
-        //                ^?
+
       },
     },
   },
@@ -124,8 +119,7 @@ Moving the implementation inline doesn’t work for all cases. The action loses 
 
 Event types in inline entry actions are not currently typed to the event that led to them. Consider the following example:
 
-```ts twoslash
-// @errors: 2339
+```ts
 import { createMachine } from 'xstate';
 
 interface Context {}
@@ -163,7 +157,7 @@ createMachine({
 
 In the example above, XState doesn’t know which event led to the `entry` action on `state2`. The only fix similar to the fix for events in machine options above:
 
-```ts twoslash {19-20}
+```ts
 import { createMachine } from 'xstate';
 
 interface Context {}
@@ -174,7 +168,6 @@ type Event =
       type: 'EVENT_WITHOUT_FLAG';
     };
 
-// ---cut---
 
 createMachine({
   schema: {
@@ -193,9 +186,10 @@ createMachine({
     state2: {
       entry: [
         (context, event) => {
+          // highlight-start
           if (event.type !== 'EVENT_WITH_FLAG') return;
           console.log(event.flag);
-          //                ^?
+          // highlight-end
         },
       ],
     },
@@ -209,9 +203,8 @@ createMachine({
 
 When run in `strict: true` mode, assign actions can sometimes behave strangely.
 
-```ts twoslash
+```ts
 import { createMachine, assign } from 'xstate';
-// ---cut---
 
 interface Context {
   something: boolean;
@@ -226,7 +219,6 @@ createMachine({
     assign({
       skip: true,
       something: (context) => context.something,
-      //                               ^?
     }),
   ],
 });
@@ -234,15 +226,13 @@ createMachine({
 
 In this case, it may appear that nothing you try works and all syntaxes seem buggy. The fix is strange but works consistently: add an unused `context` argument to the first argument of your assigner function.
 
-```ts twoslash
-// @noErrors
+```ts
 import { createMachine, assign } from 'xstate';
 
 interface Context {
   something: boolean;
   skip: boolean;
 }
-// ---cut---
 
 createMachine({
   schema: {
@@ -252,7 +242,6 @@ createMachine({
     assign({
       skip: (context) => true,
       something: (context) => context.something,
-      //                               ^?
     }),
   ],
 });

--- a/docs/xstate/typescript/type-helpers.mdx
+++ b/docs/xstate/typescript/type-helpers.mdx
@@ -12,7 +12,7 @@ XState makes several type helpers available to you for composing types in TypeSc
 
 `StateFrom` can be used to extract the `State` from a machine.
 
-```ts twoslash
+```ts
 import { createMachine, StateFrom } from 'xstate';
 
 const machine = createMachine({
@@ -25,7 +25,6 @@ const machine = createMachine({
 
 const myFunction = (state: StateFrom<typeof machine>) => {
   const context = state.context;
-  //    ^?
 };
 ```
 
@@ -33,7 +32,7 @@ const myFunction = (state: StateFrom<typeof machine>) => {
 
 `ContextFrom` can be used to extract the `context` from a machine.
 
-```ts twoslash
+```ts
 import { createMachine, ContextFrom } from 'xstate';
 
 const machine = createMachine({
@@ -46,7 +45,6 @@ const machine = createMachine({
 
 const myFunction = (context: ContextFrom<typeof machine>) => {
   console.log(context);
-  //          ^?
 };
 ```
 
@@ -54,7 +52,7 @@ const myFunction = (context: ContextFrom<typeof machine>) => {
 
 `EventFrom` can be used to extract the `event` types from a machine
 
-```ts twoslash
+```ts
 import { createMachine, EventFrom } from 'xstate';
 
 const machine = createMachine({
@@ -72,13 +70,12 @@ const machine = createMachine({
 
 const myFunction = (event: EventFrom<typeof machine>) => {
   console.log(event);
-  //          ^?
 };
 ```
 
 You can also extract _specific_ events by passing the type to the second generic slot.
 
-```ts twoslash
+```ts
 import { createMachine, EventFrom } from 'xstate';
 
 const machine = createMachine({
@@ -94,10 +91,8 @@ const machine = createMachine({
   },
 });
 
-// ---cut---
 const myFunction = (event: EventFrom<typeof machine, 'BAR'>) => {
   console.log(event);
-  //          ^?
 };
 ```
 
@@ -105,7 +100,7 @@ const myFunction = (event: EventFrom<typeof machine, 'BAR'>) => {
 
 `InterpreterFrom` gives you the type of the actor returned from `interpret` or `useInterpret`.
 
-```ts twoslash
+```ts
 import { createMachine, InterpreterFrom } from 'xstate';
 
 const machine = createMachine({
@@ -118,7 +113,6 @@ const machine = createMachine({
 
 const myFunction = (actor: InterpreterFrom<typeof machine>) => {
   const context = actor.state.context;
-  //    ^?
 };
 ```
 
@@ -126,7 +120,7 @@ const myFunction = (actor: InterpreterFrom<typeof machine>) => {
 
 `ActorRefFrom` is especially useful when [spawning actors](../actors/spawn.mdx) because it types the reference created by `spawn` when assigning to context.
 
-```ts twoslash
+```ts
 import { createMachine, ActorRefFrom, spawn, assign } from 'xstate';
 
 const childMachine = createMachine({});
@@ -151,8 +145,7 @@ const machine = createMachine({
 
 You can use `MachineOptionsFrom` in combination with [typegen](../typescript/typegen.mdx) to get a strongly typed version of the machine’s options.
 
-```ts twoslash
-// @filename: myMachine.typegen.ts
+```ts
 export interface Typegen0 {
   '@@xstate/typegen': true;
   eventsCausingActions: {
@@ -175,8 +168,6 @@ export interface Typegen0 {
   tags: never;
 }
 
-// @filename: myMachine.ts
-// ---cut---
 import { createMachine, MachineOptionsFrom } from 'xstate';
 
 const machine = createMachine({
@@ -192,7 +183,7 @@ const machine = createMachine({
 const options: MachineOptionsFrom<typeof machine> = {
   actions: {
     sayHello: (context) => {
-      //          ^?
+  
     },
   },
 };
@@ -200,8 +191,7 @@ const options: MachineOptionsFrom<typeof machine> = {
 
 You can also pass `true` to the second element of the generic to ensure that all missing implementations are passed. In the example below, `sayGoodbye` is missing, so **must** be passed when you pass `true` to `MachineOptionsFrom`.
 
-```ts twoslash
-// @filename: myMachine.typegen.ts
+```ts
 export interface Typegen0 {
   '@@xstate/typegen': true;
   eventsCausingActions: {
@@ -224,8 +214,6 @@ export interface Typegen0 {
   tags: never;
 }
 
-// @filename: myMachine.ts
-// ---cut---
 import { createMachine, MachineOptionsFrom } from 'xstate';
 
 const machine = createMachine(

--- a/docs/xstate/typescript/typegen.mdx
+++ b/docs/xstate/typescript/typegen.mdx
@@ -27,14 +27,16 @@ Install the [CLI](../../tools/developer-tools#xstate-cli-command-line-interface)
 
 Next try to create a machine, make sure to set the `schema` attributes:
 
-```ts twoslash {4-7}
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
+  // highlight-start
   schema: {
     context: {} as { value: string },
     events: {} as { type: 'FOO'; value: string } | { type: 'BAR' },
   },
+  // highlight-end
   initial: 'a',
   states: {
     a: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -201,6 +201,10 @@ const config = {
         disableSwitch: false,
         respectPrefersColorScheme: true,
       },
+      prism: {
+        theme: require('prism-react-renderer/themes/dracula'),
+        darkTheme: require('prism-react-renderer/themes/dracula'),
+      },
     }),
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,13 +87,6 @@ const config = {
         },
       }),
     ],
-    [
-      'docusaurus-preset-shiki-twoslash',
-      {
-        alwayRaiseForTwoslashExceptions: true,
-        themes: ['github-light', 'github-dark'],
-      },
-    ],
   ],
 
   themeConfig:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@xstate/machine-extractor": "^0.7.1",
     "@xstate/react": "^3.0.1",
     "clsx": "^1.2.1",
-    "docusaurus-preset-shiki-twoslash": "^1.1.38",
     "prism-react-renderer": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -543,7 +543,7 @@ html[data-theme='dark'], html[data-theme='dark'] body {
 
 /* Shiki Twoslash code examples */
 
-[data-theme='light'] .shiki.github-dark {
+/* [data-theme='light'] .shiki.github-dark {
   display: none;
 }
 
@@ -568,7 +568,7 @@ html pre.shiki div.highlight {
 html pre.shiki .copy-button {
   background: var(--st-copy-button-background);
   color: var(--st-copy-button-text);
-}
+} */
 
 /* Specific font-variation-settings for web font support */
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -177,6 +177,7 @@ html, body {
   --ifm-color-secondary-dark:var(--st-text);
   --ifm-color-secondary-darker:var(--st-text);
   --ifm-color-secondary-darkest:var(--st-text);
+  --docusaurus-details-decoration-color: var(--st-text);
   --ifm-color-secondary-light:white;
   --ifm-color-secondary-lighter:white;
   --ifm-color-secondary-lightest:white;
@@ -1149,12 +1150,34 @@ footer [class*=iconExternalLink] {
   padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
 }
 
+details.alert {
+  display: block;
+}
+
+details > div > div {
+  padding: calc(var(--ifm-alert-padding-vertical)*2) var(--ifm-alert-padding-horizontal) var(--ifm-alert-padding-vertical);
+}
+
+details summary::before {
+  --docusaurus-details-decoration-color: var(--st-text);
+  top: 0.35rem !important;
+}
+
 @media (min-width: 1300px) {
-  .alert {
+  .alert:not(details) {
     --ifm-alert-padding-horizontal: 0.85rem;
     /* pull admonitions into margins so text aligns with paragraph text */
     margin-left: calc(-1 * var(--ifm-alert-padding-horizontal));
     margin-right: calc(-1 * var(--ifm-alert-padding-horizontal));
+  }
+}
+
+@media (min-width: 1300px) {
+  details {
+    --ifm-alert-padding-horizontal: 1rem;
+    /* pull admonitions into margins so text aligns with paragraph text */
+    margin-left: calc(-1 * var(--ifm-alert-padding-horizontal)) !important;
+    margin-right: calc(-1 * var(--ifm-alert-padding-horizontal)) !important;
   }
 }
 
@@ -1239,13 +1262,13 @@ footer [class*=iconExternalLink] {
   opacity: 0.75;
 }
 
-.alert h2, .alert h3, .alert h4, .alert h5, .alert h6 {
+.alert:not(details) h2, .alert:not(details) h3, .alert:not(details) h4, .alert:not(details) h5, .alert:not(details) h6 {
   color: inherit;
   font-size: 1.1rem;
   margin-bottom: calc(var(--ifm-alert-padding-vertical) * .5);
 }
 
-.alert a {
+.alert:not(details) a {
   color: inherit;
 }
 
@@ -1254,11 +1277,11 @@ footer [class*=iconExternalLink] {
   opacity: 1;
 }
 
-.alert a {
+.alert:not(details) a {
   text-decoration-color: var(--ifm-alert-foreground-color);
 }
 
-.alert a:hover {
+.alert:not(details) a:hover {
   text-decoration-thickness: 1px;
 }
 

--- a/versioned_docs/version-5/about.mdx
+++ b/versioned_docs/version-5/about.mdx
@@ -41,7 +41,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 <ul className="content-boxes">
   <li>
     <a className="link-box" href="./states">
-      🏁 <strong>Get started</strong> Jump straight into learning how to use the Stately Studio
+      🏁 <strong>Get started</strong> Jump straight into learning how to use Stately Studio
       editor, starting with states.
     </a>
   </li>

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -4,26 +4,14 @@ title: 'Actions'
 
 import ThemedImage from '@theme/ThemedImage';
 
-While the statechart is running, it can execute other effects called actions.
+While the state machine is running, it can execute other effects called actions.
 
 An action can be fired upon entry or exit of a state. Actions are “fire-and-forget effects”; once the machine has fired the action, it moves on and forgets the action. Actions are not awaited and don’t return anything to the state machine. You can also fire actions on transitions.
-
-You can fire multiple entry and exit actions on a state. Top-level final states cannot have exit actions, since the machine is stopped and no further transitions can occur.
 
 Examples of actions:
 
 - Logging a message
 - Sending a message to another [actor](actors.mdx)
-
-TODO: more examples
-
-## Editor: using actions
-
-:::tip
-
-Watch our [“Entry actions and exit actions” video on YouTube](https://www.youtube.com/watch?v=GYoYZ1Dt1sA&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=8) (1m32s).
-
-:::
 
 <p>
   <ThemedImage
@@ -38,9 +26,37 @@ Watch our [“Entry actions and exit actions” video on YouTube](https://www.yo
 
 [View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=222e2d7a-0ed6-4f2c-843a-e6646d717000).
 
-In our video player, we have entry and exit actions on the Playing state. We use the entry action of playVideo to fire an effect playing the video on entry to the Playing state. We use the exit action of pauseVideo to fire an effect pausing the video when the Playing state is exited.
+In our video player machine, we have entry and exit actions on the Playing state. We use the entry action of playVideo to fire an effect playing the video on entry to the Playing state. We use the exit action of pauseVideo to fire an effect pausing the video when the Playing state is exited.
 
-### Add an entry action to a state
+In XState, actions are represented on transitions in the `actions: ...` property. Anywhere you can use an action, you can also declare it as an array to express multiple actions.
+
+Actions can also be on a states’ `entry` or `exit`, also as a single action or an array.
+
+<!-- TODO: simple example -->
+
+## Entry and exit actions
+
+Entry actions are actions that occur on any transition that enters a state node.
+
+<!-- TODO: illustation -->
+
+Exit actions are actions that occur on any transition that exits a state node.
+
+<!-- TODO: illustration -->
+
+Entry and exit actions are defined using the `entry: ...` and `exit: ...` attributes on a state node. You can fire multiple entry and exit actions on a state. Top-level final states cannot have exit actions, since the machine is stopped and no further transitions can occur.
+
+<!-- TODO: example -->
+
+### In the Studio
+
+:::tip
+
+Watch our [“Entry actions and exit actions” video on YouTube](https://www.youtube.com/watch?v=GYoYZ1Dt1sA&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=8) (1m32s).
+
+:::
+
+#### Add an entry action to a state
 
 1. Select the state you want to have an entry action.
 2. Open the **State details** panel from the right tool menu.
@@ -49,7 +65,7 @@ In our video player, we have entry and exit actions on the Playing state. We use
 5. Use the **Assign** tab under **Entry actions** to assign **key** and **assignment** pairs to the entry action.
 6. Save the entry action using the **Save** button.
 
-### Add an exit action to a state
+#### Add an exit action to a state
 
 1. Select the state you want to have an exit action.
 2. Open the **State details** panel from the right tool menu.
@@ -58,26 +74,35 @@ In our video player, we have entry and exit actions on the Playing state. We use
 5. Use the **Assign** tab under **Exit actions** to assign **key** and **assignment** pairs to the exit action.
 6. Save the entry action using the **Save** button.
 
-## Actions in XState
-
-Actions are represented on transitions in `actions: ...` property, and can be a single action or an array.
-
-They can also be on states `entry` or `exit`, also as single or array.
-
-TODO: simple example
-
-## Action order
-
-- Exit actions
-- Transition actions
-- Entry actions
-- Actions are executed in-order
-
 ## Inline actions
 
-Useful for prototyping and simple cases. It's recommended to serialize them instead.
+In XState we usually pass options into the config using serialized (also known as *named*) actions:
 
-TODO: `{ actions: () => { ... } }
+```ts twoslash
+import { createMachine } from 'xstate';
+
+// ---cut---
+const machine = createMachine({
+  entry: ['sayHello'],
+});
+```
+
+You can also declare actions inline:
+
+```ts twoslash
+import { createMachine } from 'xstate';
+
+// ---cut---
+const machine = createMachine({
+  entry: [
+    () => {
+      console.log('Hello!');
+    },
+  ],
+});
+```
+
+Inline actions are useful for prototyping and simple cases but we generally recommended using serialized actions.
 
 ## Action objects
 
@@ -85,7 +110,7 @@ They have a `type` and optional `params`.
 
 TODO: parameterized action
 
-## Implementing actions
+### Implementing actions
 
 Actions are implemented with `.provide(...)`
 
@@ -95,21 +120,7 @@ TODO: `.provide({ actions })`
 
 From there, you can read `{ action }` object, which has `type` and `params`
 
-## Entry and exit actions
-
-Entry actions = actions that occur on any transition that enters a state node
-
-TODO: illustation
-
-Exit actions = actions that occur on any transition that exits a state node
-
-TODO: illustration
-
-Entry and exit actions are defined on `entry: ...` and `exit: ...` of state node.
-
-TODO: example
-
-## Assign action
+### Assign action
 
 Assign action is a special action that assigns data to the state context. Special action
 
@@ -128,7 +139,7 @@ TODO: example
 
 Raised events can be dynamic: `raise(({ context, event }) => ({ type: 'SOME_EVENT' }))`
 
-## Send-to action
+## `send-to` action
 
 The `sendTo(...)` action is a special action that sends an event to a specific actor.
 

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -24,7 +24,7 @@ Examples of actions:
   />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=222e2d7a-0ed6-4f2c-843a-e6646d717000).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=222e2d7a-0ed6-4f2c-843a-e6646d717000).
 
 In our video player machine, we have entry and exit actions on the Playing state. We use the entry action of playVideo to fire an effect playing the video on entry to the Playing state. We use the exit action of pauseVideo to fire an effect pausing the video when the Playing state is exited.
 

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -78,10 +78,9 @@ Watch our [“Entry actions and exit actions” video on YouTube](https://www.yo
 
 In XState we usually pass options into the config using serialized (also known as *named*) actions:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const machine = createMachine({
   entry: ['sayHello'],
 });
@@ -89,10 +88,9 @@ const machine = createMachine({
 
 You can also declare actions inline:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 
-// ---cut---
 const machine = createMachine({
   entry: [
     () => {

--- a/versioned_docs/version-5/actor-model.mdx
+++ b/versioned_docs/version-5/actor-model.mdx
@@ -2,14 +2,38 @@
 title: The actor model
 ---
 
-What is the actor model?
+In the actor model, actors are objects that can talk to each other. They are independent computational entities that communicate via asynchronous message passing. In XState, we refer to these messages as [**events**](transitions.mdx).
 
-The actor model is a model of computation that treats an **actor** as a unit of computation. Practically, you can think of an actor as an object that can "talk to" other objects, by sending messages (referred to as "events" in XState) to them.
+TODO: What are some good examples of actors in software development?
 
-## The actor model in backend development
+## State
 
-## The actor model in frontend development
+An actor has its own internal, encapsulated state that the actor itself can only update. An actor may update its internal state in response to a message it receives, but it cannot be updated by any other entity. Actors do not share state. The only way for an actor to share data is by sending events.
 
-## The actor model in XState
+[Read more about actors and state](actors.mdx).
 
-## Resources
+## Communication with events
+
+Actors communicate with other actors by sending and receiving events asynchronously. Actors use an internal “mailbox” that acts like an event queue, processing events one at a time.
+
+[Read more about actors and events](actors.mdx).
+
+## Spawning
+
+Actors can spawn new actors. Actors will spawn new actors in situations where they need to delegate work to another actor or when they need to create a new actor to handle a new task. Spawning allows for a flexible and dynamic system where actors can be created and destroyed as needed to handle the workload efficiently.
+
+[Read more about spawning actors](spawn.mdx).
+
+## Backend development
+
+TODO: How do you use the actor model in backend dev? (Summary, maybe example)
+
+## Frontend development
+
+TODO: How do you use the actor model in frontend dev? (Summary, maybe example)
+
+## XState
+
+TODO: How does the actor model work in XState? (Summary, link to further text)
+
+## Further resources

--- a/versioned_docs/version-5/actor-model.mdx
+++ b/versioned_docs/version-5/actor-model.mdx
@@ -2,7 +2,7 @@
 title: The actor model
 ---
 
-In the actor model, actors are objects that can talk to each other. They are independent computational entities that communicate via asynchronous message passing. In XState, we refer to these messages as [**events**](transitions.mdx).
+When you run a state machine, it becomes an actor. In the actor model, actors are objects that can talk to each other via asynchronous messages. In XState, we refer to these messages as [**events**](transitions.mdx).
 
 TODO: What are some good examples of actors in software development?
 

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -30,7 +30,7 @@ You can invoke multiple actors on a single state. Top-level final states cannot 
 />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=66f77051-089e-4b0a-9fa9-42e1f7598135).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=66f77051-089e-4b0a-9fa9-42e1f7598135).
 
 In the video player above, the *startVideo* actor is invoked when the video player is in the *Opened* state.
 

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -4,7 +4,7 @@ title: 'Actors'
 
 import ThemedImage from '@theme/ThemedImage';
 
-When you run a statechart, it becomes an actor: a running process that can receive messages, send messages and change its behavior based on the messages it receives, which can cause effects outside of the actor.
+When you run a state machine, it becomes an actor: a running process that can receive messages, send messages and change its behavior based on the messages it receives, which can cause effects outside of the actor.
 
 An invoked actor is an actor that can execute its own actions and communicate with the machine. These invoked actors are started in a state and stopped when the state is exited.
 

--- a/versioned_docs/version-5/context.mdx
+++ b/versioned_docs/version-5/context.mdx
@@ -4,7 +4,9 @@ title: 'Context'
 
 In XState, `context` is how you store data in a state machine actor.
 
-It is a special property that is available in all states and is used to store data that is relevant to the state machine. The `context` object is immutable, so you cannot directly modify it. Instead, you use the `assign(...)` action to update `context`.
+`context` is a special property available in all states and used to store data relevant to the state machine. The `context` object is immutable, so you cannot directly modify it. Instead, use the `assign(...)` action to update `context`.
+
+The `context` property is _optional_; if the state machine only specifies [finite states](finite-states.mdx), it may not need `context`.
 
 ```ts
 import { createMachine } from 'xstate';
@@ -26,19 +28,20 @@ feedbackActor.start();
 // logs 'Some feedback'
 ```
 
-<!-- TODO: add link below -->
+<details>
+<summary>
+Using context in Stately Studio
+</summary>
 
-The `context` property is _optional_; if the state machine only specifies [finite states](#), then it may not need `context`.
+- TODO: Setting initial values
+- TODO: Updating context with assign
+- TODO: JS/TS export
 
-## Stately Studio’s editor: context
-
-- Setting initial values
-- Updating context with assign
-- JS/TS export
+</details>
 
 ## Initial context
 
-The initial context of a machine is set in the `context` property of the machine config.
+Set the initial context of a machine in the `context` property of the machine config:
 
 ```ts
 import { createMachine } from 'xstate';
@@ -52,11 +55,11 @@ const feedbackMachine = createMachine({
 });
 ```
 
-The object that you pass to `context` will be the initial `context` value for any actor that is created from this machine.
+The object you pass to `context` will be the initial `context` value for any actor created from this machine.
 
 :::warningxstate
 
-It is important that you do not mutate the `context` object. Instead, you should use the `assign(...)` action to update `context` immutably. If you mutate the `context` object, you may get unexpected behavior, such as mutating the `context` of other actors.
+Do not mutate the `context` object. Instead, you should use the `assign(...)` action to update `context` immutably. If you mutate the `context` object, you may get unexpected behavior, such as mutating the `context` of other actors.
 
 :::
 
@@ -82,7 +85,7 @@ Lazy initial context is evaluated per actor, so each actor will have its own `co
 
 ### Input
 
-You can provide input data to a machine's initial `context` by passing an `input` property to the `interpret(machine, { input })` function and using the `input` property from the first argument in the `context` function:
+You can provide input data to a machine’s initial `context` by passing an `input` property to the `interpret(machine, { input })` function and using the `input` property from the first argument in the `context` function:
 
 ```ts
 const feedbackMachine = createMachine({
@@ -102,13 +105,11 @@ console.log(feedbackActor.getSnapshot().context.rating);
 // logs 5
 ```
 
-<!-- TODO: add link below -->
-
-Learn more about [input](#).
+Learn more about [input](input.mdx).
 
 ## Updating context with `assign(...)`
 
-Context is updated by using the `assign(...)` action in a transition:
+Use the `assign(...)` action in a transition to update context:
 
 ```ts
 import { createMachine, assign } from 'xstate';
@@ -146,6 +147,8 @@ feedbackActor.send({
 
 ## TypeScript
 
+TODO: explain this example
+
 ```ts
 const machine = createMachine({
   schema: {} as {
@@ -161,9 +164,11 @@ const machine = createMachine({
 });
 ```
 
-## Cheatsheet
+## Context cheatsheet
 
-**Initial context**
+Use our XState context cheatsheet below to get started quickly.
+
+### Initial context
 
 ```ts
 const machine = createMachine({
@@ -173,7 +178,7 @@ const machine = createMachine({
 });
 ```
 
-**Lazy initial context**
+### Lazy initial context
 
 ```ts
 const machine = createMachine({
@@ -184,7 +189,7 @@ const machine = createMachine({
 });
 ```
 
-**Updating context with `assign(...)`**
+### Updating context with `assign(...)`
 
 ```ts
 const machine = createMachine({
@@ -201,7 +206,7 @@ const machine = createMachine({
 });
 ```
 
-**Input**
+### Input
 
 ```ts
 const machine = createMachine({
@@ -218,4 +223,4 @@ const feedbackActor = interpret(machine, {
 });
 ```
 
-## Resources
+## Further resources

--- a/versioned_docs/version-5/context.mdx
+++ b/versioned_docs/version-5/context.mdx
@@ -2,7 +2,7 @@
 title: 'Context'
 ---
 
-In XState, `context` is how you store data in a state machine actor.
+In XState, `context` is how you store data in a state machine [actor](actors.mdx).
 
 `context` is a special property available in all states and used to store data relevant to the state machine. The `context` object is immutable, so you cannot directly modify it. Instead, use the `assign(...)` action to update `context`.
 

--- a/versioned_docs/version-5/delayed-transitions.mdx
+++ b/versioned_docs/version-5/delayed-transitions.mdx
@@ -25,7 +25,7 @@ Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtu
 />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=5671366b-05cf-43f5-a09a-b88373ea27c1).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=5671366b-05cf-43f5-a09a-b88373ea27c1).
 
 In a video player, we might want the video to be *Closed* out of fullscreen mode a few seconds after the video has *Stopped*, instead of closing the fullscreen mode suddenly as soon as the video is stopped. The eventless transition above transitions from the *Stopped* state to the *Closed* state after 5 seconds.
 

--- a/versioned_docs/version-5/descriptions.mdx
+++ b/versioned_docs/version-5/descriptions.mdx
@@ -24,7 +24,7 @@ Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/wa
 />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a).
 
 In the video player above, the text “The video player should be in full-screen mode” is a description of the *Opened* event.
 

--- a/versioned_docs/version-5/discover.mdx
+++ b/versioned_docs/version-5/discover.mdx
@@ -5,7 +5,7 @@ title: Discover
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Are you seeking inspiration for your machine? Or do you want to learn how somebody else models their machines? The [Discover page](https://stately.ai/registry/discover) lists all the public machines created with the Stately Studio.
+Are you seeking inspiration for your machine? Or do you want to learn how somebody else models their machines? The [Discover page](https://stately.ai/registry/discover) lists all the public machines created with Stately Studio.
 
 <p>
 <ThemedImage
@@ -36,7 +36,7 @@ Read [more about exporting your machines as code](export-as-code.mdx).
 
 :::tip
 
-You must be signed into the Stately Studio to fork a machine.
+You must be signed into Stately Studio to fork a machine.
 
 :::
 

--- a/versioned_docs/version-5/examples.mdx
+++ b/versioned_docs/version-5/examples.mdx
@@ -2,6 +2,6 @@
 title: 'Request examples'
 ---
 
-**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our Canny request board](https://statelyai.canny.io/examples) or upvote an existing suggestion. 
+**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion. 
 
 If you have an example you want to share, [let us know on our Stately Discord](https://discord.gg/xstate).

--- a/versioned_docs/version-5/final-states.mdx
+++ b/versioned_docs/version-5/final-states.mdx
@@ -29,7 +29,7 @@ Watch our [“What are final states?” video on YouTube](https://www.youtube.co
   />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=c6f8ca35-25e3-4fc6-b4fe-c9994715852e).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=c6f8ca35-25e3-4fc6-b4fe-c9994715852e).
 
 ### Make a state a final state
 

--- a/versioned_docs/version-5/finite-states.mdx
+++ b/versioned_docs/version-5/finite-states.mdx
@@ -145,8 +145,6 @@ console.log(feedbackActor.getSnapshot().value);
 // logs 'thanks'
 ```
 
-TODO: add link below
-
 Read more about [events and transitions](transitions.mdx).
 
 ## Targets

--- a/versioned_docs/version-5/glossary.mdx
+++ b/versioned_docs/version-5/glossary.mdx
@@ -16,7 +16,7 @@ An [action](actions.mdx) can be fired upon entry or exit of a state. Actions are
 
 ## Actors
 
-When you run a statechart, it becomes an [actor](actors.mdx); a running process that can receive messages, send messages and change its behavior based on the messages it receives, which can cause effects outside of the actor.
+When you run a state machine, it becomes an [actor](actors.mdx); a running process that can receive messages, send messages and change its behavior based on the messages it receives, which can cause effects outside of the actor.
 
 ## After transitions
 
@@ -76,7 +76,7 @@ A [state](states.mdx) describes the status of the machine. A state can be as sim
 
 ## State machines
 
-A [state machine](state-machines-and-statecharts.mdx) is a model that describes how the state of a process transitions to another state when an event occurs. State machines make building reliable software easier because they prevent impossible states and undesired transitions.
+A [state machine](state-machines-and-statecharts.mdx) is a model that describes how the state of a process transitions to another state when an event occurs. State machines make building reliable software easier because they prevent impossible states and undesired transitions. When you run a state machine, it becomes an [actor](actors.mdx).
 
 ## Transitions and events
 

--- a/versioned_docs/version-5/guards.mdx
+++ b/versioned_docs/version-5/guards.mdx
@@ -21,7 +21,7 @@ A **guard** is a condition that the machine checks when it goes through an eve
 
 :::studio
 
-In the Stately Studio, guards are numbered in the order they are checked and labeled with “if” or “else if” along with their condition. Multiple guards on the same events are connected with a dotted line.
+In Stately Studio, guards are numbered in the order they are checked and labeled with “if” or “else if” along with their condition. Multiple guards on the same events are connected with a dotted line.
 
 :::
 

--- a/versioned_docs/version-5/import-from-code.mdx
+++ b/versioned_docs/version-5/import-from-code.mdx
@@ -2,7 +2,7 @@
 title: Import from code
 ---
 
-Importing from code is helpful if you’ve already built machines while working with [XState](xstate.mdx), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried the Stately Studio editor.
+Importing from code is helpful if you’ve already built machines while working with [XState](xstate.mdx), or have created a machine using our older [Stately Viz](https://stately.ai/viz) but haven’t yet tried Stately Studio’s editor.
 
 :::tip
 

--- a/versioned_docs/version-5/initial-states.mdx
+++ b/versioned_docs/version-5/initial-states.mdx
@@ -24,11 +24,11 @@ Watch our [“What are initial states?” video on YouTube](https://www.youtube.
 />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=3ebc8874-2294-480b-a06e-74845337cd8d).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=3ebc8874-2294-480b-a06e-74845337cd8d).
 
 :::studio
 
-In the Stately Studio, the filled circle with an arrow icon represents the initial state.
+In Stately Studio, the filled circle with an arrow icon represents the initial state.
 
 :::
 

--- a/versioned_docs/version-5/input.mdx
+++ b/versioned_docs/version-5/input.mdx
@@ -2,7 +2,7 @@
 title: 'Input'
 ---
 
-Input refers to the data provided to a state machine that influences its behavior. In XState, input is provided when creating an actor via the 2nd argument of the `interpret(machine, { input })` function:
+Input refers to the data provided to a state machine that influences its behavior. In [XState](xstate.mdx), you provide input when creating an [actor](actors.mdx) using the second argument of the `interpret(machine, { input })` function:
 
 ```ts
 import { interpret, createMachine } from 'xstate';
@@ -26,9 +26,11 @@ const feedbackActor = interpret(feedbackMachine, {
 });
 ```
 
-## Stately Studio’s editor: input
+:::studio
 
-_Coming soon_
+Input is coming to Stately Studio’s editor soon…
+
+:::
 
 ## Initial event input
 
@@ -57,7 +59,7 @@ const feedbackActor = interpret(feedbackMachine, {
 
 ## Invoking actors with input
 
-Input can be provided to invoked actors via the `input` property of the `invoke` configuration:
+You can provide input to invoked actors via the `input` property of the `invoke` configuration:
 
 ```ts
 import { interpret, createMachine } from 'xstate';
@@ -110,7 +112,7 @@ const feedbackMachine = createMachine({
 
 ## Spawning actors with input
 
-Input can be provided to spawned actors via the `input` property of the `spawn` configuration:
+You can provide input to spawned actors via the `input` property of the `spawn` configuration:
 
 ```ts
 import { interpret, createMachine } from 'xstate';
@@ -168,7 +170,9 @@ const machine = createMachine({
 
 ## Cheatsheet
 
-**Providing input**
+Use our XState input cheatsheet below to get started quickly.
+
+### Providing input
 
 ```ts
 const feedbackActor = interpret(feedbackMachine, {
@@ -179,7 +183,7 @@ const feedbackActor = interpret(feedbackMachine, {
 });
 ```
 
-**Providing input to invoked actors**
+### Providing input to invoked actors
 
 ```ts
 const feedbackMachine = createMachine({
@@ -192,7 +196,7 @@ const feedbackMachine = createMachine({
 });
 ```
 
-**Providing dynamic input to invoked actors**
+### Providing dynamic input to invoked actors
 
 ```ts
 const feedbackMachine = createMachine({
@@ -206,7 +210,7 @@ const feedbackMachine = createMachine({
 });
 ```
 
-**Providing input to spawned actors**
+### Providing input to spawned actors
 
 ```ts
 const feedbackMachine = createMachine({
@@ -229,4 +233,4 @@ const feedbackMachine = createMachine({
 });
 ```
 
-## Resources
+## Further resources

--- a/versioned_docs/version-5/inspector.mdx
+++ b/versioned_docs/version-5/inspector.mdx
@@ -24,7 +24,7 @@ npm install @xstate/inspect
 
 2. Import @xstate/inspect at the beginning of your project before any other code is called:
 
-```ts twoslash
+```ts
 import { inspect } from '@xstate/inspect';
 
 inspect({
@@ -36,11 +36,10 @@ inspect({
 
 3. Add `{ devTools: true }` to any interpreted machines you want to visualize:
 
-```ts twoslash
+```ts
 import { createMachine } from 'xstate';
 const someMachine = createMachine({});
 
-// ---cut---
 import { interpret } from 'xstate';
 import { inspect } from '@xstate/inspect';
 
@@ -98,7 +97,7 @@ Use the `url` property (string) to specify the URL of the inspector you want to 
 
 `inspect` returns a function, `disconnect`, you can use to disconnect the inspector.
 
-```ts twoslash
+```ts
 import { inspect } from '@xstate/inspect';
 
 const inspector = inspect();

--- a/versioned_docs/version-5/machines.mdx
+++ b/versioned_docs/version-5/machines.mdx
@@ -2,7 +2,7 @@
 title: 'State machines'
 ---
 
-A state machine is a model that describes how the state of an actor transitions to another state when an event occurs.
+A [state machine](state-machines-and-statecharts.mdx) is a model that describes how the state of an [actor](actors.mdx) transitions to another state when an event occurs.
 
 :::tip
 
@@ -12,9 +12,13 @@ Read our [introduction to state machines and statecharts](state-machines-and-sta
 
 ## Benefits of state machines
 
-State machines help build reliable software by making it easier to prevent impossible states and undesired transitions.
+State machines help build reliable and robust software:
 
-How are state machines useful?
+- Use state machines to implement complex state-based logic in a modular and efficient way.
+- You can easily extend and modify state machines as your system’s requirements change over time.
+- State machines provide a clear and concise representation of complex behavior, making it easier for you to reason about and understand code.
+- State machines help avoid errors and bugs in code by making it easier to prevent impossible states and undesired transitions.
+- You can use state machines to model the behavior of real-world systems, making it easier to test and debug software.
 
 ## Creating a state machine
 

--- a/versioned_docs/version-5/machines.mdx
+++ b/versioned_docs/version-5/machines.mdx
@@ -4,14 +4,21 @@ title: 'State machines'
 
 A state machine is a model that describes how the state of an actor transitions to another state when an event occurs.
 
-- Benefits of state machines
-  State machines help build reliable software by making it easier to prevent impossible states and undesired transitions.
+:::tip
 
-- How are state machines useful?
+Read our [introduction to state machines and statecharts](state-machines-and-statecharts.mdx) if you haven’t already!
+
+:::
+
+## Benefits of state machines
+
+State machines help build reliable software by making it easier to prevent impossible states and undesired transitions.
+
+How are state machines useful?
 
 ## Creating a state machine
 
-In XState, a state machine (referred to as a "machine") is created using the `createMachine(config)` function:
+In [XState](xstate.mdx), a state machine (referred to as a “machine”) is created using the `createMachine(config)` function:
 
 ```ts
 import { createMachine } from 'xstate';
@@ -37,7 +44,7 @@ const feedbackMachine = createMachine({
 
 ## Interpreting machines
 
-A machine is just a blueprint for an actor. An [actor](#todo) is a running instance of the machine; in other words, it is the entity whose logic is described by the machine.
+A machine is just a blueprint for an actor. An [actor](actors.mdx) is a running instance of the machine; in other words, it is the entity whose logic is described by the machine.
 
 To create an actor, interpret the machine using the `interpret(machine)` function:
 
@@ -56,14 +63,14 @@ feedbackActor.start();
 
 ## Providing implementations
 
-Machine implementations refer to the language-specific code that is executed that is not directly related to the state machine's logic. This includes:
+Machine implementations are the language-specific code that is executed but is not directly related to the state machine’s logic. This includes:
 
-- [Actions](#todo)
-- [Actors](#todo)
-- [Guards](#todo)
-- [Delays](#todo)
+- [Actions](actions.mdx)
+- [Actors](actors.mdx)
+- [Guards](guards.mdx)
+- [Delays](delayed-transitions.mdx)
 
-Typically, you will reference implementations using strings or objects, such as `{ type: 'doSomething' }`, and then create a new machine with the provided implementations via `machine.provide({...})`:
+Typically, you will reference implementations using strings or objects, such as `{ type: 'doSomething' }`, and then create a new machine with the provided implementations using `machine.provide({...})`:
 
 ```ts
 import { createMachine } from 'xstate';
@@ -111,7 +118,7 @@ const feedbackActor = interpret(
 
 ## Specifying types
 
-TypeScript types can be specified inside the machine config, in the `.types` property:
+You can specify TypeScript types inside the machine config using the `.types` property:
 
 ```ts
 const feedbackMachine = createMachine({
@@ -123,11 +130,11 @@ const feedbackMachine = createMachine({
 });
 ```
 
-These types will be inferred throughout the machine config, as well as in the created machine and actor, so that methods such as `machine.transition(...)` and `actor.send(...)` will be type-safe.
+These types will be inferred throughout the machine config and in the created machine and actor so that methods such as `machine.transition(...)` and `actor.send(...)` will be type-safe.
 
 ## Transition method
 
-A machine's `.transition(state, event)` method is a pure method that returns the next state given the current state and an event:
+A machine’s `.transition(state, event)` method is a pure method that returns the next state given the current state and an event:
 
 ```ts
 const feedbackMachine = createMachine({
@@ -158,13 +165,17 @@ The `machine.transition(...)` method is useful for testing or building a custom 
 
 ## API
 
-Link to API
+TODO: Link to API
 
 ## TypeScript
 
+TODO:
+
 ## Cheatsheet
 
-**Create a machine**
+Use our XState cheatsheet below to get started quickly. We recommend you save [the cheatsheet URL](machines.mdx#cheatsheet) to your bookmarks for future reference!
+
+### Create a machine
 
 ```ts
 import { createMachine } from 'xstate';
@@ -178,7 +189,7 @@ const machine = createMachine({
 });
 ```
 
-**Provide implementations**
+### Provide implementations
 
 ```ts
 import { createMachine } from 'xstate';
@@ -203,4 +214,6 @@ const machineWithImpls = machine.provide({
 });
 ```
 
-## Resources
+### Further resources
+
+TODO:

--- a/versioned_docs/version-5/machines.mdx
+++ b/versioned_docs/version-5/machines.mdx
@@ -171,9 +171,9 @@ TODO: Link to API
 
 TODO:
 
-## Cheatsheet
+## Machine cheatsheet
 
-Use our XState cheatsheet below to get started quickly. We recommend you save [the cheatsheet URL](machines.mdx#cheatsheet) to your bookmarks for future reference!
+Use our XState machine cheatsheet below to get started quickly.
 
 ### Create a machine
 

--- a/versioned_docs/version-5/parallel-states.mdx
+++ b/versioned_docs/version-5/parallel-states.mdx
@@ -29,7 +29,7 @@ Watch our [“What are parallel states?” video on YouTube](https://www.youtube
   />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=733de338-26cb-40a5-a0b5-b76bfc0405c3).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=733de338-26cb-40a5-a0b5-b76bfc0405c3).
 
 In the video player machine above, the video and audio states are active at the same time, which means the following combinations of states can happen simultaneously:
 

--- a/versioned_docs/version-5/parent-states.mdx
+++ b/versioned_docs/version-5/parent-states.mdx
@@ -24,7 +24,7 @@ Watch our [“Parent and child states” video on YouTube](https://www.youtube.c
 />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa).
 
 In the video player above, the *Opened* state is a parent state to the *Playing*, *Paused*, and *Stopped* states. These states, their transitions, and their events are nested inside the *Opened* state.
 

--- a/versioned_docs/version-5/projects.mdx
+++ b/versioned_docs/version-5/projects.mdx
@@ -17,13 +17,13 @@ A project is a collection of machines that helps you organize your personal mach
 />
 </p>
 
-You can access your projects from **My Projects** at the left of Stately Studio’s top bar when you’re signed into the Stately Studio. **My Projects** lists your personal projects and is one of the locations where you can create new projects.
+You can access your projects from **My Projects** at the left of Stately Studio’s top bar when you’re signed into Stately Studio. **My Projects** lists your personal projects and is one of the locations where you can create new projects.
 
 When you select a project, the first machine in the project will open in Stately Studio’s editor. The other machines in your project are accessible from the **Machines** list in the left drawer menu.
 
 <p>
 <ThemedImage
-  alt="Stately Studio editor showing the Machines list in the left drawer for the Stately Studio Tutorials project. The selected machine is called ‘Parent states.’"
+  alt="Stately Studio’s editor showing the Machines list in the left drawer for Stately Studio Tutorials project. The selected machine is called ‘Parent states.’"
   sources={{
     light: useBaseUrl('/projects/machines-list.png'),
     dark: useBaseUrl('/projects/machines-list-dm.png'),
@@ -33,7 +33,7 @@ When you select a project, the first machine in the project will open in Stately
 
 ### Shared projects
 
-Shared projects are available to [Teams](teams.mdx). Team projects are listed inside their Team in the Stately Studio workspace.
+Shared projects are available to [Teams](teams.mdx). Team projects are listed inside their Team in Stately Studio workspace.
 
 <p>
 <ThemedImage
@@ -47,13 +47,13 @@ Shared projects are available to [Teams](teams.mdx). Team projects are listed in
 
 :::studio
 
-Teams and shared projects are Pro features of the Stately Studio. [Check out the features on our Pro plan](https://stately.ai/pricing) or [upgrade to the Pro plan](https://stately.ai/registry/billing).
+Teams and shared projects are Pro features of Stately Studio. [Check out the features on our Pro plan](https://stately.ai/pricing) or [upgrade to the Pro plan](https://stately.ai/registry/billing).
 
 :::
 
 ### Create a new project
 
-You can create a new project when you first save a machine or from the **Create project** button in [**My Projects**](/#my-projects). You must be signed in to the Stately Studio to access **My Projects** and shared team projects, or to create new projects.
+You can create a new project when you first save a machine or from the **Create project** button in [**My Projects**](/#my-projects). You must be signed in to Stately Studio to access **My Projects** and shared team projects, or to create new projects.
 
 #### Create a new project from **My Projects**
 
@@ -90,7 +90,7 @@ You can move projects between your teams if you have an [**Owner**](teams.mdx#ow
 
 <p>
 <ThemedImage
-  alt="Stately Studio editor page showing the Share modal with the options for changing project visibility and moving projects to another team."
+  alt="Stately Studio’s editor page showing the Share modal with the options for changing project visibility and moving projects to another team."
   sources={{
     light: useBaseUrl('/projects/move-projects.png'),
     dark: useBaseUrl('/projects/move-projects-dm.png'),

--- a/versioned_docs/version-5/sign-up.mdx
+++ b/versioned_docs/version-5/sign-up.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sign up for the Stately Studio
+title: Sign up for Stately Studio
 ---
 
 # Sign up
@@ -10,7 +10,7 @@ Sign up using your email address and password, or sign in using your GitHub, Goo
 
 :::studio
 
-We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-plan.mdx) so you can explore how our Pro features work for you and your team. You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio.
+We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-plan.mdx) so you can explore how our Pro features work for you and your team. You can [upgrade](upgrade.mdx) when you’re signed into Stately Studio.
 
 :::
 
@@ -24,6 +24,6 @@ If you forget, or want to change your password, use the Forgot password link on 
 
 ### Using social sign in
 
-You can also [sign in to the Stately Studio using your GitHub, Google, or Twitter account credentials](https://stately.ai/registry/login). As you have already signed up to your platform of choice, you can skip the sign up with Stately Studio and immediately sign in.
+You can also [sign in to Stately Studio using your GitHub, Google, or Twitter account credentials](https://stately.ai/registry/login). As you have already signed up to your platform of choice, you can skip the sign up with Stately Studio and immediately sign in.
 
 When you sign in with GitHub, Google, or Twitter, we will send emails with information about your account, as well as team and project invitations, to the email address you used to sign up for that platform.

--- a/versioned_docs/version-5/state-machines-and-statecharts.mdx
+++ b/versioned_docs/version-5/state-machines-and-statecharts.mdx
@@ -27,13 +27,13 @@ State machines model your application logic. Below is the logic for a video play
 
 Statecharts are fancy state machines used to model more complex logic.
 
-Statecharts are a visual extension to state machines that use boxes and arrows, much like flowcharts and sequence diagrams. Statecharts add extra features not available in ordinary state machines, including [hierarchy](parent-states.mdx), [concurrency](parallel-states.mdx) and [communication](actors.mdx).
+Statecharts are a visual extension to state machines that use boxes and arrows, much like flowcharts and sequence diagrams. Statecharts add extra features not available in ordinary state machines, including [hierarchy](parent-states.mdx), [concurrency](parallel-states.mdx) and [communication](actor-model.mdx).
 
-When you make a state machine in the [Stately Studio](https://stately.ai/editor), it’s also a statechart!
+When you make a state machine in [Stately Studio](https://stately.ai/editor), it’s also a statechart!
 
 :::studio
 
-In the Stately Studio, we refer to both state machines and statecharts as **machines**.
+In Stately Studio, we refer to both state machines and statecharts as **machines**.
 
 :::
 
@@ -57,6 +57,9 @@ A state describes the machine’s status or mode, which could be as simple as *
 [View the dog states machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=469f2d59-551f-43cb-bfc0-e6f3ea0f9d87).
 
 A dog is always **asleep** or **awake**. The dog can’t be asleep and awake at the same time, and it’s impossible for the dog to be neither asleep nor awake. There are only these two states, a precisely limited, _finite_ number of states.
+
+- [More about states](states.mdx).
+- [More about finite states](finite-states.mdx).
 
 :::studio
 
@@ -89,6 +92,8 @@ Transitions are “deterministic”; each combination of state and event always 
 
 With its two finite states and transitions, this tiny dog process is a _Finite State Machine._ A state machine is used to describe the behavior of something. The machine describes the thing’s states and the transitions between those states. It’s a Finite State Machine because it has a finite number of states. (Sometimes abbreviated to FSM by folks who love jargon).
 
+[Read more about transitions and events](transitions.mdx).
+
 :::studio
 
 ### Events and transitions in the Stately Studio
@@ -118,6 +123,8 @@ In a statechart describing the process of walking the dog, the initial state wou
 
 [View the dog waiting machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=65cf2bcb-658d-40dc-bb26-80f26c159256).
 
+[Read more about initial states](initial-states.mdx).
+
 :::studio
 
 ### Initial states in the Stately Studio
@@ -145,11 +152,13 @@ In the dog walking statechart, the final state would be **walk complete**.
 
 [View the dog walk machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=988d8d05-86ba-422a-8a28-d13cbf54d481).
 
+[Read more about final states](final-states.mdx)
+
 ## Parent states
 
 A parent state is a state that can contain more states, also known as child states. These child states can only happen when the parent state is happening. Inside the **on a walk** state, there could be the child states of **walking** and **running**.
 
-A parent state is symbolised by a labelled rectangle box that acts as a container for its child states.
+A parent state is symbolised by a labelled rectangle box that acts as a container for its child states. Parent states are sometimes known as *compound states*.
 
 <!-- no alt because the image is already described in the surrounding text -->
 
@@ -169,6 +178,8 @@ A parent state is symbolised by a labelled rectangle box that acts as a containe
 A parent state should also specify which child state is the initial state. In the **on a walk** parent state, the initial state is **walking**.
 
 Parent and child states are one of the features that make statecharts capable of handling more complexity than an everyday state machine.
+
+[Read more about parent states](parent-states.mdx).
 
 ## Atomic states
 
@@ -197,6 +208,8 @@ Inside the **on a walk** parallel state, there could be two regions. One region 
 
 Both regions should also specify which child state is the initial state. In our **tail** region, the initial state is **not wagging**.
 
+[Read more about parallel states](parallel-states.mdx).
+
 ## Self-transition
 
 A self-transition is when an event happens, but the transition returns to the same state. The transition arrow exits and re-enters the same state.
@@ -220,6 +233,8 @@ In a **dog begging** process, there would be a **begging** state with a **gets t
 
 [View the dog begging machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=1f43dcd3-255c-40bf-b6b0-eba9a2bccb23).
 
+[Read more about self transitions](transitions.mdx/#self-transitions)
+
 ## What next?
 
-Now you know enough to get started in the [Stately Studio](https://stately.ai/editor). Get an [overview of the Stately Studio and its features](/#studio-editor), or [continue to learn more about states in detail](states.mdx).
+Now you know enough to get started in the [Stately Studio](https://stately.ai/editor?source=docs). Get an [overview of the Stately Studio and its features](studio.mdx), or [continue to learn about XState](xstate.mdx).

--- a/versioned_docs/version-5/state-machines-and-statecharts.mdx
+++ b/versioned_docs/version-5/state-machines-and-statecharts.mdx
@@ -21,7 +21,7 @@ State machines model your application logic. Below is the logic for a video play
   />
 </p>
 
-[View the video player machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=dbcfca1c-075d-4cd6-a865-efcbd7be1544).
+[View the video player machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=dbcfca1c-075d-4cd6-a865-efcbd7be1544).
 
 ## What is a statechart?
 
@@ -54,7 +54,7 @@ A state describes the machine’s status or mode, which could be as simple as *
   />
 </p>
 
-[View the dog states machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=469f2d59-551f-43cb-bfc0-e6f3ea0f9d87).
+[View the dog states machine in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=469f2d59-551f-43cb-bfc0-e6f3ea0f9d87).
 
 A dog is always **asleep** or **awake**. The dog can’t be asleep and awake at the same time, and it’s impossible for the dog to be neither asleep nor awake. There are only these two states, a precisely limited, _finite_ number of states.
 
@@ -63,9 +63,9 @@ A dog is always **asleep** or **awake**. The dog can’t be asleep and awake at 
 
 :::studio
 
-### States in the Stately Studio
+### States in Stately Studio
 
-The rounded rectangle boxes are states. [Read how to create states in the Stately Studio](states.mdx).
+The rounded rectangle boxes are states. [Read how to create states in Stately Studio](states.mdx).
 
 :::
 
@@ -88,7 +88,7 @@ Transitions are “deterministic”; each combination of state and event always 
   />
 </p>
 
-[View the dog states machine with events and transitions in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=e48e774e-c31f-4e51-a934-6b795c12b2b9).
+[View the dog states machine with events and transitions in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=e48e774e-c31f-4e51-a934-6b795c12b2b9).
 
 With its two finite states and transitions, this tiny dog process is a _Finite State Machine._ A state machine is used to describe the behavior of something. The machine describes the thing’s states and the transitions between those states. It’s a Finite State Machine because it has a finite number of states. (Sometimes abbreviated to FSM by folks who love jargon).
 
@@ -96,9 +96,9 @@ With its two finite states and transitions, this tiny dog process is a _Finite S
 
 :::studio
 
-### Events and transitions in the Stately Studio
+### Events and transitions in Stately Studio
 
-In the Stately Studio, the arrows are transitions, and the rounded rectangles on the arrow’s lines are events. Each transition has a **source** state which comes before the transition, and a **target** state, which comes after the transition. The transition’s arrow starts from the source state and points to the target state. [Read how to create events and transitions in the Stately Studio](transitions.mdx).
+In Stately Studio, the arrows are transitions, and the rounded rectangles on the arrow’s lines are events. Each transition has a **source** state which comes before the transition, and a **target** state, which comes after the transition. The transition’s arrow starts from the source state and points to the target state. [Read how to create events and transitions in Stately Studio](transitions.mdx).
 
 :::
 
@@ -121,15 +121,15 @@ In a statechart describing the process of walking the dog, the initial state wou
   />
 </p>
 
-[View the dog waiting machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=65cf2bcb-658d-40dc-bb26-80f26c159256).
+[View the dog waiting machine in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=65cf2bcb-658d-40dc-bb26-80f26c159256).
 
 [Read more about initial states](initial-states.mdx).
 
 :::studio
 
-### Initial states in the Stately Studio
+### Initial states in Stately Studio
 
-The filled circle with an arrow icon represents the initial state. [Read how to create initial states in the Stately Studio](initial-states.mdx).
+The filled circle with an arrow icon represents the initial state. [Read how to create initial states in Stately Studio](initial-states.mdx).
 
 :::
 
@@ -150,7 +150,7 @@ In the dog walking statechart, the final state would be **walk complete**.
   />
 </p>
 
-[View the dog walk machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=988d8d05-86ba-422a-8a28-d13cbf54d481).
+[View the dog walk machine in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=988d8d05-86ba-422a-8a28-d13cbf54d481).
 
 [Read more about final states](final-states.mdx)
 
@@ -173,7 +173,7 @@ A parent state is symbolised by a labelled rectangle box that acts as a containe
   />
 </p>
 
-[View the dog walk machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=aa8a9c5d-8fd9-4e47-b71a-bda219cda066).
+[View the dog walk machine in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=aa8a9c5d-8fd9-4e47-b71a-bda219cda066).
 
 A parent state should also specify which child state is the initial state. In the **on a walk** parent state, the initial state is **walking**.
 
@@ -204,7 +204,7 @@ Inside the **on a walk** parallel state, there could be two regions. One region 
   />
 </p>
 
-[View the dog walk machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=1f43dcd3-255c-40bf-b6b0-eba9a2bccb23).
+[View the dog walk machine in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=1f43dcd3-255c-40bf-b6b0-eba9a2bccb23).
 
 Both regions should also specify which child state is the initial state. In our **tail** region, the initial state is **not wagging**.
 
@@ -231,10 +231,10 @@ In a **dog begging** process, there would be a **begging** state with a **gets t
   />
 </p>
 
-[View the dog begging machine in the Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=1f43dcd3-255c-40bf-b6b0-eba9a2bccb23).
+[View the dog begging machine in Stately Studio](https://stately.ai/registry/editor/1f84ff0d-fe41-4a92-ad5c-fadfa8b37ffb?machineId=1f43dcd3-255c-40bf-b6b0-eba9a2bccb23).
 
 [Read more about self transitions](transitions.mdx/#self-transitions)
 
 ## What next?
 
-Now you know enough to get started in the [Stately Studio](https://stately.ai/editor?source=docs). Get an [overview of the Stately Studio and its features](studio.mdx), or [continue to learn about XState](xstate.mdx).
+Now you know enough to get started in the [Stately Studio](https://stately.ai/editor?source=docs). Get an [overview of Stately Studio and its features](studio.mdx), or [continue to learn about XState](xstate.mdx).

--- a/versioned_docs/version-5/states.mdx
+++ b/versioned_docs/version-5/states.mdx
@@ -28,11 +28,11 @@ Stately Studio: states
   />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=741f69fd-7f01-4932-9407-6871e225bb6d).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=741f69fd-7f01-4932-9407-6871e225bb6d).
 
 :::studio
 
-In the Stately Studio, the rounded rectangle boxes are states. The **?** question mark icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
+In Stately Studio, the rounded rectangle boxes are states. The **?** question mark icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
 
 :::
 

--- a/versioned_docs/version-5/states.mdx
+++ b/versioned_docs/version-5/states.mdx
@@ -6,16 +6,13 @@ import ThemedImage from '@theme/ThemedImage';
 
 A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
 
+These states are “finite”; the machine can only move through the states you’ve pre-defined.
+
 :::tip
 
 Watch our [“What are states?” video on YouTube](https://www.youtube.com/watch?v=z-6yhmSWUcc&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=2) (53s).
 
 :::
-
-<details>
-<summary>
-Stately Studio: states
-</summary>
 
 <p>
   <ThemedImage
@@ -30,15 +27,15 @@ Stately Studio: states
 
 [View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=741f69fd-7f01-4932-9407-6871e225bb6d).
 
-:::studio
 
-In Stately Studio, the rounded rectangle boxes are states. The **?** question mark icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
-
-:::
-
-These states are “finite”; the machine can only move through the states you’ve pre-defined.
+<details>
+<summary>
+Using states in Stately Studio
+</summary>
 
 ## Using states in Stately Studio
+
+In Stately Studio, the rounded rectangle boxes are states. The **?** question mark icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
 
 ### Create a state
 
@@ -52,11 +49,11 @@ These states are “finite”; the machine can only move through the states you�
 
 ## State object
 
-The state object represents the current state of a running machine (actor). It contains the following properties:
+The state object represents the current state of a running machine ([actor](actor-model.mdx)) and contains the following properties:
 
-- `value` - the current state value, which is either a string representing a simple state like `'playing'` or an object representing nested states like `{ paused: 'buffering' }`
-- `context` - the current [context](#todo) (extended state)
-- `meta` - an object containing state node meta data
+- **`value`**: the current state value, which is either a string representing a simple state like `'playing'` or an object representing nested states like `{ paused: 'buffering' }`.
+- **`context`**: the current [context](context.mdx) (extended state.)
+- **`meta`**: an object containing state node meta data.
 
 ```ts
 const feedbackMachine = createMachine({
@@ -94,7 +91,7 @@ console.log(actor.getSnapshot());
 
 ## Accessing state snapshots
 
-You can access the snapshot of an actor (its emitted state) by subscribing to it or reading from the actor’s `.getSnapshot()` method.
+You can access an actor’s the emitted state (or *snapshot*) by subscribing to or reading from the actor’s `.getSnapshot()` method.
 
 ```ts
 const actor = interpret(feedbackMachine);
@@ -114,9 +111,9 @@ console.log(actor.getSnapshot());
 
 ## State value
 
-A state machine with nested states (statechart) is a tree-like structure, where each node is a "state node". The root state node is the top-level state node that represents the entire machine. It may have child state nodes, and those may have child state nodes, and so on.
+A state machine with nested states (or *[statechart](state-machines-and-statecharts.mdx#what-is-a-statechart)*) is a tree-like structure where each node is a *state node*. The root state node is the top-level state node that represents the entire machine. The root node may have child state nodes, which may have child state nodes, and so on.
 
-The **state value** is an object that represents all of the active state nodes in a machine. For state machines that have state nodes without child state nodes, the state value is a string:
+The **state value** is an object that represents all the active state nodes in a machine. For state machines that have state nodes without child state nodes, the state value is a string:
 
 TODO: make this a visual example
 
@@ -130,7 +127,7 @@ TODO: make this a visual example
 
 - `state.value === { form: 'invalid' }` - this represents a state machine with an active child node with key `form` that has an active child node with key `invalid`
 
-For state machines with [parallel state nodes](#todo), the state value contains object(s) with multiple keys for each state node region:
+For state machines with [parallel state nodes](parallel-states.mdx), the state value contains object(s) with multiple keys for each state node region:
 
 ```ts
 state.value ===
@@ -166,6 +163,6 @@ State machines may also have no state nodes other than the root state node. For 
 
 ## Cheatsheet
 
-## Resources
+## Further resources
 
 - Persisting state

--- a/versioned_docs/version-5/studio-community-plan.mdx
+++ b/versioned_docs/version-5/studio-community-plan.mdx
@@ -4,11 +4,11 @@ title: Stately Studio Community plan
 
 # Stately Studio Community
 
-**The Stately Studio will always be free to our Community users** on this free plan, and we will make many future features available on every plan. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.ai).
+**Stately Studio will always be free to our Community users** on this free plan, and we will make many future features available on every plan. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.ai).
 
 :::studio
 
-We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-plan.mdx) so you can explore how our Pro features work for you and your team. You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio.
+We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-plan.mdx) so you can explore how our Pro features work for you and your team. You can [upgrade](upgrade.mdx) when you’re signed into Stately Studio.
 
 :::
 

--- a/versioned_docs/version-5/studio-enterprise-plan.mdx
+++ b/versioned_docs/version-5/studio-enterprise-plan.mdx
@@ -4,7 +4,7 @@ title: Stately Studio Enterprise plan
 
 # Stately Studio Enterprise
 
-<p><a href="mailto:sales@stately.com?subject=I'm interested in the Stately Studio Enterprise plan">Email the Stately team</a> for a custom plan tailored to the requirements of your organization.</p>
+<p><a href="mailto:sales@stately.com?subject=I'm interested in Stately Studio Enterprise plan">Email the Stately team</a> for a custom plan tailored to the requirements of your organization.</p>
 
 :::studio
 

--- a/versioned_docs/version-5/studio-pro-plan.mdx
+++ b/versioned_docs/version-5/studio-pro-plan.mdx
@@ -18,11 +18,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 We have many more pro features planned. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.ai).
 
-We offer a **30-day free trial** on the Stately Studio Pro account so you can explore how our Pro features work for you and your team.
+We offer a **30-day free trial** on Stately Studio Pro account so you can explore how our Pro features work for you and your team.
 
 :::studio
 
-**The Stately Studio will always be free to our Community users** on the free plan, and we will make many future features available on every plan.
+**Stately Studio will always be free to our Community users** on the free plan, and we will make many future features available on every plan.
 
 :::
 
@@ -34,11 +34,11 @@ You can choose between monthly or yearly billing on our Pro accounts and how man
 
 You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the editor](https://stately.ai/editor)’s top bar.
 
-Read more about [signing up for the Stately Studio](sign-up.mdx).
+Read more about [signing up for Stately Studio](sign-up.mdx).
 
 ### How to upgrade
 
-You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into Stately Studio using the **Upgrade** button in the editor’s header.
 
 ## Priority support
 

--- a/versioned_docs/version-5/studio.mdx
+++ b/versioned_docs/version-5/studio.mdx
@@ -27,7 +27,7 @@ What are state machines and statecharts? We’re glad you asked! [Check out our 
 
 ## Stately Studio’s editor
 
-Stately Studio’s editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; **Design** mode for creating your machines and **Simulation** mode for simulating how your machine works.
+Stately Studio’s editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; **Design** mode for creating your machines and **Simulate** mode for simulating how your machine works.
 
 ### Design mode
 
@@ -43,7 +43,7 @@ Stately Studio’s editor supports everything you need to visually build state m
 
 Visually add, modify, and delete states, events, and transitions, as well as data, including actions, descriptions, and invoked actors.
 
-### Simulation mode
+### Simulate mode
 
 <p>
   <ThemedImage

--- a/versioned_docs/version-5/studio.mdx
+++ b/versioned_docs/version-5/studio.mdx
@@ -101,6 +101,6 @@ Are you seeking inspiration for your machine? Or do you want to learn from how s
 
 ## Our roadmap
 
-Do you want to request a feature in Stately Studio? [Check out our Canny roadmap](https://statelyai.canny.io) to post your feature idea and upvote other features. Our roadmap also shows you the features we have planned and those already in progress.
+Do you want to request a feature in Stately Studio? [Check out our roadmap](https://feedback.stately.ai) to post your feature ideas and upvote other features. Our roadmap also shows you the features we have planned and those already in progress.
 
 You can also keep up with the Stately team’s work in progress at our regular [office hour live streams](https://youtube.com/statelyai).

--- a/versioned_docs/version-5/studio.mdx
+++ b/versioned_docs/version-5/studio.mdx
@@ -5,7 +5,7 @@ title: Stately Studio
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-The Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](developer-tools.mdx), and much more coming soon.
+Stately Studio is a suite of tools for building app logic, including the Studio Editor, [developer tools for XState](developer-tools.mdx), and much more coming soon.
 
 <p>
   <ThemedImage
@@ -17,7 +17,7 @@ The Stately Studio is a suite of tools for building app logic, including the Stu
   />
 </p>
 
-You can use the [Stately Studio editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
+You can use [Stately Studio’s editor](#studio-editor) to model your logic using state machines and statecharts visually; no code required! Collaborate on your machines with coworkers and friends with [shared projects in teams](/#projects-and-teams). Use the [XState VS Code extension](xstate-vscode-extension.mdx) to use the editor with your codebase inside your code editor, or [export](/#export) your code from Stately Studio into your codebase.
 
 :::tip
 
@@ -27,7 +27,7 @@ What are state machines and statecharts? We’re glad you asked! [Check out our 
 
 ## Stately Studio’s editor
 
-Stately Studio editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; **Design** mode for creating your machines and **Simulation** mode for simulating how your machine works.
+Stately Studio’s editor supports everything you need to visually build state machines and statecharts. The editor currently has two modes; **Design** mode for creating your machines and **Simulation** mode for simulating how your machine works.
 
 ### Design mode
 
@@ -73,7 +73,7 @@ You can also export machines to JSON, JavaScript and TypeScript, ready to be use
   />
 </p>
 
-As a [Pro user](https://stately.ai/pricing), you can create and join teams in the Stately Studio to share your machines and collaborate on private team projects. [Read more about Projects](projects.mdx) and [Teams](teams.mdx).
+As a [Pro user](https://stately.ai/pricing), you can create and join teams in Stately Studio to share your machines and collaborate on private team projects. [Read more about Projects](projects.mdx) and [Teams](teams.mdx).
 
 <p>
   <ThemedImage
@@ -87,7 +87,7 @@ As a [Pro user](https://stately.ai/pricing), you can create and join teams in th
 
 ## Discover machines
 
-Are you seeking inspiration for your machine? Or do you want to learn from how somebody else models their machines? The [Discover page](https://stately.ai/registry/discover) lists all the public machines created with the Stately Studio. [Read more about the Discover page](discover.mdx).
+Are you seeking inspiration for your machine? Or do you want to learn from how somebody else models their machines? The [Discover page](https://stately.ai/registry/discover) lists all the public machines created with Stately Studio. [Read more about the Discover page](discover.mdx).
 
 <p>
   <ThemedImage
@@ -101,6 +101,6 @@ Are you seeking inspiration for your machine? Or do you want to learn from how s
 
 ## Our roadmap
 
-Do you want to request a feature in the Stately Studio? [Check out our Canny roadmap](https://statelyai.canny.io) to post your feature idea and upvote other features. Our roadmap also shows you the features we have planned and those already in progress.
+Do you want to request a feature in Stately Studio? [Check out our Canny roadmap](https://statelyai.canny.io) to post your feature idea and upvote other features. Our roadmap also shows you the features we have planned and those already in progress.
 
 You can also keep up with the Stately team’s work in progress at our regular [office hour live streams](https://youtube.com/statelyai).

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -1,12 +1,12 @@
 ---
 title: Teams
-description: 'You can create and join teams in the Stately Studio to share and collaborate on team projects.'
+description: 'You can create and join teams in Stately Studio to share and collaborate on team projects.'
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-You can create and join teams in the Stately Studio to share and collaborate on team projects.
+You can create and join teams in Stately Studio to share and collaborate on team projects.
 
 <p>
   <ThemedImage
@@ -20,7 +20,7 @@ You can create and join teams in the Stately Studio to share and collaborate on 
 
 :::studio
 
-Teams and shared projects are Pro features of the Stately Studio. [Check out the features on our Pro plan](https://stately.ai/pricing) or [upgrade to the Pro plan](https://stately.ai/registry/billing).
+Teams and shared projects are Pro features of Stately Studio. [Check out the features on our Pro plan](https://stately.ai/pricing) or [upgrade to the Pro plan](https://stately.ai/registry/billing).
 
 :::
 
@@ -59,7 +59,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 
 #### Teams members and Pro plan seats
 
-Creating a team requires the Pro plan of the Stately Studio, including enough seats in your plan to cover the number of members in your team. You can add more seats to your Pro plan anytime from the [**Billing** page](https://stately.ai/registry/billing) in your Profile menu.
+Creating a team requires the Pro plan of Stately Studio, including enough seats in your plan to cover the number of members in your team. You can add more seats to your Pro plan anytime from the [**Billing** page](https://stately.ai/registry/billing) in your Profile menu.
 
 ### Admin role
 

--- a/versioned_docs/version-5/templates.mdx
+++ b/versioned_docs/version-5/templates.mdx
@@ -2,7 +2,9 @@
 title: 'Templates'
 ---
 
-Check out our new templates:
+XState runs anywhere you can run JavaScript and is framework-agnostic. But you can get started with or without your framework of choice using the templates below.
+
+Check out our new code + CodeSandbox templates:
 
 - [XState TypeScript template](https://github.com/statelyai/xstate/tree/main/templates/vanilla-ts)
 - [XState React TypeScript template](https://github.com/statelyai/xstate/tree/main/templates/react-ts)

--- a/versioned_docs/version-5/transitions.mdx
+++ b/versioned_docs/version-5/transitions.mdx
@@ -49,7 +49,7 @@ The arrows are transitions, and the rounded rectangles on the arrow’s lines ar
   />
 </p>
 
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9630e3b7-9f8e-4dc9-8b55-661f854d28b7).
+[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9630e3b7-9f8e-4dc9-8b55-661f854d28b7).
 
 In the video player machine above, the events are *PLAY* and *PAUSE*. The *Play* event transitions from the *Paused* state to the *Playing* state. The *Pause* event transitions from the *Playing* state to the *Paused* state.
 

--- a/versioned_docs/version-5/typegen.mdx
+++ b/versioned_docs/version-5/typegen.mdx
@@ -24,14 +24,16 @@ Install the [CLI](developer-tools.mdx/#xstate-cli-command-line-interface) and ru
 
 Next try to create a machine, make sure to set the `schema` attributes:
 
-```ts twoslash {4-7}
+```ts
 import { createMachine } from 'xstate';
 
 const machine = createMachine({
+  // highlight-start
   schema: {
     context: {} as { value: string },
     events: {} as { type: 'FOO'; value: string } | { type: 'BAR' },
   },
+  // highlight-end
   initial: 'a',
   states: {
     a: {

--- a/versioned_docs/version-5/upgrade.mdx
+++ b/versioned_docs/version-5/upgrade.mdx
@@ -7,17 +7,17 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Upgrade
 
-**The Stately Studio will always be free to our Community users** on the [Community plan](studio-community-plan.mdx), and we will make many future features available on every plan.
+**Stately Studio will always be free to our Community users** on the [Community plan](studio-community-plan.mdx), and we will make many future features available on every plan.
 
 We offer a **30-day free trial** on the [Stately Studio Pro account](studio-pro-plan.mdx) so you can explore how our Pro features work for you and your team.
 
 ## Upgrade to a Pro plan
 
-You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into Stately Studio using the **Upgrade** button in the editor’s header.
 
 <p>
 <ThemedImage
-  alt="Upgrade button in the header of the Stately Studio between the Save and share buttons."
+  alt="Upgrade button in the header of Stately Studio between the Save and share buttons."
   sources={{
     light: useBaseUrl('/upgrade/upgrade.png'),
     dark: useBaseUrl('/upgrade/upgrade-dm.png'),
@@ -27,7 +27,7 @@ You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio usin
 
 ## Upgrade to an Enterprise plan
 
-<p><a href="mailto:sales@stately.com?subject=I'm interested in the Stately Studio Enterprise plan">Email the Stately team</a> for a custom plan tailored to the requirements of your organization.</p>
+<p><a href="mailto:sales@stately.com?subject=I'm interested in Stately Studio Enterprise plan">Email the Stately team</a> for a custom plan tailored to the requirements of your organization.</p>
 
 ## Modify your subscription plan and seats
 
@@ -40,7 +40,7 @@ If you want to modify the number of seats on your plan, change the **Quantity** 
 
 <p>
 <ThemedImage
-  alt="Billing option in the user account menu in the Stately Studio header."
+  alt="Billing option in the user account menu in Stately Studio header."
   sources={{
     light: useBaseUrl('/upgrade/billing.png'),
     dark: useBaseUrl('/upgrade/billing-dm.png'),

--- a/versioned_docs/version-5/visualizer.mdx
+++ b/versioned_docs/version-5/visualizer.mdx
@@ -16,7 +16,7 @@ The [Stately Visualizer](https://stately.ai/viz) is a tool for creating and insp
 
 :::tip
 
-Stately still supports the Stately Visualizer, but you will find many more advanced features, including the Stately Studio [visual editor](../#studio-editor), teams, and shared projects.
+Stately still supports the Stately Visualizer, but you will find many more advanced features, including Stately Studio [visual editor](../#studio-editor), teams, and shared projects.
 
 :::
 

--- a/versioned_docs/version-5/xstate.mdx
+++ b/versioned_docs/version-5/xstate.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 XState is a state management and orchestration solution for JavaScript and TypeScript apps.
 
-It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines. It integrates well with React, Vue, Svelte, and other frameworks and can be used in the frontend, backend, or wherever JavaScript runs.
+It uses [event-driven](transitions.mdx) programming, [state machines, statecharts](state-machines-and-statecharts.mdx), and the [actor model](actor-model.mdx) to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines. It integrates well with React, Vue, Svelte, and other frameworks and can be used in the frontend, backend, or wherever JavaScript runs.
 
 :::tip
 

--- a/versioned_docs/version-5/xstate.mdx
+++ b/versioned_docs/version-5/xstate.mdx
@@ -6,9 +6,15 @@ slug: '/xstate'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-XState is a state management & orchestration solution for JavaScript and TypeScript apps.
+XState is a state management and orchestration solution for JavaScript and TypeScript apps.
 
-It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines. It integrates well with React, Vue, Svelte, and other frameworks, and can be used in the frontend, backend, or anywhere else JavaScript runs.
+It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines. It integrates well with React, Vue, Svelte, and other frameworks and can be used in the frontend, backend, or wherever JavaScript runs.
+
+:::tip
+
+Want to find out more about state machines? [Read our introduction](state-machines-and-statecharts.mdx).
+
+:::
 
 ## Installation
 
@@ -143,19 +149,10 @@ textActor.send({ type: 'text.cancel' });
 // logs 'Hello'
 ```
 
-## Installation
-
-- [Install XState](./installation.mdx)
-- [Learn about the XState basics](/xstate/basics/what-is-a-statechart)
-
-:::xstate
-
 ## Download the XState VS Code extension
 
 - [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode)
 - [Open VSX Registry](https://open-vsx.org/extension/statelyai/stately-vscode)
-
-:::
 
 [Read more about our developer tools](/tools/developer-tools/).
 

--- a/versioned_sidebars/version-5-sidebars.json
+++ b/versioned_sidebars/version-5-sidebars.json
@@ -49,13 +49,13 @@
       "items": [
         {
           "type": "doc",
-          "label": "Actor model",
-          "id": "actor-model"
+          "label": "State machines",
+          "id": "state-machines-and-statecharts"
         },
         {
           "type": "doc",
-          "label": "State machines",
-          "id": "state-machines-and-statecharts"
+          "label": "Actor model",
+          "id": "actor-model"
         },
         {
           "type": "doc",

--- a/versioned_sidebars/version-5-sidebars.json
+++ b/versioned_sidebars/version-5-sidebars.json
@@ -11,7 +11,7 @@
       "link": {
         "type": "generated-index",
         "title": "Get started",
-        "description": "Get started quickly with XState and the Stately Studio.",
+        "description": "Get started quickly with XState and Stately Studio.",
         "slug": "/category/get-started",
         "keywords": ["guides"]
       },
@@ -40,7 +40,7 @@
       "link": {
         "type": "generated-index",
         "title": "Core concepts",
-        "description": "Learn the core concepts for XState and the Stately Studio.",
+        "description": "Learn the core concepts for XState and Stately Studio.",
         "slug": "/category/core-concepts",
         "keywords": ["guides"]
       },
@@ -70,7 +70,7 @@
       "link": {
         "type": "generated-index",
         "title": "Using Stately Studio",
-        "description": "Learn how to use the Stately Studio and our editor.",
+        "description": "Learn how to use Stately Studio’s editor.",
         "slug": "/category/studio",
         "keywords": ["guides"]
       },
@@ -88,7 +88,7 @@
           "link": {
             "type": "generated-index",
             "title": "Design mode",
-            "description": "Learn how to use Design mode in the Stately Studio’s editor.",
+            "description": "Learn how to use Design mode in Stately Studio’s editor.",
             "slug": "/category/design-mode",
             "keywords": ["guides"]
           },
@@ -108,7 +108,7 @@
           "link": {
             "type": "generated-index",
             "title": "Stately Studio accounts",
-            "description": "Learn about the Stately Studio plans and how to manage your account.",
+            "description": "Learn about Stately Studio plans and how to manage your account.",
             "slug": "/category/accounts",
             "keywords": ["guides"]
           },
@@ -150,7 +150,7 @@
       "link": {
         "type": "generated-index",
         "title": "State machines",
-        "description": "Learn how to use state machines in XState and the Stately Studio.",
+        "description": "Learn how to use state machines in XState and Stately Studio.",
         "slug": "/category/state-machines",
         "keywords": ["guides"]
       },
@@ -180,7 +180,7 @@
       "link": {
         "type": "generated-index",
         "title": "Actors",
-        "description": "Learn how to use actors and the actor model in XState and the Stately Studio.",
+        "description": "Learn how to use actors and the actor model in XState and Stately Studio.",
         "slug": "/category/actors",
         "keywords": ["guides"]
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,29 +2127,6 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript/twoslash@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript/twoslash/-/twoslash-3.1.0.tgz#20b4d4bb58729681ff7f4b187af98757ea8723d4"
-  integrity sha512-kTwMUQ8xtAZaC4wb2XuLkPqFVBj2dNBueMQ89NWEuw87k2nLBbuafeG5cob/QEr6YduxIdTVUjix0MtC7mPlmg==
-  dependencies:
-    "@typescript/vfs" "1.3.5"
-    debug "^4.1.1"
-    lz-string "^1.4.4"
-
-"@typescript/vfs@1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.3.4.tgz#07f89d2114f6e29255d589395ed7f3b4af8a00c2"
-  integrity sha512-RbyJiaAGQPIcAGWFa3jAXSuAexU4BFiDRF1g3hy7LmRqfNpYlTQWGXjcrOaVZjJ8YkkpuwG0FcsYvtWQpd9igQ==
-  dependencies:
-    debug "^4.1.1"
-
-"@typescript/vfs@1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.3.5.tgz#801e3c97b5beca4ff5b8763299ca5fd605b862b8"
-  integrity sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==
-  dependencies:
-    debug "^4.1.1"
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -3412,15 +3389,6 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-preset-shiki-twoslash@^1.1.38:
-  version "1.1.38"
-  resolved "https://registry.yarnpkg.com/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.38.tgz#297ddff7b5b84bc6bc9ebf32a3ee1ff17ae0e035"
-  integrity sha512-v8bp6Q6gUNLuWmf4x19Tk2VvjEc8Luuy6o7fpTg7fTFUwo7ZBVWPTrxJe/aN4OmjkVBmuDfBc/muUGEAJTVm2g==
-  dependencies:
-    copy-text-to-clipboard "^3.0.1"
-    remark-shiki-twoslash "3.1.0"
-    typescript ">3"
-
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -3820,11 +3788,6 @@ feed@^4.2.2:
   integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
   dependencies:
     xml-js "^1.6.11"
-
-fenceparser@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fenceparser/-/fenceparser-1.1.1.tgz#e10a5f12a54884d4f14edb0f7a52a0edc58fa667"
-  integrity sha512-VdkTsK7GWLT0VWMK5S5WTAPn61wJ98WPFwJiRHumhg4ESNUO/tnkU8bzzzc62o6Uk1SVhuZFLnakmDA4SGV7wA==
 
 file-loader@^6.2.0:
   version "6.2.0"
@@ -4792,11 +4755,6 @@ json5@^2.1.2, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-jsonc-parser@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
-  integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -4951,11 +4909,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-lz-string@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
-  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
@@ -6200,7 +6153,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
@@ -6304,21 +6257,6 @@ remark-parse@8.0.3:
     unist-util-remove-position "^2.0.0"
     vfile-location "^3.0.0"
     xtend "^4.0.1"
-
-remark-shiki-twoslash@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/remark-shiki-twoslash/-/remark-shiki-twoslash-3.1.0.tgz#b5e58eec9f97458ade1df73cb96566d031cc75bd"
-  integrity sha512-6LqSqVtHQR4S0DKfdQ2/ePn9loTKUtpyopYvwk8johjDTeUW5MkaLQuZHlWNkkST/4aMbz6aTkstIcwfwcHpXg==
-  dependencies:
-    "@typescript/twoslash" "3.1.0"
-    "@typescript/vfs" "1.3.4"
-    fenceparser "^1.1.0"
-    regenerator-runtime "^0.13.7"
-    shiki "0.10.1"
-    shiki-twoslash "3.1.0"
-    tslib "2.1.0"
-    typescript ">3"
-    unist-util-visit "^2.0.0"
 
 remark-squeeze-paragraphs@4.0.0:
   version "4.0.0"
@@ -6658,25 +6596,6 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-shiki-twoslash@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/shiki-twoslash/-/shiki-twoslash-3.1.0.tgz#818aaa15e83e0f34325dd56a991f7023f7e8e6db"
-  integrity sha512-uDqrTutOIZzyHbo103GsK7Vvc10saK1XCCivnOQ1NHJzgp3FBilEpftGeVzVSMOJs+JyhI7whkvhXV7kXQ5zCg==
-  dependencies:
-    "@typescript/twoslash" "3.1.0"
-    "@typescript/vfs" "1.3.4"
-    shiki "0.10.1"
-    typescript ">3"
-
-shiki@0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
-  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
-  dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-oniguruma "^1.6.1"
-    vscode-textmate "5.2.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -7053,11 +6972,6 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-tslib@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-
 tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -7087,11 +7001,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-typescript@>3:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typescript@^4.8.4:
   version "4.8.4"
@@ -7363,16 +7272,6 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-vscode-oniguruma@^1.6.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz#aeb9771a2f1dbfc9083c8a7fdd9cccaa3f386607"
-  integrity sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==
-
-vscode-textmate@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 wait-on@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
- Edited and fleshed out v5 docs from start of sidebar, down to and including `Input`.
- Got use of `the Stately Studio` / `Stately Studio` in line with main/live docs
- Removed Shiki twoslash, so highlighting with `// highlight-start` etc now works
- Added support for light/dark mode codeblocks, but still need to implement themes