### PR TITLE
More v5 docs content

### DIFF
--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -221,6 +221,8 @@ A cancel action cancels a delayed sendTo/raise action.
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -13,7 +13,7 @@ Examples of actions:
 - Logging a message
 - Sending a message to another [actor](actors.mdx)
 
-TODO: more examples
+Coming soon… more examples
 
 ```ts
 const feedbackMachine = createMachine({
@@ -72,21 +72,21 @@ In XState, actions are represented on transitions in the `actions: ...` property
 
 Actions can also be on a states’ `entry` or `exit`, also as a single action or an array.
 
-<!-- TODO: simple example -->
+Coming soon… simple example
 
 ## Entry and exit actions
 
 Entry actions are actions that occur on any transition that enters a state node.
 
-<!-- TODO: illustation -->
+Coming soon… illustation
 
 Exit actions are actions that occur on any transition that exits a state node.
 
-<!-- TODO: illustration -->
+Coming soon… illustration
 
 Entry and exit actions are defined using the `entry: ...` and `exit: ...` attributes on a state node. You can fire multiple entry and exit actions on a state. Top-level final states cannot have exit actions, since the machine is stopped and no further transitions can occur.
 
-<!-- TODO: example -->
+Coming soon… example
 
 ### In the Studio
 
@@ -146,13 +146,13 @@ Inline actions are useful for prototyping and simple cases but we generally reco
 
 They have a `type` and optional `params`.
 
-TODO: parameterized action
+Coming soon… parameterized action
 
 ### Implementing actions
 
 Actions are implemented with `.provide(...)`
 
-TODO: `.provide({ actions })`
+Coming soon… `.provide({ actions })`
 
 - Show how `params` can be used in implementation
 
@@ -164,13 +164,13 @@ Assign action is a special action that assigns data to the state context. Specia
 
 Can assign per property: `assign({ foo: 'bar' })` or overall: `assign(() => ({ foo: 'bar' }))`
 
-TODO: example
+Coming soon… example
 
 ## Raise action
 
 Raise action is a special action that raises an event. A **raised event** is an event that the machine creates and sends to itself.
 
-TODO: example
+Coming soon… example
 
 - Raise delay `{ delay: 1000 }`
 - Canceling a delay (link)
@@ -181,7 +181,7 @@ Raised events can be dynamic: `raise(({ context, event }) => ({ type: 'SOME_EVEN
 
 The `sendTo(...)` action is a special action that sends an event to a specific actor.
 
-TODO: example
+Coming soon… example
 
 - Send to delay `{ delay: 1000 }`
 - Canceling a delay (link)
@@ -192,19 +192,19 @@ TODO: example
 
 A pure action is a higher-level action that returns an array of actions to be executed, without actually executing any effects (hence the name "pure").
 
-TODO: example
+Coming soon… example
 
 ## Log action
 
 A log action is an easy way to log messages to the console.
 
-TODO: example
+Coming soon… example
 
 ## Choose action
 
 A choose action is a higher-level action that returns an array of actions to be executed.
 
-TODO: example
+Coming soon… example
 
 ## Cancel action
 

--- a/versioned_docs/version-5/actor-model.mdx
+++ b/versioned_docs/version-5/actor-model.mdx
@@ -4,7 +4,7 @@ title: The actor model
 
 When you run a state machine, it becomes an actor. In the actor model, actors are objects that can talk to each other via asynchronous messages. In XState, we refer to these messages as [**events**](transitions.mdx).
 
-TODO: What are some good examples of actors in software development?
+Coming soon… what are some good examples of actors in software development?
 
 ## State
 
@@ -26,14 +26,14 @@ Actors can spawn new actors. Actors will spawn new actors in situations where th
 
 ## Backend development
 
-TODO: How do you use the actor model in backend dev? (Summary, maybe example)
+Coming soon… how do you use the actor model in backend dev? (Summary, maybe example)
 
 ## Frontend development
 
-TODO: How do you use the actor model in frontend dev? (Summary, maybe example)
+Coming soon… how do you use the actor model in frontend dev? (Summary, maybe example)
 
 ## XState
 
-TODO: How does the actor model work in XState? (Summary, link to further text)
+Coming soon… how does the actor model work in XState? (Summary, link to further text)
 
 ## Further resources

--- a/versioned_docs/version-5/actor-model.mdx
+++ b/versioned_docs/version-5/actor-model.mdx
@@ -35,5 +35,3 @@ Coming soon… how do you use the actor model in frontend dev? (Summary, maybe e
 ## XState
 
 Coming soon… how does the actor model work in XState? (Summary, link to further text)
-
-## Further resources

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -54,8 +54,6 @@ In the actor model, actors are objects that can talk to each other. They are ind
 - State is not shared between actors. The only way for an actor to share data is by sending events.
 - Actors can spawn new actors.
 
-## Stately Studio’s editor: actors
-
 ## Creating actors
 
 - `interpret(machine, options)`
@@ -125,6 +123,8 @@ function withUndoRedo(actorLogic) {
 
 ## Custom actors
 
+_Coming soon_
+
 ## Empty actors
 
 Actor that does nothing and only has a single emitted snapshot: `undefined`
@@ -137,6 +137,8 @@ const emptyActor = createEmptyActor();
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/context.mdx
+++ b/versioned_docs/version-5/context.mdx
@@ -34,9 +34,9 @@ feedbackActor.start();
 
 ## Using context in Stately Studio
 
-- TODO: Setting initial values
-- TODO: Updating context with assign
-- TODO: JS/TS export
+- Coming soon…  setting initial values
+- Coming soon…  updating context with assign
+- Coming soon…  JS/TS export
 
 ## Initial context
 
@@ -145,8 +145,6 @@ feedbackActor.send({
 ```
 
 ## TypeScript
-
-TODO: explain this example
 
 ```ts
 const machine = createMachine({

--- a/versioned_docs/version-5/context.mdx
+++ b/versioned_docs/version-5/context.mdx
@@ -219,5 +219,3 @@ const feedbackActor = interpret(machine, {
   },
 });
 ```
-
-## Further resources

--- a/versioned_docs/version-5/delayed-transitions.mdx
+++ b/versioned_docs/version-5/delayed-transitions.mdx
@@ -4,16 +4,47 @@ title: Delayed (after) transitions
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import SkipDownLink from '@site/src/components/SkipDownLink';
 
-**Delayed transitions** are transitions that only happen after a specified duration. If another event happens before the end of the timer, the transition doesn’t complete. Delayed transitions are handy if you need to build timeouts and intervals into your application logic.
+**Delayed transitions** are transitions that only happen after a set amount of time. Delayed transitions are handy for building timeouts and intervals into your application logic. If another event occurs before the end of the timer, the transition doesn’t complete.
 
-Delayed transitions are labeled “after” and often referred to as “after” transitions.
+Delayed transitions are defined on the `after` property in milliseconds. They are often referred to as “after” transitions.
+
+```ts
+import { createMachine } from 'xstate';
+
+const pushTheButtonGame = createMachine({
+  initial: 'waitingForButtonPush',
+  states: {
+    waitingForButtonPush: {
+      // highlight-start
+      after: {
+        5000: {
+          target: 'timedOut',
+          actions: 'logThatYouGotTimedOut',
+        },
+      },
+      // highlight-end
+      on: {
+        PUSH_BUTTON: {
+          actions: 'logSuccess',
+          target: 'success',
+        },
+      },
+    },
+    success: {},
+    timedOut: {},
+  },
+});
+```
 
 :::tip
 
 Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtube.com/watch?v=5RE_eazRhrw&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=12) (1m17s).
 
 :::
+
+<SkipDownLink text="Jump to learning more about delays in XState" link="#delays"/>
 
 <p>
   <ThemedImage
@@ -31,9 +62,11 @@ Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtu
 
 [View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=5671366b-05cf-43f5-a09a-b88373ea27c1).
 
-In a video player, we might want the video to be *Closed* out of fullscreen mode a few seconds after the video has *Stopped*, instead of closing the fullscreen mode suddenly as soon as the video is stopped. The eventless transition above transitions from the *Stopped* state to the *Closed* state after 5 seconds.
+In a video player, want the video to be *Closed* out of fullscreen mode a few seconds after the video has *Stopped*, instead of closing the fullscreen mode suddenly as soon as the video is stopped. The eventless transition above transitions from the *Stopped* state to the *Closed* state after 5 seconds.
 
 ## Using delayed transitions in Stately Studio
+
+In Stately Studio, delayed transitions are labeled “after.”
 
 ### Make an event into a delayed transition
 
@@ -51,18 +84,41 @@ First, select the event you want to replace with a delayed transition. Then…
 2. Choose **After** from the **Event type** dropdown menu.
 3. Specify the delay time in milliseconds using the **Delay** text input.
 
-Delayed transitions are taken after a set amount of time. They are defined on the `after` property:
-
-<!-- TODO: `{ after: ... }` -->
-
 ## Delays
 
-- Delays can be inlined as number, e.g. `after: { 1000: ... }`
-- Delays can be referenced; e.g. `after: { timeout: ... }`
-- `.provide({ delays })`
-- Can be defined as expression: `after: [{ delay: () => 1000, target: ... }]`
+You can define delays in a few ways: [inlined](#inlined-delays), [referenced](#referenced-delays), and [as an expression](#delay-expressions).
 
-## Delay references
+### Inlined delays
+
+- Inlined as number, for example `after: { 1000: ... }`
+
+### Reference delays
+
+- Referenced, for example `after: { timeout: ... }`
+
+- `.provide({ delays })`
+
+### Delay expressions
+
+The delay option can be evaluated as a delay expression. This function that takes in the current `context` and `event` that triggered the `send()` action and returns the resolved `delay` (in milliseconds).
+
+```ts
+`after: [{ delay: () => 1000, target: ... }]`
+```
+
+## Lifecycle
+
+Delayed transition timers are canceled when the state is exited.
+
+## Testing
+
+- Simulated clock
+
+## TypeScript
+
+## Cheatsheet
+
+Use our XState delayed transitions cheatsheet below to get started quickly.
 
 ```ts
 createMachine({
@@ -77,17 +133,5 @@ createMachine({
   },
 });
 ```
-
-## Lifecycle
-
-- Canceled when the state is exited
-
-## Testing
-
-- Simulated clock
-
-## TypeScript
-
-## Cheatsheet
 
 ## Resources

--- a/versioned_docs/version-5/delayed-transitions.mdx
+++ b/versioned_docs/version-5/delayed-transitions.mdx
@@ -116,6 +116,8 @@ Delayed transition timers are canceled when the state is exited.
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
 Use our XState delayed transitions cheatsheet below to get started quickly.
@@ -133,5 +135,3 @@ createMachine({
   },
 });
 ```
-
-## Resources

--- a/versioned_docs/version-5/developer-tools.mdx
+++ b/versioned_docs/version-5/developer-tools.mdx
@@ -27,8 +27,6 @@ Use the following command to run the typegen against a glob.
 
 `xstate typegen "src/**/*.ts?(x)"`
 
-<!-- TODO: add link below -->
-
 Running typegen will scan every targeted file and generate a typegen file to accompany it. It will also import the typegen into your file, as described in [our typegen documentation](typegen.mdx).
 
 :::caution
@@ -42,10 +40,6 @@ Ensure you wrap your glob in quotes for correct execution. If you don’t wrap t
 `xstate typegen "src/**/*.ts?(x)" --watch`
 
 Runs the task on a watch, monitoring for changed files and running the typegen script against them.
-
-## Chrome Devtools
-
-<!-- TODO: What are the Chrome devtools? -->
 
 ### Quick Start
 

--- a/versioned_docs/version-5/eventless-transitions.mdx
+++ b/versioned_docs/version-5/eventless-transitions.mdx
@@ -77,6 +77,8 @@ Coming soon… examples
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/eventless-transitions.mdx
+++ b/versioned_docs/version-5/eventless-transitions.mdx
@@ -67,13 +67,13 @@ You should define eventless transitions either with:
 
 If `target` is declared, the value should differ from the current state node.
 
-<!-- TODO: example `{ always: { ... } }` -->
+Coming soon… example `{ always: { ... } }`
 
 ## When to use
 
 Eventless transitions can be helpful when a state change is necessary, but there is no specific trigger for that change.
 
-<!-- TODO: examples -->
+Coming soon… examples
 
 ## TypeScript
 

--- a/versioned_docs/version-5/eventless-transitions.mdx
+++ b/versioned_docs/version-5/eventless-transitions.mdx
@@ -2,7 +2,9 @@
 title: Eventless (always) transitions
 ---
 
-**Eventless transitions** are transitions that are not enabled by an event. These transitions are *always* taken when the transition is enabled.
+import SkipDownLink from '@site/src/components/SkipDownLink';
+
+**Eventless transitions** are transitions that happen without an explicit event. These transitions are *always* taken when the transition is enabled.
 
 Eventless transitions are labeled “always” and often referred to as “always” transitions.
 
@@ -24,7 +26,9 @@ Eventless transitions are labeled “always” and often referred to as “alway
 }
 ```
 
-## Usign eventless transitions in Stately Studio
+<SkipDownLink text="Jump to learning more about eventless transitions in XState" link="#eventless-transitions-and-guards"/>
+
+## Using eventless transitions in Stately Studio
 
 ### Make an event into an eventless transition
 
@@ -40,15 +44,34 @@ First, select the event you want to replace with an eventless transition. Then�
 1. Open the **Transition details** panel from the right tool menu.
 2. Choose **Always** from the **Event type** dropdown menu.
 
-In statecharts, an eventless transition is a transition that occurs without an explicit event. They are taken immediately after normal transitions are taken, if they are enabled (that is, if their guards are true (LINK)).
+## Eventless transitions and guards
 
-They are useful for doing things when some condition is true.
+Eventless transitions are taken immediately after normal transitions are taken. They are only taken if enabled, for example, if their [guards](guards.mdx) are true. This makes eventless transitions helpful in doing things when some condition is true.
 
-Warning: avoid infinite loops by using guards.
+## Avoid infinite loops
+
+:::warningxstate
+
+Since unguarded “always” transitions always run, you should be careful not to create an infinite loop.
+
+:::
+
+Eventless transitions with no `target` nor `guard` will cause an infinite loop. Transitions using `guard` and `actions` may run into an infinite loop if its `guard` keeps returning true.
+
+You should define eventless transitions either with:
+
+- `target`
+- `guard` + `target`
+- `guard` + `actions`
+- `guard` + `target` + `actions`
+
+If `target` is declared, the value should differ from the current state node.
 
 <!-- TODO: example `{ always: { ... } }` -->
 
 ## When to use
+
+Eventless transitions can be helpful when a state change is necessary, but there is no specific trigger for that change.
 
 <!-- TODO: examples -->
 

--- a/versioned_docs/version-5/final-states.mdx
+++ b/versioned_docs/version-5/final-states.mdx
@@ -98,6 +98,8 @@ Done data, specified on `output`
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/finite-states.mdx
+++ b/versioned_docs/version-5/finite-states.mdx
@@ -6,8 +6,6 @@ A finite state is one of the possible states that a state machine can be in at a
 
 For example in a feedback form, you can be in a state where you are filling out the form, or a state where the form is being submitted. You cannot be filling out the form and submitting it at the same time; this is an "impossible state".
 
-TODO: add links below
-
 State machines always start at an [initial state](initial-states.mdx), and may end at a [final state](final-states.mdx). The state machine is always in a finite state.
 
 ```ts
@@ -35,9 +33,7 @@ const feedbackMachine = createMachine({
 });
 ```
 
-TODO: add link below
-
-You can combine finite states with [context](#), which make up the overall state of a machine:
+You can combine finite states with [context](context.mdx), which make up the overall state of a machine:
 
 ```ts
 const feedbackMachine = createMachine({
@@ -67,7 +63,7 @@ console.log(feedbackActor.getSnapshot().context);
 // logs { name: '', email: '', feedback: '' }
 ```
 
-TODO: `.getSnapshot()` and show `.value` and `.context`
+Coming soon… `.getSnapshot()` and show `.value` and `.context`
 
 ## Stately Studio’s editor: finite states
 
@@ -76,7 +72,7 @@ TODO: `.getSnapshot()` and show `.value` and `.context`
 - unreachable states
 - states with same key
 
-TODO: image
+Coming soon… image
 
 ## Initial state
 
@@ -285,10 +281,6 @@ const feedbackMachine = createMachine({
   },
 });
 ```
-
-TODO: add link below
-
-See [identifying states](#) for more information.
 
 ## Identifying state nodes
 

--- a/versioned_docs/version-5/finite-states.mdx
+++ b/versioned_docs/version-5/finite-states.mdx
@@ -65,12 +65,12 @@ console.log(feedbackActor.getSnapshot().context);
 
 Coming soon… `.getSnapshot()` and show `.value` and `.context`
 
-## Stately Studio’s editor: finite states
+## Finite states in Stately Studio
 
-- set initial state
-- change initial states
-- unreachable states
-- states with same key
+- Coming soon… set initial state
+- Coming soon… change initial states
+- Coming soon… unreachable states
+- Coming soon… states with same key
 
 Coming soon… image
 
@@ -104,7 +104,11 @@ A state node is a finite state that is defined by the `states` property on a mac
 
 ## Tags
 
+_Coming soon_
+
 ## Meta
+
+_Coming soon_
 
 ## Transitions
 
@@ -329,6 +333,8 @@ In statecharts, there are other types of states:
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/guards.mdx
+++ b/versioned_docs/version-5/guards.mdx
@@ -26,7 +26,7 @@ const feedbackMachine = createMachine({
 });
 ```
 
-## Editor: using guards
+## Using guards in Stately Studio
 
 <p>
   <ThemedImage

--- a/versioned_docs/version-5/guards.mdx
+++ b/versioned_docs/version-5/guards.mdx
@@ -44,7 +44,7 @@ In Stately Studio, guards are numbered in the order they are checked and labeled
 
 :::
 
-TODO: Why you might use a guard with example.
+Coming soon… Why you might use guards.
 
 ### Add a guard to an event
 
@@ -123,9 +123,7 @@ on: {
 
 ## In-state guards
 
-TODO: add link below
-
-Most useful for parallel states (TODO: link)
+Most useful for [parallel states](parallel-states.mdx):
 
 ```ts
 on: {
@@ -143,6 +141,8 @@ For simple guards: `guard: 'something'`
 
 ## TypeScript
 
+_Coming soon_.
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_.

--- a/versioned_docs/version-5/history-states.mdx
+++ b/versioned_docs/version-5/history-states.mdx
@@ -16,7 +16,7 @@ The history state can be deep or shallow:
 - A shallow history state remembers the immediate child’s state.
 - A deep history state remembers the deepest active state or states inside its child states.
 
-TODO: Why you might use a history state with example.
+Coming soon… Why you might use a history state.
 
 ## Using history states in Stately Studio
 
@@ -42,8 +42,6 @@ Essentially, this allows statecharts to "remember" where they left off when exit
 
 - If no child state remembered, history goes to `.target` state, if it is specified
 - Otherwise, go to [initial state](initial-states.mdx)
-
-## Stately Studio’s editor: History states
 
 ## Shallow vs. deep history
 
@@ -110,7 +108,3 @@ const machine = createMachine({
   },
 });
 ```
-
-## Resources
-
-_Coming soon_

--- a/versioned_docs/version-5/initial-states.mdx
+++ b/versioned_docs/version-5/initial-states.mdx
@@ -46,4 +46,4 @@ Each new machine or parent state will set the first new state as its initial sta
 2. Open the **State details** panel from the right tool menu.
 3. Choose the desired initial state from the Initial state dropdown menu.
 
-<!-- TODO: initial states in XState -->
+Coming soon… initial states in XState.

--- a/versioned_docs/version-5/input.mdx
+++ b/versioned_docs/version-5/input.mdx
@@ -331,5 +331,3 @@ const feedbackMachine = createMachine({
   // ...
 });
 ```
-
-## Further resources

--- a/versioned_docs/version-5/input.mdx
+++ b/versioned_docs/version-5/input.mdx
@@ -57,7 +57,7 @@ userFetcherActor.onDone((data) => {
 });
 ```
 
-TODO: show examples for `fromTransition`, `fromObservable`, etc.
+Coming soon… show examples for `fromTransition`, `fromObservable`, etc.
 
 ## Initial event input
 
@@ -222,12 +222,14 @@ const feedbackActor = interpret(feedbackMachine, {
 });
 ```
 
-- TODO: Usage with `@xstate/react`
-- TODO: Usage with `@xstate/vue`
-- TODO: Usage with `@xstate/svelte`
-- TODO: Usage with `@xstate/solid`
+- Coming soon… Usage with `@xstate/react`
+- Coming soon… Usage with `@xstate/vue`
+- Coming soon… Usage with `@xstate/svelte`
+- Coming soon… Usage with `@xstate/solid`
 
-TODO: Note: changing the input will not cause the actor to be restarted. You need to send an event to the actor to pass the new data to the actor:
+### Passing new data to an actor
+
+Changing the input will not cause the actor to be restarted. You need to send an event to the actor to pass the new data to the actor:
 
 ```tsx
 const Component = (props) => {

--- a/versioned_docs/version-5/installation.mdx
+++ b/versioned_docs/version-5/installation.mdx
@@ -56,7 +56,7 @@ actor.subscribe((state) => {
 actor.start();
 ```
 
-TODO: try it out (Codepen link)
+Coming soon… Codepen link.
 
 ## Exports
 

--- a/versioned_docs/version-5/invoke-done-events.mdx
+++ b/versioned_docs/version-5/invoke-done-events.mdx
@@ -6,7 +6,7 @@ An **invoke done event** transitions from a state once its invocation has been
 
 Coming soon… Why you might use invoke done events.
 
-### Create invoke done events
+### Create invoke done events in Stately Studio
 
 1. Select the state with an invoked actor where you want to add an invoke done event.
 2. Drag from the handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.

--- a/versioned_docs/version-5/invoke-done-events.mdx
+++ b/versioned_docs/version-5/invoke-done-events.mdx
@@ -4,7 +4,7 @@ title: Invoke done events
 
 An **invoke done event** transitions from a state once its invocation has been completed. An invoke done event is labeled “done:” followed by the invocation’s ID.
 
-<!-- TODO: Why you might use invoke done events with example -->
+Coming soon… Why you might use invoke done events.
 
 ### Create invoke done events
 

--- a/versioned_docs/version-5/invoke-error-events.mdx
+++ b/versioned_docs/version-5/invoke-error-events.mdx
@@ -6,7 +6,7 @@ An **invoke error event** transitions from a state when an error occurs in its
 
 Coming soon… Why you might use invoke error events.
 
-## How to create invoke error events
+## How to create invoke error events in Stately Studio
 
 1. Select the state with an invoked actor where you want to add an invoke error event.
 2. Drag from the handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.

--- a/versioned_docs/version-5/invoke-error-events.mdx
+++ b/versioned_docs/version-5/invoke-error-events.mdx
@@ -4,7 +4,7 @@ title: Invoke error events
 
 An **invoke error event** transitions from a state when an error occurs in its invocation. An invoke error event is labeled “error:” followed by the invocation’s ID.
 
-<!--TODO: Why you might use invoke error events with example-->
+Coming soon… Why you might use invoke error events.
 
 ## How to create invoke error events
 

--- a/versioned_docs/version-5/invoke.mdx
+++ b/versioned_docs/version-5/invoke.mdx
@@ -82,6 +82,8 @@ The actor snapshot is the latest emitted value from the actor. It can be read fr
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/invoke.mdx
+++ b/versioned_docs/version-5/invoke.mdx
@@ -6,11 +6,11 @@ XState is based on the [actor model](actors.mdx). Invoked actors are managed by 
 
 - Invoked actors are created and started when the state is entered, and stopped when the state is exited.
 
-<!-- TODO: invoking an actor: `{ invoke: { src: ... } }` -->
+Coming soon… invoking an actor: `{ invoke: { src: ... } }`.
 
 - Actors can also be invoked on the root of the machine. They last the lifetime of the machine
 
-<!-- TODO: example of invoking an actor at root -->
+Coming soon… example of invoking an actor at root.
 
 ## Stately Studio’s editor: Invoke
 

--- a/versioned_docs/version-5/machines.mdx
+++ b/versioned_docs/version-5/machines.mdx
@@ -64,7 +64,7 @@ feedbackActor.send({ type: 'feedback.good' });
 
 ## Interpreting machines
 
-A machine can be considered a "blueprint" for an actor. An [actor](actor.mdx) is a running instance of the machine; in other words, it is the entity whose logic is described by the machine.
+A machine can be considered a "blueprint" for an actor. An [actor](actors.mdx) is a running instance of the machine; in other words, it is the entity whose logic is described by the machine.
 
 To create an actor, interpret the machine using the `interpret(machine)` function:
 

--- a/versioned_docs/version-5/machines.mdx
+++ b/versioned_docs/version-5/machines.mdx
@@ -64,7 +64,7 @@ feedbackActor.send({ type: 'feedback.good' });
 
 ## Interpreting machines
 
-A machine can be considered a "blueprint" for an actor. An [actor](#todo) is a running instance of the machine; in other words, it is the entity whose logic is described by the machine.
+A machine can be considered a "blueprint" for an actor. An [actor](actor.mdx) is a running instance of the machine; in other words, it is the entity whose logic is described by the machine.
 
 To create an actor, interpret the machine using the `interpret(machine)` function:
 
@@ -200,16 +200,16 @@ const nextState = feedbackMachine.transition(initialState, {
 
 The `machine.transition(...)` method is useful for testing or building a custom interpreter.
 
-- [Testing](#todo)
-- [Custom interpreters](#todo)
+- [Testing](testing.mdx)
+- Coming soon… Custom interpreters
 
 ## API
 
-TODO: Link to API
+Coming soon… Link to API
 
 ## TypeScript
 
-TODO:
+_Coming soon_
 
 ## Machine cheatsheet
 
@@ -253,7 +253,3 @@ const machineWithImpls = machine.provide({
   },
 });
 ```
-
-### Further resources
-
-TODO:

--- a/versioned_docs/version-5/migration.mdx
+++ b/versioned_docs/version-5/migration.mdx
@@ -37,7 +37,7 @@ No more null events; use `always`
 
 No more `.withConfig()`; use `.provide()` instead
 
-No more `.withContext()`; use [input](#todo) instead
+No more `.withContext()`; use [input](input.mdx) instead
 
 Actions are now in predictable order
 

--- a/versioned_docs/version-5/parallel-states.mdx
+++ b/versioned_docs/version-5/parallel-states.mdx
@@ -59,6 +59,8 @@ First, select the parent state you want to set as a parallel state. Then…
 
 ## onDone transition
 
+_Coming soon_
+
 ## Modeling
 
 - Avoid transitions between regions
@@ -67,6 +69,8 @@ First, select the parent state you want to set as a parallel state. Then…
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/parent-states.mdx
+++ b/versioned_docs/version-5/parent-states.mdx
@@ -45,12 +45,20 @@ Using the **State details** panel:
 
 ## Root state
 
+_Coming soon_
+
 ## Initial state
+
+_Coming soon_
 
 ## Transitions on compound states
 
+_Coming soon_
+
 ## TypeScript
+
+_Coming soon_
 
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/projects.mdx
+++ b/versioned_docs/version-5/projects.mdx
@@ -98,7 +98,7 @@ You can move projects between your teams if you have an [**Owner**](teams.mdx#ow
 />
 </p>
 
-<!-- TODO: ### How to move a machine between projects -->
+Coming soon… How to move a machine between projects.
 
 ### Change a project’s visibility
 

--- a/versioned_docs/version-5/spawn.mdx
+++ b/versioned_docs/version-5/spawn.mdx
@@ -6,7 +6,9 @@ XState is based on the [actor model](actors.mdx). Spawned actors are managed by 
 
 Coming soon… example.
 
-## Stately Studio’s editor: spawning actors
+## Spawing actors in Stately Studio
+
+_Coming soon_
 
 ## API
 
@@ -44,6 +46,8 @@ actions: assign({
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/spawn.mdx
+++ b/versioned_docs/version-5/spawn.mdx
@@ -2,11 +2,9 @@
 title: 'Spawn'
 ---
 
-<!-- TODO: add link below -->
-
 XState is based on the [actor model](actors.mdx). Spawned actors are managed by the state machine.
 
-<!-- TODO: example -->
+Coming soon… example.
 
 ## Stately Studio’s editor: spawning actors
 

--- a/versioned_docs/version-5/state-done-events.mdx
+++ b/versioned_docs/version-5/state-done-events.mdx
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 A **state done event** transitions from a parent state when one of its child states reaches its final state. State done events are labeled “onDone.”
 
-<!-- TODO: write more about why you might use an onDone event -->
+Coming soon… why you might use an onDone event.
 
 :::tip
 

--- a/versioned_docs/version-5/states.mdx
+++ b/versioned_docs/version-5/states.mdx
@@ -112,7 +112,7 @@ A state machine with nested states (or *[statechart](state-machines-and-statecha
 
 The **state value** is an object that represents all the active state nodes in a machine. For state machines that have state nodes without child state nodes, the state value is a string:
 
-TODO: make this a visual example
+Coming soon… a visual example.
 
 - `state.value === 'question'`
 - `state.value === 'thanks'`
@@ -120,7 +120,7 @@ TODO: make this a visual example
 
 For state machines with parent state nodes, the state value is an object:
 
-TODO: make this a visual example
+Coming soon… a visual example.
 
 - `state.value === { form: 'invalid' }` - this represents a state machine with an active child node with key `form` that has an active child node with key `invalid`
 
@@ -138,7 +138,7 @@ State machines may also have no state nodes other than the root state node. For 
 
 ## State context
 
-State machines can have [context](#todo), which is an object that represents the extended state of the machine. The context is immutable, and can only be updated by [assigning](#todo) to it in an action. You can read the `state.context` property to get the current context.
+State machines can have [context](context.mdx), which is an object that represents the extended state of the machine. The context is immutable, and can only be updated by [assigning](actions.mdx#assign-action) to it in an action. You can read the `state.context` property to get the current context.
 
 ```ts
 const currentState = feedbackActor.getSnapshot();

--- a/versioned_docs/version-5/states.mdx
+++ b/versioned_docs/version-5/states.mdx
@@ -291,8 +291,12 @@ states: {
 
 ## TypeScript
 
+_Coming soon_
+
 ## Cheatsheet
+
+_Coming soon_
 
 ## Further resources
 
-- Persisting state
+[Persisting state](persistence.mdx)

--- a/versioned_docs/version-5/system.mdx
+++ b/versioned_docs/version-5/system.mdx
@@ -21,7 +21,7 @@ const actor = interpret(machine).start();
 actor.system;
 ```
 
-## Stately Studio’s editor: systems
+Coming soon… systems in Stately Studio’s editor
 
 ## Actor registration
 
@@ -112,4 +112,4 @@ const todosMachine = createMachine({
 
 ## Cheatsheet
 
-## Resources
+_Coming soon_

--- a/versioned_docs/version-5/testing.mdx
+++ b/versioned_docs/version-5/testing.mdx
@@ -2,10 +2,18 @@
 title: 'Testing'
 ---
 
-- Testing logic
+## Testing logic
 
-- Testing actors
+_Coming soon_
 
-- Mocking effects
+## Testing actors
 
-- Using `@xstate/test`
+_Coming soon_
+
+## Mocking effects
+
+_Coming soon_
+
+## Using `@xstate/test`
+
+_Coming soon_

--- a/versioned_docs/version-5/transitions.mdx
+++ b/versioned_docs/version-5/transitions.mdx
@@ -313,7 +313,9 @@ _Coming soon_
 
 ## Cheatsheet
 
-**Event objects**
+Use our XState events and transitions cheatsheet below to get started quickly.
+
+### Event objects
 
 ```ts
 feedbackActor.send({
@@ -325,7 +327,7 @@ feedbackActor.send({
 });
 ```
 
-**Transition targets**
+### Transition targets
 
 ```ts
 const machine = createMachine({
@@ -373,7 +375,3 @@ const machine = createMachine({
   },
 });
 ```
-
-## Resources
-
-_Coming soon_

--- a/versioned_docs/version-5/transitions.mdx
+++ b/versioned_docs/version-5/transitions.mdx
@@ -98,8 +98,6 @@ Transitions are selected by checking the deepest child states first. If the tran
 
 A state can transition to itself. This is known as a **self-transition**, and is useful for changing context and/or executing actions without changing the finite state. You can also use self-transitions to restart a state.
 
-TODO: Why you might use self-transitions with example.
-
 ### Using self-transitions in Stately Studio
 
 #### Make an event into a self-transition
@@ -113,8 +111,6 @@ TODO: Why you might use self-transitions with example.
 
 1. Select the event.
 2. Grab the circular handle at the arrow end of the transition and drag the handle to connect it back to the source state.
-
-TODO: assign example
 
 ## Transitions between states
 
@@ -142,13 +138,15 @@ const feedbackMachine = createMachine({
 });
 ```
 
+Coming soon… assign example
+
 ## Parent to child transitions
 
 When a state machine receives an event, it will first check the deepest ([atomic](state-machines-and-statecharts.mdx#atomic-states)) state to see if there is any enabled transition. If not, the parent state is checked, and so on, until the machine reaches the root state.
 
 When you want an event to transition to a state regardless of which sibling state is active, a useful pattern is to transition from the parent state to the child state.
 
-TODO: example with `{ on: { target: '.child' } }`
+Coming soon… example with `{ on: { target: '.child' } }`
 
 ## Re-entering
 
@@ -162,9 +160,9 @@ In XState v4, re-entering transitions were known as **external transitions**, an
 
 :::
 
-TODO: illustration showing no re-enter vs. re-enter
+Coming soon… illustration showing no re-enter vs. re-enter
 
-TODO: example with `{ target: '.child', reenter: true }`
+Coming soon…  example with `{ target: '.child', reenter: true }`
 
 ## Transitions to any state
 
@@ -256,16 +254,12 @@ Since parallel states have multiple regions that can be active at the same time,
 
 Multiple targets are specified as an array of strings:
 
-```ts
-import { createMachine } from 'xstate';
-
-// todo: example
-```
+Coming soon…  example.
 
 ## Other transitions
 
-- [Eventless (always) transitions](#todo) are transitions without events. These transitions are *always* taken after any transition in their state is enabled.
-- [Delayed (after) transitions](#todo) are transitions that are enabled after a specified duration.
+- [**Eventless (always) transitions**](eventless-transitions.mdx) are transitions without events. These transitions are *always* taken after any transition in their state is enabled.
+- [**Delayed (after) transitions**](delayed-transitions.mdx) are transitions that are enabled after a specified duration.
 
 ## Transition descriptions
 

--- a/versioned_docs/version-5/typegen.mdx
+++ b/versioned_docs/version-5/typegen.mdx
@@ -16,8 +16,6 @@ All you need to do is to install the [Stately XState extension](https://marketpl
 
 #### How to get started with the CLI (other editors)
 
-<!-- TODO: add link below -->
-
 Install the [CLI](developer-tools.mdx/#xstate-cli-command-line-interface) and run the `xstate typegen` command with the `--watch` flag.
 
 ### Typegen in action


### PR DESCRIPTION
Fleshed out:
- eventless transitions
- delayed transitions

Added links for all link todos.

Replaced todos with _coming soon_ and removed redundant `Resources`/`Further resources` until those resources exist.