### PR TITLE
Add difference between invoke and spawn and cross-link relevant pages

### DIFF
--- a/versioned_docs/version-5/actor-model.mdx
+++ b/versioned_docs/version-5/actor-model.mdx
@@ -22,7 +22,8 @@ Actors communicate with other actors by sending and receiving events asynchronou
 
 Actors can spawn new actors. Actors will spawn new actors in situations where they need to delegate work to another actor or when they need to create a new actor to handle a new task. Spawning allows for a flexible and dynamic system where actors can be created and destroyed as needed to handle the workload efficiently.
 
-[Read more about spawning actors](spawn.mdx).
+- [Read more about spawning actors](spawn.mdx).
+- [Read about the difference between invoking and spawning actors](actors.mdx#invoking-and-spawning-actors).
 
 ## Backend development
 

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -42,7 +42,7 @@ An invoked actor represents a state-based actor, so it is stopped when the invok
 
 A spawned actor represents multiple entities that can be started at any time and stopped at any time. Spawed actors are action-based and used for a dynamic or unknown number of actors.
 
-An example of the difference between invoking and spawning actors could occur in a todo app. When saving todos, a `saveTodos` actor would be an invoked actor; it represents a state-based task. In comparison, each of the `n` todos can themselves be spawned actors.
+An example of the difference between invoking and spawning actors could occur in a todo app. When loading todos, a `loadTodos` actor would be an invoked actor; it represents a single state-based task. In comparison, each of the todos can themselves be spawned actors, and there can be a dynamic number of these actors.
 
 - [Read more about invoking actors](invoke.mdx)
 - [Read more about spawning actors](spawn.mdx)

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -8,6 +8,8 @@ When you run a state machine, it becomes an actor: a running process that can re
 
 An invoked actor is an actor that can execute its own actions and communicate with the machine. These invoked actors are started in a state and stopped when the state is exited.
 
+A spawned actor represents multiple entities that can be started at any time and stopped at any time. 
+
 :::tip
 
 Watch our [“What are invoked actors?” video on YouTube](https://www.youtube.com/watch?v=TRMS8NYKWnA&list=PLvWgkXBB3dd4I_l-djWVU2UGPyBgKfnTQ&index=9) (1m57s).
@@ -34,10 +36,16 @@ In the actor model, actors are objects that can talk to each other. They are ind
 - Starting actors via `actor.start()`
 - Stopping system actor via `actor.stop()`
 
-Inside machines:
+### Invoking and spawning actors
 
-- [invoke](invoke.mdx)
-- [spawn](spawn.mdx)
+An invoked actor represents a state-based actor, so it is stopped when the invoking state is exited. Invoked actors are used for a finite/known number of actors.
+
+A spawned actor represents multiple entities that can be started at any time and stopped at any time. Spawed actors are action-based and used for a dynamic or unknown number of actors.
+
+An example of the difference between invoking and spawning actors could occur in a todo app. When saving todos, a `saveTodos` actor would be an invoked actor; it represents a state-based task. In comparison, each of the `n` todos can themselves be spawned actors.
+
+- [Read more about invoking actors](invoke.mdx)
+- [Read more about spawning actors](spawn.mdx)
 
 ## Actor snapshots
 

--- a/versioned_docs/version-5/invoke.mdx
+++ b/versioned_docs/version-5/invoke.mdx
@@ -10,6 +10,10 @@ Coming soon… invoking an actor: `{ invoke: { src: ... } }`.
 
 Coming soon… example of invoking an actor at root.
 
+::: tip
+[Read about the difference between invoking and spawning actors](actors.mdx#invoking-and-spawning-actors).
+:::
+
 ## Using invoked actors in Stately Studio
 
 Invoked actors are are labeled on their invoking state with “Invoke /” followed by the actor’s source name and ID.

--- a/versioned_docs/version-5/spawn.mdx
+++ b/versioned_docs/version-5/spawn.mdx
@@ -6,6 +6,10 @@ XState is based on the [actor model](actors.mdx). Spawned actors are managed by 
 
 Coming soon… example.
 
+::: tip
+[Read about the difference between spawning and invoking actors](actors.mdx#invoking-and-spawning-actors).
+:::
+
 ## Spawing actors in Stately Studio
 
 _Coming soon_


### PR DESCRIPTION
This PR adds a more detailed explanation ([based on @davidkpiano’s explanation in Discord](https://discord.com/channels/795785288994652170/838444044774277151/1105318289778937897)) of the difference between invoking and spawning actors:

**Preview link: https://docs-mva9hmf0u-statelyai.vercel.app/xstate-v5/actors#invoking-and-spawning-actors**

The PR also links to this explanation from the actor model, invoke, and spawn pages.