### PR TITLE
Update migration.mdx for v5 migration `state.can()`

### DIFF
--- a/versioned_docs/version-5/migration.mdx
+++ b/versioned_docs/version-5/migration.mdx
@@ -317,6 +317,30 @@ actor.send('someEvent');
 
 ---
 
+String event types can no longer be sent to e.g. `state.can(event)`; you must send an event object instead:
+
+<Tabs>
+<TabItem value="v5" label="XState v5">
+
+```ts
+// ✅
+state.can({ type: 'someEvent' });
+```
+
+</TabItem>
+
+<TabItem value="v4" label="XState v4">
+
+```ts
+// ❌ DEPRECATED
+state.can('someEvent');
+```
+
+</TabItem>
+</Tabs>
+
+---
+
 Eventless ("always") events must now be defined through the `always: { ... }` property of a state node; they can no longer be defined via an empty string:
 
 <Tabs>


### PR DESCRIPTION
Add a similar section for `state.can()` to explain the need to pass an event object instead of an event string.