### PR TITLE
Improve meta titles and descriptions

### DIFF
--- a/blog/2021-05-27-global-state-xstate-react/index.mdx
+++ b/blog/2021-05-27-global-state-xstate-react/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to manage global state with XState and React
-description: ""
+description: "Everything you need to know to manage global state with XState and React."
 authors: [matt]
 date: 2021-05-27
 tags: [xstate, react, redux, webdev]

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -2,48 +2,58 @@ anders:
   name: Anders Bech Mellson
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/anders.png
   title: Stately Team
+  url: https://github.com/mellson
 
 david:
   name: David Khourshid
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/david.png
   title: Stately Team
+  url: https://github.com/davidkpiano
 
 farzad:
   name: Farzad Yousefzadeh
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/farzad.png
   title: Stately Team
+  url: https://github.com/farskid
 
 gavin:
   name: Gavin Bauman
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/gavin.png
   title: Stately Team
+  url: https://github.com/gavination
 
 jenny:
   name: Jenny Truong
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/jenny.png
   title: Stately Team
+  url: https://github.com/jenny-tru
 
 kevin:
   name: Kevin Maes
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/kevin.png
   title: Stately Team
+  url: https://github.com/kevinmaes
 
 laura:
   name: Laura Kalbag
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/laura.png
   title: Stately Team
+  url: https://github.com/laurakalbag
 
 mateusz:
   name: Mateusz Burzynski
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/mateusz.png
   title: Stately Team
+  url: https://github.com/Andarist
   
 matt:
   name: Matt Pocock
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/matt.png
   title: Stately Team
+  url: https://github.com/mattpocock
 
 nick:
   name: Nick Perich
   image_url: https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/avatars/nick.png
   title: Stately Team
+  url: https://github.com/cirephe

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -139,6 +139,10 @@
     "message": "{nDocsTagged} with “{tagName}”",
     "description": "The title of the page for a docs tag"
   },
+  "theme.blog.tagListPageDescription": {
+      "message": "From A-Z, browse all the tags used in the blog posts on the Stately Blog.",
+      "description": "The description of the page for the blog tags list"
+  },
   "theme.docs.versionBadge.label": {
     "message": "Version: {versionLabel}"
   },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -99,6 +99,10 @@
     "message": "{nPosts} tagged with “{tagName}”",
     "description": "The title of the page for a blog tag"
   },
+  "theme.blog.tagDescription": {
+    "message": "Browse all posts tagged with “{tagName}” on the Stately blog. {nPosts} tagged with “{tagName}.”",
+    "description": "The description of the page for a blog tag"
+  },
   "theme.tags.tagsPageLink": {
     "message": "View all tags",
     "description": "The label of the link targeting the tag list page"

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -96,7 +96,7 @@
     "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.blog.tagTitle": {
-    "message": "{nPosts} tagged with \"{tagName}\"",
+    "message": "{nPosts} tagged with “{tagName}”",
     "description": "The title of the page for a blog tag"
   },
   "theme.tags.tagsPageLink": {
@@ -132,7 +132,7 @@
     "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.docs.tagDocListPageTitle": {
-    "message": "{nDocsTagged} with \"{tagName}\"",
+    "message": "{nDocsTagged} with “{tagName}”",
     "description": "The title of the page for a docs tag"
   },
   "theme.docs.versionBadge.label": {
@@ -258,7 +258,7 @@
     "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.SearchPage.existingResultsTitle": {
-    "message": "Search results for \"{query}\"",
+    "message": "Search results for “{query}”",
     "description": "The search page title for non-empty query"
   },
   "theme.SearchPage.emptyResultsTitle": {

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -262,7 +262,7 @@
     "description": "The search page title for non-empty query"
   },
   "theme.SearchPage.emptyResultsTitle": {
-    "message": "Search the documentation",
+    "message": "Search the Stately documentation and blog",
     "description": "The search page title for empty query"
   },
   "theme.SearchPage.inputPlaceholder": {
@@ -378,7 +378,7 @@
     "description": "The text for the link to report missing results"
   },
   "theme.SearchModal.placeholder": {
-    "message": "Search docs",
+    "message": "Search docs and blog",
     "description": "The placeholder of the input of the DocSearch pop-up modal"
   }
 }

--- a/src/theme/BlogTagsListPage/index.js
+++ b/src/theme/BlogTagsListPage/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  translateTagsPageTitle,
+} from '@docusaurus/theme-common';
+import BlogLayout from '@theme/BlogLayout';
+import TagsListByLetter from '@theme/TagsListByLetter';
+import SearchMetadata from '@theme/SearchMetadata';
+function useBlogTagsPostsPageDescription() {
+  return translate(
+    {
+      id: 'theme.blog.tagListPageDescription',
+      description: 'The description of the page for a blog tag',
+      message: 'Browse all the tags used in the posts.',
+    },
+  );
+}
+
+export default function BlogTagsListPage({tags, sidebar}) {
+  const title = translateTagsPageTitle();
+  const description = useBlogTagsPostsPageDescription();
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.blogPages,
+        ThemeClassNames.page.blogTagsListPage,
+      )}>
+      <PageMetadata title={title} description={description} />
+      <SearchMetadata tag="blog_tags_list" />
+      <BlogLayout sidebar={sidebar}>
+        <h1>{title}</h1>
+        <TagsListByLetter tags={tags} />
+      </BlogLayout>
+    </HtmlClassNameProvider>
+  );
+}

--- a/src/theme/BlogTagsPostsPage/index.js
+++ b/src/theme/BlogTagsPostsPage/index.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate, {translate} from '@docusaurus/Translate';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  usePluralForm,
+} from '@docusaurus/theme-common';
+import Link from '@docusaurus/Link';
+import BlogLayout from '@theme/BlogLayout';
+import BlogListPaginator from '@theme/BlogListPaginator';
+import SearchMetadata from '@theme/SearchMetadata';
+import BlogPostItems from '@theme/BlogPostItems';
+// Very simple pluralization: probably good enough for now
+function useBlogPostsPlural() {
+  const {selectMessage} = usePluralForm();
+  return (count) =>
+    selectMessage(
+      count,
+      translate(
+        {
+          id: 'theme.blog.post.plurals',
+          description:
+            'Pluralized label for "{count} posts". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One post|{count} posts',
+        },
+        {count},
+      ),
+    );
+}
+function useBlogTagsPostsPageTitle(tag) {
+  const blogPostsPlural = useBlogPostsPlural();
+  return translate(
+    {
+      id: 'theme.blog.tagTitle',
+      description: 'The title of the page for a blog tag',
+      message: '{nPosts} tagged with "{tagName}"',
+    },
+    {nPosts: blogPostsPlural(tag.count), tagName: tag.label},
+  );
+}
+function useBlogTagsPostsPageDescription(tag) {
+  const blogPostsPlural = useBlogPostsPlural();
+  return translate(
+    {
+      id: 'theme.blog.tagDescription',
+      description: 'The description of the page for a blog tag',
+      message: 'Browse all posts tagged with "{tagName}". {nPosts} found.',
+    },
+    {nPosts: blogPostsPlural(tag.count), tagName: tag.label},
+  );
+}
+function BlogTagsPostsPageMetadata({tag}) {
+  const title = useBlogTagsPostsPageTitle(tag);
+  const description = useBlogTagsPostsPageDescription(tag);
+  return (
+    <>
+      <PageMetadata title={title} description={description} />
+      <SearchMetadata tag="blog_tags_posts" />
+    </>
+  );
+}
+function BlogTagsPostsPageContent({tag, items, sidebar, listMetadata}) {
+  const title = useBlogTagsPostsPageTitle(tag);
+  return (
+    <BlogLayout sidebar={sidebar}>
+      <header className="margin-bottom--xl">
+        <h1>{title}</h1>
+
+        <Link href={tag.allTagsPath}>
+          <Translate
+            id="theme.tags.tagsPageLink"
+            description="The label of the link targeting the tag list page">
+            View All Tags
+          </Translate>
+        </Link>
+      </header>
+      <BlogPostItems items={items} />
+      <BlogListPaginator metadata={listMetadata} />
+    </BlogLayout>
+  );
+}
+export default function BlogTagsPostsPage(props) {
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.blogPages,
+        ThemeClassNames.page.blogTagPostListPage,
+      )}>
+      <BlogTagsPostsPageMetadata {...props} />
+      <BlogTagsPostsPageContent {...props} />
+    </HtmlClassNameProvider>
+  );
+}


### PR DESCRIPTION
This PR:

- Adds GitHub links for each of the blog authors
- Improves the search page title
- Adds one missing blog post description
- Adds curly quotes in list page titles
- Adds meta description to single Tag list pages 
- Adds meta description to blog tags list page

Commits from the last two additions will be helpful examples for implementing meta descriptions for more templates in the future if necessary, as the descriptions are added to the templates but are maintained/changeable through the i18n file.