### PR TITLE
Add more spacing between tab panel + headings than tab panel + other content

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1498,6 +1498,11 @@ html[data-theme='dark'] [role='tabpanel'] .theme-code-block pre {
   border-top-left-radius: 0;
 }
 
+/* Add more space above headings that follow tab panels */
+.tabs-container + h2, .tabs-container + h3, .tabs-container + h4 {
+  margin-top: calc(var(--ifm-leading) * 3);
+}
+
 /* Footer */
 
 .footer {

--- a/src/theme/Tabs/styles.module.css
+++ b/src/theme/Tabs/styles.module.css
@@ -1,5 +1,5 @@
-.tabList {
-  margin-bottom: calc(var(--ifm-leading) * 3);
+.tabList + * {
+  margin-top: calc(var(--ifm-leading) * 1.5);
 }
 
 .tabItem {


### PR DESCRIPTION
This PR tweaks the CSS for tab panels, and headings that follow tab panels. Spacing between panels and headings is twice as much as the default spacing between panels and the following content.