### PR TITLE
Update share images in blog front matter to fix URLs

### DIFF
--- a/blog/2022-03-11-xstate-vscode-extension-now-available-on-the-open-vsx-registry/index.mdx
+++ b/blog/2022-03-11-xstate-vscode-extension-now-available-on-the-open-vsx-registry/index.mdx
@@ -6,7 +6,8 @@ description: >-
   Registry.
 tags: [extension, open source, xstate, vscode]
 authors: [laura]
-image: share.png
+slug: /2022/03/11/xstate-vscode-extension-now-available-on-the-open-vsx-registry
+image: /blog/2022/03/11/xstate-vscode-extension-now-available-on-the-open-vsx-registry/share.png
 date: 2022-03-15
 ---
 

--- a/blog/2022-03-28-stately-is-hiring/index.mdx
+++ b/blog/2022-03-28-stately-is-hiring/index.mdx
@@ -4,7 +4,8 @@ description: We’re hiring for a frontend engineer, backend engineer, developer
 tags: [stately, hiring]
 authors: [laura]
 date: 2022-03-28
-image: share.png
+image: /blog/2022/03/28/stately-is-hiring/share.png
+slug: /2022/03/28/stately-is-hiring
 ---
 
 We’re hiring for a frontend engineer, backend engineer, developer advocate and product designer at Stately. You can [check out the Careers at Stately page on Notion](https://statelyai.notion.site/Careers-at-Stately-db3d704abd8f41058e5361e5ab9c1098).

--- a/blog/2022-04-05-building-a-video-player/index.mdx
+++ b/blog/2022-04-05-building-a-video-player/index.mdx
@@ -4,7 +4,8 @@ description: "A few weeks ago we uploaded a new video to the Stately YouTube cha
 tags: [xstate, modeling, tutorial]
 authors: [laura]
 date: 2022-04-05
-image: share.png
+slug: /2022/04/05/building-a-video-player
+image: /blog//2022/04/05/building-a-video-player/share.png
 ---
 
 A few weeks ago we uploaded a new video to the [Stately YouTube channel](http://youtube.com/c/statelyai) showing how you can build basic video player functionality using XState and Stately tools. You can watch the video below or [use the chapter links](/#video-chapters) to jump to the chapter you want to watch.

--- a/blog/2023-05-12-office-hours-64/index.mdx
+++ b/blog/2023-05-12-office-hours-64/index.mdx
@@ -18,7 +18,7 @@ tags:
 authors: [laura]
 date: 2023-05-12
 slug: office-hours-64
-image: share.png
+image: /blog/office-hours-64/share.png
 ---
 
 Two weeks ago, we had what some have called our “best office hours yet.” We introduced a whole bunch of new features and improvements to Stately Studio, including [state.new](https://state.new?source=blog) with our new starter machine, annotations, embed mode, and version history. We also gave the first peek at our most significant editor update to date; we call it “codename: blocks,” check out the video to find out why!

--- a/blog/2023-05-16-stately-streams/index.mdx
+++ b/blog/2023-05-16-stately-streams/index.mdx
@@ -5,7 +5,7 @@ tags: [stately, studio, xstate, xstate v5, stately stream, demo, examples ]
 authors: [farzad]
 date: 2023-05-16
 slug: stately-streams-may-2023
-image: share.png
+image: /blog/stately-streams-may-2023/share.png
 ---
 
 [Tomorrow is part four in our popular Stately Stream series](https://www.youtube.com/watch?v=sigMw-Xelvw), where we are modeling a semi-complex client-side app using XState, Stately Studio, React and TypeScript. You can catch up on the previous videos in the series below or [watch all our past videos in our Stately Streams YouTube playlist](https://www.youtube.com/playlist?list=PLvWgkXBB3dd5UEJZCk4C3Wn1Ys8WRMDbi).<!--truncate-->

--- a/blog/2023-05-18-explain-your-machines-with-annotations/index.mdx
+++ b/blog/2023-05-18-explain-your-machines-with-annotations/index.mdx
@@ -5,7 +5,7 @@ tags: [stately, studio, annotations, comments, teams]
 authors: [laura]
 publishedAt: 2023-05-18
 slug: explain-your-machines-with-annotations
-image: share.png
+image: /blog/explain-your-machines-with-annotations/share.png
 ---
 
 import EmbedMachine from '@site/src/components/EmbedMachine';

--- a/blog/2023-05-25-announcing-xstate-v5-beta/index.mdx
+++ b/blog/2023-05-25-announcing-xstate-v5-beta/index.mdx
@@ -4,7 +4,7 @@ description: We’re excited to announce the beta release of XState v5 and relat
 tags: [xstate, xstate v5, announcement, beta]
 authors: [david]
 slug: announcing-xstate-v5-beta
-image: share.png
+image: /announcing-xstate-v5-beta/share.png
 date: 2023-05-25
 ---
 

--- a/blog/2023-5-30-what-is-the-actor-model-and-when-should-i-use-it/index.mdx
+++ b/blog/2023-5-30-what-is-the-actor-model-and-when-should-i-use-it/index.mdx
@@ -13,7 +13,7 @@ tags:
   ]
 authors: [gavin]
 slug: what-is-the-actor-model
-image: share.png
+image: /blog/what-is-the-actor-model/share.png
 date: 2023-05-30
 ---
 


### PR DESCRIPTION
Some of the `image:` URLs in the blog frontmatter were missing the correct paths. Some of these posts also did not have `slug` defined in the frontmatter. This PR fixes this and should ensure the open graph images display correctly.