### PR TITLE
Enable contextual search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,7 +76,7 @@ const config = {
               'warningxstate',
               'studio',
               'new',
-              'video'
+              'video',
             ],
           },
 
@@ -184,7 +184,7 @@ const config = {
         appId: 'BYNMHHN151',
         apiKey: 'e2fd3f2a7cd06067674996dd674fb241',
         indexName: 'stately',
-        contextualSearch: false,
+        contextualSearch: true,
         replaceSearchResultPathname:
           // Remove /docs from the search result pathname when we're in a preview deployment
           process.env.VERCEL_ENV === 'preview'


### PR DESCRIPTION
Enable contextual search now we have added versioned docs. This will make searching more predictable across the different versions of the docs. We have had [reports of the non-contextual search being confusing](https://discord.com/channels/795785288994652170/838444044774277151/1108573737256767558).