### PR TITLE
Add lucide react to docs

### DIFF
--- a/docs/image.mdx
+++ b/docs/image.mdx
@@ -4,19 +4,21 @@ title: Share machine images using their image URL
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import { LinkIcon } from 'lucide-react';
 
 You can share an image of your machine anywhere that supports images. You can use the image URL for live-updating images where the machine is always updated with your latest changes. Machine images can be helpful in documentation, including GitHub pull requests.
 
 The image below is embedded using the copy image URL. Try switching between light and dark mode in the docs top bar; the image will change color mode too.
 
 <p>
-<ThemedImage
-  alt="State machine for the Copy image URL flow. An initial state of Viewing machine which transitions to Left drawer open via an event of Open left drawer. The use … icon event transitions from left drawer open to Machine options menu open."
-  sources={{
-    light: 'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.light.png',
-    dark: 'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png',
-  }}
-/>
+  <ThemedImage
+    alt="State machine for the Copy image URL flow. An initial state of Viewing machine which transitions to Left drawer open via an event of Open left drawer. The use … icon event transitions from left drawer open to Machine options menu open."
+    sources={{
+      light:
+        'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.light.png',
+      dark: 'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png',
+    }}
+  />
 </p>
 
 Your machine image will only be available if:
@@ -38,7 +40,7 @@ You can also [embed your machine](embed.mdx) for a focused non-editable view of 
 
 1. Open the **Machines** list from the left drawer menu.
 2. Use the **...** triple dot icon alongside your machine name to open the machine options menu.
-3. Use the **Copy image URL** option to copy the image URL to your clipboard.
+3. Use the <LinkIcon size={16} /> **Copy image URL** option to copy the image URL to your clipboard.
 4. Paste the URL wherever you want it used.
 
 <!-- TODO: add image illustrating above -->
@@ -60,5 +62,8 @@ The examples below show how you can use the image URL.
 ### HTML
 
 ```html
-<img src="https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png" alt="State machine for the copy image URL flow in dark mode." />
+<img
+  src="https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png"
+  alt="State machine for the copy image URL flow in dark mode."
+/>
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@xstate/react": "^3.0.1",
     "clsx": "^1.2.1",
     "docusaurus-plugin-api-extractor": "^2.0.4",
+    "lucide-react": "^0.129.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/versioned_docs/version-5/image.mdx
+++ b/versioned_docs/version-5/image.mdx
@@ -4,19 +4,21 @@ title: Share machine images using their image URL
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import { LinkIcon } from 'lucide-react';
 
 You can share an image of your machine anywhere that supports images. You can use the image URL for live-updating images where the machine is always updated with your latest changes. Machine images can be helpful in documentation, including GitHub pull requests.
 
 The image below is embedded using the copy image URL. Try switching between light and dark mode in the docs top bar; the image will change color mode too.
 
 <p>
-<ThemedImage
-  alt="State machine for the Copy image URL flow. An initial state of Viewing machine which transitions to Left drawer open via an event of Open left drawer. The use … icon event transitions from left drawer open to Machine options menu open."
-  sources={{
-    light: 'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.light.png',
-    dark: 'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png',
-  }}
-/>
+  <ThemedImage
+    alt="State machine for the Copy image URL flow. An initial state of Viewing machine which transitions to Left drawer open via an event of Open left drawer. The use … icon event transitions from left drawer open to Machine options menu open."
+    sources={{
+      light:
+        'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.light.png',
+      dark: 'https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png',
+    }}
+  />
 </p>
 
 Your machine image will only be available if:
@@ -37,7 +39,7 @@ You can also [embed your machine](embed.mdx) for a focused non-editable view of 
 
 1. Open the **Machines** list from the left drawer menu.
 2. Use the **...** triple dot icon alongside your machine name to open the machine options menu.
-3. Use the **Copy image URL** option to copy the image URL to your clipboard.
+3. Use the <LinkIcon size={16} /> **Copy image URL** option to copy the image URL to your clipboard.
 4. Paste the URL wherever you want it used.
 
 <!-- TODO: add image illustrating above -->
@@ -59,5 +61,8 @@ The examples below show how you can use the image URL.
 ### HTML
 
 ```html
-<img src="https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png" alt="State machine for the copy image URL flow in dark mode." />
+<img
+  src="https://stately.ai/registry/machines/1b050e43-c8a5-4e28-b881-71eadcc5b8a1.dark.png"
+  alt="State machine for the copy image URL flow in dark mode."
+/>
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -5370,6 +5370,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lucide-react@^0.129.0:
+  version "0.129.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.129.0.tgz#c0eeedd1f64c1e8bb8cd40a931204da9e50b043f"
+  integrity sha512-kGEZ+pOk9FLKsCr4luL4HYqr23lQdVbmN+3cgTj0Ye6s95FED3CX/DNzB3o8/TimgNmKKw+iq+g3mnTbtS7/ew==
+
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"


### PR DESCRIPTION
This PR adds the lucide icons react package to make it easy to use the same icons in the documentation as we do in the Studio.

I've only added the package and one icon as an example on the Copy Image URL page.
It adds the same link icon we use in the Studio.

<img width="705" alt="CleanShot 2023-05-23 at 14 32 21" src="https://github.com/statelyai/docs/assets/167574/d554d5a2-7a34-43a0-b3bd-9531c5accaf8">

Direct link to the preview deploy; https://docs-e1i1y6vca-statelyai.vercel.app/image#copy-the-image-url.
