### PR TITLE
Reintroduces 'Edit this page on GitHub' for blog posts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,6 +89,8 @@ const config = {
           blogDescription: 'Stately’s engineering blog',
           blogSidebarCount: 0,
           postsPerPage: 'ALL',
+          editUrl: ({ locale, blogDirPath, blogPath, permalink }) =>
+            `https://github.com/statelyai/docs/edit/main/${blogDirPath}/${blogPath}`
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
I think in the past you had an edit link on blog posts. Recently you changed something so that Docusaurus handles the blog, right? I added a config, so that this feature is available again.