### PR TITLE
Add info on space-based indentation to the VS Code extension docs

### DIFF
--- a/docs/tools/xstate-vscode-extension.mdx
+++ b/docs/tools/xstate-vscode-extension.mdx
@@ -17,7 +17,7 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 1. Open the command palette with `shift` + `cmd/ctrl` + `p`.
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
-4. Ensure you have VS Code setup to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation); we have seen problems if tabs are used for indentation.
+4. Ensure you have [VS Code setup to insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation); we have noticed problems when tabs are used for indentation.
 
 Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
 

--- a/docs/tools/xstate-vscode-extension.mdx
+++ b/docs/tools/xstate-vscode-extension.mdx
@@ -71,6 +71,6 @@ This layout string is for persisting manual changes you make to the machine’s 
 
 :::caution
 
-**Caution**: if you use tab based-indentation in VS Code the extension might not work. Setup VS Code to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation) automatically.
+**Caution**: if you use tab based-indentation in VS Code the extension might not work. [Setup VS Code to insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation) automatically.
 
 :::

--- a/docs/tools/xstate-vscode-extension.mdx
+++ b/docs/tools/xstate-vscode-extension.mdx
@@ -4,7 +4,7 @@ title: 'XState VS Code extension'
 
 # XState VS Code extension
 
-The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VSCode.
+The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VS Code.
 
 :::tip
 
@@ -17,6 +17,7 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 1. Open the command palette with `shift` + `cmd/ctrl` + `p`.
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
+4. Ensure you have VS Code setup to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation); we have seen problems if tabs are used for indentation.
 
 Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
 
@@ -26,7 +27,7 @@ You can also [download the VS Code extension from the VS Code marketplace](https
 
 ## Features
 
-- **Visually edit machines**. Edit any XState machine with drag-and-drop using the integrated [Stately Studio visual editor](https://stately.ai/editor).
+- **Visually edit machines**. Edit any XState machine with drag-and-drop using the integrated [Stately Visual editor](https://stately.ai/editor).
 - **Autocomplete**. Intelligent suggestions for transition targets and initial states.
 - **Linting**. Highlights errors and potential bugs in your XState machine definitions.
 - **Jump to definition**. Navigate around machines easily with jump to definition on targets, actions, guards, actors and more.
@@ -56,7 +57,7 @@ createMachine({});
 
 ## Machine layout persistence
 
-Upon opening an XState machine in the VS Code editor, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
+Upon opening an XState machine in VS Code, you may notice a long `@xstate-layout` comment inserted in the code just above the call to `createMachine()`.
 
 ```js
 const machine =
@@ -65,5 +66,11 @@ createMachine({...});
 ```
 
 This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in Stately Studio’s editor.
+
+:::
+
+:::caution
+
+**Caution**: if you use tab based-indentation in VS Code the extension might not work. Setup VS Code to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation) automatically.
 
 :::

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -17,7 +17,7 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 1. Open the command palette with `shift` + `cmd/ctrl` + `p`.
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
-4. Ensure you have VS Code setup to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation); we have seen problems if tabs are used for indentation.
+4. Ensure you have [VS Code setup to insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation); we have noticed problems when tabs are used for indentation.
 
 Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
 

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -71,6 +71,6 @@ This layout string is for persisting manual changes you make to the machine’s 
 
 :::caution
 
-**Caution**: if you use tab based-indentation in VS Code the extension might not work. Setup VS Code to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation) automatically.
+**Caution**: if you use tab based-indentation in VS Code the extension might not work. [Setup VS Code to insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation) automatically.
 
 :::

--- a/versioned_docs/version-5/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-5/xstate-vscode-extension.mdx
@@ -17,6 +17,7 @@ If you don’t use VS Code but use an open source code editor that supports VS C
 1. Open the command palette with `shift` + `cmd/ctrl` + `p`.
 2. Search for the Install Extensions command and hit enter to open the Extensions search.
 3. Search for XState to find the XState VS Code extension and install the extension using the Install button.
+4. Ensure you have VS Code setup to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation); we have seen problems if tabs are used for indentation.
 
 Once installed, you can run `XState: Open Visual Editor` from the command palette to open any machine at your cursor’s location.
 
@@ -65,5 +66,11 @@ createMachine({...});
 ```
 
 This layout string is for persisting manual changes you make to the machine’s layout and is automatically updated by the XState Extension whenever layout changes occur. It is not intended to be human-readable nor manually edited. When updates to this string are made by the extension, the file is not saved until a manual save is performed. The layout algorithm is able to interpret this string and automatically format the machine's layout whenever it is re-opened in Stately Studio’s editor.
+
+:::
+
+:::caution
+
+**Caution**: if you use tab based-indentation in VS Code the extension might not work. Setup VS Code to [insert spaces](https://code.visualstudio.com/docs/editor/codebasics#_indentation) automatically.
 
 :::


### PR DESCRIPTION
This PR adds a word of caution to the extension docs about potential problems when using tab-based indentation. And suggests using space-based indentation instead, which is the VS Code default.

Direct link to changed pages:
v4: https://docs-git-mellson-sta-4383-add-info-on-space-ba-63f6a7-statelyai.vercel.app/docs/tools/xstate-vscode-extension
v5: https://docs-git-mellson-sta-4383-add-info-on-space-ba-63f6a7-statelyai.vercel.app/docs/xstate-v5/xstate-vscode-extension