### PR TITLE
Fix link broken when we changed the docs root directory

### DIFF
--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -27,7 +27,7 @@ Here you can find all the documentation for the Stately Studio and [XState](/xst
     </a>
   </li>
   <li>
-    <a className="link-box" href="xstate">
+    <a className="link-box" href="/docs/xstate">
       💻 <strong>Learn XState</strong> Get started with our JavaScript and
       TypeScript library for state machines and statecharts.
     </a>


### PR DESCRIPTION
Inspired by #148, thanks to @lauthieb for spotting the issue.