### PR TITLE
Update examples docs page for new examples in xstate repo

### DIFF
--- a/versioned_docs/version-5/examples.mdx
+++ b/versioned_docs/version-5/examples.mdx
@@ -2,14 +2,7 @@
 title: XState examples
 ---
 
-XState v5 examples are available in the [`/examples` directory](https://github.com/statelyai/xstate/tree/next/examples), or on CodeSandbox:
-
-- [Simple fetch example](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/fetch)
-- [7GUIs counter (React)](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-7guis-counter)
-- [7GUIs temperature (React)](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-7guis-temperature)
-- [Simple list (React)](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-list)
-- [Tic-tac-toe game (React)](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-tic-tac-toe)
-- [TodoMVC (React)](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/todomvc-react)
+XState v5 beta examples are available in the [`/examples` directory](https://github.com/statelyai/xstate/tree/next/examples). Each example has a CodeSandbox link where you can run the example in your browser.
 
 **More examples are coming soon**. If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion.
 

--- a/versioned_docs/version-5/examples.mdx
+++ b/versioned_docs/version-5/examples.mdx
@@ -2,8 +2,121 @@
 title: XState examples
 ---
 
-XState v5 beta examples are available in the [`/examples` directory](https://github.com/statelyai/xstate/tree/next/examples). Each example has a CodeSandbox link where you can run the example in your browser.
+XState v5 beta examples are also available in the [`/examples` directory](https://github.com/statelyai/xstate/tree/next/examples). Each example has a CodeSandbox link where you can run the example in your browser.
+
+## Simple fetch example 
+
+A simple fetch example built with:
+
+- XState v5 beta
+- Parcel
+
+
+- [Simple fetch example on GitHub](https://github.com/statelyai/xstate/tree/next/examples/fetch)
+- [Simple fetch example on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/fetch)
+
+## 7GUIs counter (React) 
+
+An implementation of the [7GUIs counter](https://eugenkiss.github.io/7guis/tasks/#counter) built with:
+
+- XState v5 beta
+- React
+- TypeScript
+- Vite
+
+
+- [7GUIs counter (React) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/7guis-counter-react)
+- [7GUIs counter (React) on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-7guis-counter)
+
+## 7GUIs temperature (React) 
+
+This is an implementation of the [7GUIs temperature converter](https://eugenkiss.github.io/7guis/tasks#temp) built with:
+
+- XState v5 beta
+- React
+- TypeScript
+- Vite
+
+
+- [7GUIs temperature (React) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/7guis-temperature-react)
+- [7GUIs temperature (React) on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-7guis-temperature)
+
+## Simple list (React) 
+
+A React list built with:
+
+- XState v5 beta
+- React
+- TypeScript
+- Vite
+
+
+- [Simple list (React) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/friends-list-react)
+- [Simple list (React) on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-list)
+
+## Stopwatch
+
+A simple stopwatch built with:
+
+- XState v5 beta
+- TypeScript
+- Vite
+
+
+- [Stopwatch on GitHub](https://github.com/statelyai/xstate/tree/next/examples/stopwatch)
+- [Stopwatch on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/stopwatch)
+
+## Tic-tac-toe game (React) 
+
+An implementation of tic-tac-toe built with:
+
+- XState v5 beta
+- React
+- TypeScript
+- Vite
+
+
+- [Tic-tac-toe game (React) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/tic-tac-toe-react)
+- [Tic-tac-toe game (React) on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/react-tic-tac-toe)
+
+## Tiles game (React)
+
+A simple tiles game built with:
+
+- XState v5 beta
+- React
+- TypeScript
+- Vite
+
+
+- [Tiles game (React) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/tiles)
+- [Tiles game (React) on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/tiles)
+
+## TodoMVC (React) 
+
+An implementation of [TodoMVC](https://todomvc.com/) built with:
+
+- XState v5 beta
+- React
+- TypeScript
+- Vite
+
+
+- [TodoMVC (React) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/todomvc-react)
+- [TodoMVC (React) on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/todomvc-react)
+
+## Toggle
+
+A simple toggle built with:
+
+- XState v5 beta
+- TypeScript
+- Vite
+
+
+- [Toggle on GitHub](https://github.com/statelyai/xstate/tree/next/examples/toggle)
+- [Toggle on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/toggle)
 
 **More examples are coming soon**. If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion.
 
-If you have an example you want to share, [let us know on our Stately Discord](https://discord.gg/xstate).
+If you have an example you want to share, [contribute your example to the XState repository](https://github.com/statelyai/xstate/tree/next/examples#contributing-an-example).


### PR DESCRIPTION
@davidkpiano I see your example-links branch and raise you this!

I also want to add links to these machines in Stately Studio. We could even embed them in the page here (depending on the performance of multiple embeds) for maximum example-ness!