### PR TITLE
Update privacy policy hosting info

### DIFF
--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -5,7 +5,7 @@ image: share-image-privacy.png
 
 # Privacy policy
 
-Last updated May 2023, changing how we use [Canny](#roadmap) for Stately Studio’s changelog, add more providers to [authentication](#authentication), and how we use [Crisp](#support) for support emails.
+Last updated June 2023, changing our [hosting](#hosting) as we no longer use Netlify.
 
 ## Analytics
 
@@ -41,13 +41,17 @@ We use GitHub, Google, and Twitter for authentication so you can sign into our p
 
 ## Hosting
 
-We use Netlify to host our [stately.ai website](http://stately.ai). We do not use Netlify to collect any information about you.
-
-We use GitHub to host our repositories and GitHub Pages to host our documentation. We do not use GitHub to collect any information about you.
+We use GitHub to host our repositories and GitHub Pages to host our legacy documentation. We do not use GitHub to collect any information about you.
 
 [GitHub’s privacy statement](https://docs.github.com/en/github/site-policy/github-privacy-statement#github-privacy-statement).
 
-We use Vercel to host our platform and API. Vercel collects activity logs which includes your user agent information to help us understand where we need to fix bugs. We do not use Vercel to collect any further information about you.
+We use Vercel to host:
+
+- [stately.ai website](https://stately.ai)
+- [our docs and blog](https:stately.ai/docs)
+- our platform and API
+
+Vercel collects activity logs which includes your user agent information to help us understand where we need to fix bugs. We do not use Vercel to collect any further information about you.
 
 [Vercel’s privacy policy](https://vercel.com/legal/privacy-policy).
 


### PR DESCRIPTION
Removing Netlify and specifying that we use Vercel to host nearly everything else.

https://linear.app/statelyai/issue/STA-4465