### PR TITLE
Adds embed component that follows the site color mode

### DIFF
--- a/docs/descriptions.mdx
+++ b/docs/descriptions.mdx
@@ -2,7 +2,6 @@
 title: Descriptions
 ---
 
-import ThemedImage from '@theme/ThemedImage';
 import EmbedMachine from '@site/src/components/EmbedMachine';
 
 You can add descriptions to state and event nodes to describe their purpose and share related notes with your team. Descriptions support markdown formatting, including links and images.
@@ -15,7 +14,7 @@ Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/wa
 
 The machine object will include your descriptions in the state or event's `description` when you export your statecharts to JSON.
 
-<p><EmbedMachine embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a" /></p>
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a" />
 
 In the video player above, the text “The video player should be in full-screen mode” is a description of the *Opened* event.
 

--- a/docs/descriptions.mdx
+++ b/docs/descriptions.mdx
@@ -3,6 +3,7 @@ title: Descriptions
 ---
 
 import ThemedImage from '@theme/ThemedImage';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 You can add descriptions to state and event nodes to describe their purpose and share related notes with your team. Descriptions support markdown formatting, including links and images.
 
@@ -15,13 +16,15 @@ Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/wa
 The machine object will include your descriptions in the state or event's `description` when you export your statecharts to JSON.
 
 <p>
-<ThemedImage
-  alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
-  sources={{
-    light: 'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.light.png',
-    dark: 'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.dark.png',
-  }}
-/>
+  <ThemedImage
+    alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
+    sources={{
+      light:
+        'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.light.png',
+      dark: 'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.dark.png',
+    }}
+  />
+  <EmbedMachine embedURL="https://dev.stately.ai/registry/editor/embed/66cd025f-18af-4b6c-91c2-44b526fe86b9?machineId=9f59bbf2-a3e1-4b9a-944f-93b94f395e2a" />
 </p>
 
 [View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a).
@@ -40,7 +43,7 @@ In the video player above, the text “The video player should be in full-screen
 2. Open the **Transition details** panel from the right tool menu.
 3. Write your event’s description in the **Description** text area.
 
-:::xstate 
+:::xstate
 
 ## Looking for how to use descriptions in XState?
 

--- a/docs/descriptions.mdx
+++ b/docs/descriptions.mdx
@@ -15,19 +15,7 @@ Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/wa
 
 The machine object will include your descriptions in the state or event's `description` when you export your statecharts to JSON.
 
-<p>
-  <ThemedImage
-    alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
-    sources={{
-      light:
-        'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.light.png',
-      dark: 'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.dark.png',
-    }}
-  />
-  <EmbedMachine embedURL="https://dev.stately.ai/registry/editor/embed/66cd025f-18af-4b6c-91c2-44b526fe86b9?machineId=9f59bbf2-a3e1-4b9a-944f-93b94f395e2a" />
-</p>
-
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a).
+<p><EmbedMachine embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a" /></p>
 
 In the video player above, the text “The video player should be in full-screen mode” is a description of the *Opened* event.
 

--- a/docs/state-machines-and-statecharts.mdx
+++ b/docs/state-machines-and-statecharts.mdx
@@ -2,6 +2,7 @@
 title: What are state machines and statecharts?
 ---
 
+import EmbedMachine from '@site/src/components/EmbedMachine';
 import ThemedImage from '@theme/ThemedImage';
 
 State machines help us model how a process goes from state to state when an event occurs.
@@ -10,18 +11,7 @@ State machines are useful in software development because they help us capture a
 
 State machines model your application logic. Below is the logic for a video player. When the video is Played, it is opened into fullscreen mode. When the video is stopped, it closes out of fullscreen mode. When the video player is in fullscreen mode, it can be _Playing_ or _Paused_.
 
-<p>
-  <ThemedImage
-    alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
-    sources={{
-      light:
-        'https://stately.ai/registry/machines/dbcfca1c-075d-4cd6-a865-efcbd7be1544.light.png',
-      dark: 'https://stately.ai/registry/machines/dbcfca1c-075d-4cd6-a865-efcbd7be1544.dark.png',
-    }}
-  />
-</p>
-
-[View the video player machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=dbcfca1c-075d-4cd6-a865-efcbd7be1544).
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=dbcfca1c-075d-4cd6-a865-efcbd7be1544"/>
 
 ## What is a statechart?
 

--- a/docs/states/final-states.mdx
+++ b/docs/states/final-states.mdx
@@ -2,7 +2,7 @@
 title: Final states
 ---
 
-import ThemedImage from '@theme/ThemedImage';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 When a machine reaches the final state, it can no longer receive any events, and anything running inside it is canceled and cleaned up. The box with a surrounding border icon represents the final state.
 
@@ -16,18 +16,7 @@ A machine can have multiple final states or no final states.
 
 In the video player below, *Stopped* is the final child state in the *Opened* state. When the video player is *Stopped*, the video player moves to its *Closed* state.
 
-<p>
-<ThemedImage
-  alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped, represented by an icon alongside the Stopped label of a square with a double border. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
-  sources={{
-    light: 'https://stately.ai/registry/machines/c6f8ca35-25e3-4fc6-b4fe-c9994715852e.light.png',
-    dark: 'https://stately.ai/registry/machines/c6f8ca35-25e3-4fc6-b4fe-c9994715852e.dark.png',
-  }}
-/>
-</p>
-
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=c6f8ca35-25e3-4fc6-b4fe-c9994715852e).
-
+<p><EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=c6f8ca35-25e3-4fc6-b4fe-c9994715852e" /></p>
 
 ## Make a state a final state
 

--- a/docs/states/intro.mdx
+++ b/docs/states/intro.mdx
@@ -2,7 +2,7 @@
 title: States
 ---
 
-import ThemedImage from '@theme/ThemedImage';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
 
@@ -12,18 +12,7 @@ Watch our [“What are states?” video on YouTube](https://www.youtube.com/watc
 
 :::
 
-<p>
-  <ThemedImage
-    alt="Video player state machine with an initial Paused state and a Playing state. There’s a warning on the playing state because there’s no transitions which means the playing state cannot be reached."
-    sources={{
-      light:
-        'https://stately.ai/registry/machines/741f69fd-7f01-4932-9407-6871e225bb6d.light.png',
-      dark: 'https://stately.ai/registry/machines/741f69fd-7f01-4932-9407-6871e225bb6d.dark.png',
-    }}
-  />
-</p>
-
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=741f69fd-7f01-4932-9407-6871e225bb6d).
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=741f69fd-7f01-4932-9407-6871e225bb6d"/>
 
 :::studio
 

--- a/docs/states/parallel-states.mdx
+++ b/docs/states/parallel-states.mdx
@@ -2,7 +2,7 @@
 title: Parallel states
 ---
 
-import ThemedImage from '@theme/ThemedImage';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 A parallel state is a state separated into multiple regions of child states, where each region is active simultaneously.
 
@@ -14,17 +14,7 @@ Watch our [“What are parallel states?” video on YouTube](https://www.youtube
 
 :::
 
-<p>
-<ThemedImage
-  alt="A state machine containing two region states with dashed borders around the outside. The first region is the video state which is active at the same time as the audio state, and contains a playing and stopped state, with stop and play events. The other region is an audio state, which is active at the same time as the video state, and has muted and unmuted states, and unmute and mute events."
-  sources={{
-    light: 'https://stately.ai/registry/machines/733de338-26cb-40a5-a0b5-b76bfc0405c3.light.png',
-    dark: 'https://stately.ai/registry/machines/733de338-26cb-40a5-a0b5-b76bfc0405c3.dark.png',
-  }}
-/>
-</p>
-
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=733de338-26cb-40a5-a0b5-b76bfc0405c3).
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=733de338-26cb-40a5-a0b5-b76bfc0405c3" />
 
 In the video player machine above, the video and audio states are active at the same time, which means the following combinations of states can happen simultaneously:
 

--- a/docs/states/parent-states.mdx
+++ b/docs/states/parent-states.mdx
@@ -2,7 +2,7 @@
 title: Parent states
 ---
 
-import ThemedImage from '@theme/ThemedImage';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 States can contain more states, also known as **child states**. These child states are only active when the parent state is active.
 
@@ -14,17 +14,7 @@ Watch our [“Parent and child states” video on YouTube](https://www.youtube.c
 
 :::
 
-<p>
-<ThemedImage
-  alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
-  sources={{
-    light: 'https://stately.ai/registry/machines/9ba5377c-aab3-4465-8909-4eea499622fa.light.png',
-    dark: 'https://stately.ai/registry/machines/9ba5377c-aab3-4465-8909-4eea499622fa.dark.png',
-  }}
-/>
-</p>
-
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa).
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa" />
 
 In the video player above, the *Opened* state is a parent state to the *Playing*, *Paused*, and *Stopped* states. These states, their transitions, and their events are nested inside the *Opened* state.
 

--- a/docs/transitions-and-events/intro.mdx
+++ b/docs/transitions-and-events/intro.mdx
@@ -2,8 +2,7 @@
 title: Transitions and events
 ---
 
-import ThemedImage from '@theme/ThemedImage';
-import useBaseUrl from '@docusaurus/useBaseUrl';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 A machine moves from state to state through **transitions**. Transitions are caused by events; when an event happens, the machine transitions to the next state.
 
@@ -17,17 +16,7 @@ Transitions are “deterministic”; each combination of state and event always 
 
 The arrows are transitions, and the rounded rectangles on the arrow’s lines are events. Each transition has a **source** state which comes before the transition, and a **target** state, which comes after the transition. The transition’s arrow starts from the source state and points to the target state.
 
-<p>
-<ThemedImage
-  alt="A video player state machine with an initial Paused State and a Playing state. The Play event transitions from Paused to Playing. The Pause event transitions from Playing to Paused."
-  sources={{
-    light: useBaseUrl('/transitions-and-events/intro/transitions-and-events.png'),
-    dark: useBaseUrl('/transitions-and-events/intro/transitions-and-events-dm.png'),
-  }}
-/>
-</p>
-
-[View this machine in the Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9630e3b7-9f8e-4dc9-8b55-661f854d28b7).
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9630e3b7-9f8e-4dc9-8b55-661f854d28b7"/>
 
 In the video player machine above, the events are *PLAY* and *PAUSE*. The *Play* event transitions from the *Paused* state to the *Playing* state. The *Pause* event transitions from the *Playing* state to the *Paused* state.
 

--- a/src/components/EmbedMachine/index.tsx
+++ b/src/components/EmbedMachine/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import styles from './styles.module.css';
 import { useColorMode } from '@docusaurus/theme-common';
 

--- a/src/components/EmbedMachine/index.tsx
+++ b/src/components/EmbedMachine/index.tsx
@@ -1,21 +1,37 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styles from './styles.module.css';
+import { useColorMode } from '@docusaurus/theme-common';
 
 type Embed = {
   name: string;
   embedURL: string;
 };
 
-export default function EmbedMachine({name, embedURL}: Embed) {
+export default function EmbedMachine({ name, embedURL }: Embed) {
+  const { colorMode } = useColorMode();
   return (
-    <p>
-        <iframe
-            loading="lazy"
-            src={embedURL}
-            className={styles.embed}
-        >
-            <a href={embedURL}>View the <em>{name}</em> machine in Stately Studio</a>.
-        </iframe>
-    </p>
+    <iframe
+      loading="lazy"
+      src={manageURL(embedURL, {
+        colorMode,
+      })}
+      className={styles.embed}
+    >
+      <a href={embedURL}>
+        View the <em>{name}</em> machine in Stately Studio
+      </a>
+      .
+    </iframe>
   );
+}
+
+function manageURL(
+  embedURL: string,
+  options?: { colorMode: 'light' | 'dark' },
+): string {
+  const url = new URL(embedURL);
+  for (const opt in options) {
+    url.searchParams.set(opt, options[opt]);
+  }
+  return url.toString();
 }

--- a/src/components/EmbedMachine/styles.module.css
+++ b/src/components/EmbedMachine/styles.module.css
@@ -1,4 +1,5 @@
 iframe.embed {
-    aspect-ratio: 6 / 4;
-    width: 100%;
+  display: block;
+  width: 100%;
+  aspect-ratio: 6 / 4;
 }

--- a/src/components/EmbedMachine/styles.module.css
+++ b/src/components/EmbedMachine/styles.module.css
@@ -1,5 +1,6 @@
 iframe.embed {
   display: block;
+  margin: 0 0 var(--ifm-paragraph-margin-bottom);
   width: 100%;
   aspect-ratio: 6 / 4;
 }

--- a/versioned_docs/version-5/about.mdx
+++ b/versioned_docs/version-5/about.mdx
@@ -8,6 +8,7 @@ hide_title: true
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 <div class="docs-intro">
 <div class="docs-intro-studio">
@@ -64,6 +65,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
     </a>
   </li>
 </ul>
+
+<EmbedMachine name="Default machine" embedURL="https://stately.ai/registry/editor/embed/5b170468-d66a-4136-84c8-676c8fea82e8?machineId=3e69d71f-1eda-41af-bee0-e82031d3f810" />
 
 ## Stately Studio or XState?
 

--- a/versioned_docs/version-5/descriptions.mdx
+++ b/versioned_docs/version-5/descriptions.mdx
@@ -2,7 +2,7 @@
 title: Descriptions
 ---
 
-import ThemedImage from '@theme/ThemedImage';
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 You can add descriptions to state and event nodes to describe their purpose and share related notes with your team. Descriptions support markdown formatting, including links and images.
 
@@ -16,7 +16,7 @@ Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/wa
 
 The machine object will include your descriptions in the state or event's `description` when you export your statecharts to JSON.
 
-<p><EmbedMachine embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a" /></p>
+<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a" />
 
 In the video player above, the text “The video player should be in full-screen mode” is a description of the *Opened* event.
 

--- a/versioned_docs/version-5/descriptions.mdx
+++ b/versioned_docs/version-5/descriptions.mdx
@@ -14,17 +14,9 @@ Watch our [“Using descriptions” video on YouTube](https://www.youtube.com/wa
 
 :::
 
-<p>
-<ThemedImage
-  alt="Video player state machine containing closed and opened states. On the Play event, the Closed state transitions to the Opened state. The Opened state invokes a startVideo actor and has a description of “The video player should be in full-screen mode.” The Opened state contains Playing and Paused states, which are transitioned between using the Pause and Play events. There’s a Stop event from the Opened state that transitions to the final state of Stopped. There’s a delayed transition from the Stopped state back to the Closed state after 5 seconds."
-  sources={{
-    light: 'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.light.png',
-    dark: 'https://stately.ai/registry/machines/574ede8a-a328-40fe-a4f9-c80fffb2c30a.dark.png',
-  }}
-/>
-</p>
+The machine object will include your descriptions in the state or event's `description` when you export your statecharts to JSON.
 
-[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a).
+<p><EmbedMachine embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=574ede8a-a328-40fe-a4f9-c80fffb2c30a" /></p>
 
 In the video player above, the text “The video player should be in full-screen mode” is a description of the *Opened* event.
 

--- a/versioned_docs/version-5/parent-states.mdx
+++ b/versioned_docs/version-5/parent-states.mdx
@@ -2,7 +2,7 @@
 title: Parent states
 ---
 
-import EmbedMachine from '@site/src/components/EmbedMachine'
+import EmbedMachine from '@site/src/components/EmbedMachine';
 
 States can contain more states, also known as **child states**. These child states are only active when the parent state is active.
 
@@ -15,8 +15,6 @@ Watch our [“Parent and child states” video on YouTube](https://www.youtube.c
 :::
 
 <EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa" />
-
-[View this machine in Stately Studio](https://stately.ai/registry/editor/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa).
 
 In the video player above, the *Opened* state is a parent state to the *Playing*, *Paused*, and *Stopped* states. These states, their transitions, and their events are nested inside the *Opened* state.
 

--- a/versioned_docs/version-5/state-machines-and-statecharts.mdx
+++ b/versioned_docs/version-5/state-machines-and-statecharts.mdx
@@ -2,8 +2,8 @@
 title: What are state machines and statecharts?
 ---
 
-import ThemedImage from '@theme/ThemedImage';
 import EmbedMachine from '@site/src/components/EmbedMachine';
+import ThemedImage from '@theme/ThemedImage';
 
 State machines help us model how a process goes from state to state when an event occurs.
 

--- a/versioned_docs/version-5/states.mdx
+++ b/versioned_docs/version-5/states.mdx
@@ -2,8 +2,8 @@
 title: State
 ---
 
-import SkipDownLink from '@site/src/components/SkipDownLink';
 import EmbedMachine from '@site/src/components/EmbedMachine';
+import SkipDownLink from '@site/src/components/SkipDownLink';
 
 A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
 

--- a/versioned_docs/version-5/transitions.mdx
+++ b/versioned_docs/version-5/transitions.mdx
@@ -2,9 +2,8 @@
 title: Events and transitions
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import SkipDownLink from '@site/src/components/SkipDownLink';
 import EmbedMachine from '@site/src/components/EmbedMachine';
+import SkipDownLink from '@site/src/components/SkipDownLink';
 
 A **transition** is a change from one finite state to another, triggered by an event.
 


### PR DESCRIPTION
https://github.com/statelyai/docs/assets/8332043/f21480ea-7f3c-4709-af8f-ff5b30f45a67

Sometimes the scroll jumps when color mode changes, but that seems to be irrelevant to the embedded iframe.

Closes https://linear.app/statelyai/issue/STA-3850