### PR TITLE
Replace YouTube videos with embedded videos in latest blog post

### DIFF
--- a/blog/2023-06-14-supercharge-the-canvas/index.mdx
+++ b/blog/2023-06-14-supercharge-the-canvas/index.mdx
@@ -50,7 +50,7 @@ Being able to stay on the canvas keeps you closer to your content, lets interact
 
 For example, we enhanced the Edit Menu to support adding [actions](/docs/xstate-v5/actions#using-actions-in-stately-studio), tags, and other data to [states](/docs/xstate-v5/states#using-states-in-stately-studio) and [transitions](/docs/xstate-v5/transitions#using-transitions-and-events-in-stately-studio). And most items on the canvas can then be edited directly.
 
-<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4" width="720" controls poster="">
+<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/create-from-canvas.mp4" width="720" controls preload="none">
   <p><a href="https://youtube.com/watch?v=ck9uGikxJ8k">Watch this video on YouTube.</a></p>
 </video>
 
@@ -153,7 +153,7 @@ Because color will be used in diagrams in dynamic and varied ways, we implemente
 
 Set a color by selecting a state or transition and choosing the one you want from the Edit Menu above it. You can set colors separately on states and on transitions. Effect blocks and other attached details inherit their color. 
 
-<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4" width="720" controls poster="">
+<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4" width="720" controls preload="none">
   <p><a href="https://youtube.com/watch?v=Yiij2FaGSd0">Watch this video on YouTube.</a></p>
 </video>
 

--- a/blog/2023-06-14-supercharge-the-canvas/index.mdx
+++ b/blog/2023-06-14-supercharge-the-canvas/index.mdx
@@ -50,7 +50,9 @@ Being able to stay on the canvas keeps you closer to your content, lets interact
 
 For example, we enhanced the Edit Menu to support adding [actions](/docs/xstate-v5/actions#using-actions-in-stately-studio), tags, and other data to [states](/docs/xstate-v5/states#using-states-in-stately-studio) and [transitions](/docs/xstate-v5/transitions#using-transitions-and-events-in-stately-studio). And most items on the canvas can then be edited directly.
 
-<YouTube id="ck9uGikxJ8k" />
+<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4" width="720" controls poster="">
+  <p><a href="https://youtube.com/watch?v=ck9uGikxJ8k">Watch this video on YouTube.</a></p>
+</video>
 
 ## Effect blocks make it easy to say what happens when
 
@@ -151,7 +153,9 @@ Because color will be used in diagrams in dynamic and varied ways, we implemente
 
 Set a color by selecting a state or transition and choosing the one you want from the Edit Menu above it. You can set colors separately on states and on transitions. Effect blocks and other attached details inherit their color. 
 
-<YouTube id="Yiij2FaGSd0" />
+<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4" width="720" controls poster="">
+  <p><a href="https://youtube.com/watch?v=Yiij2FaGSd0">Watch this video on YouTube.</a></p>
+</video>
 
 Colors are just for Pro subscribers. So if you haven’t signed up yet, [try it out with a free 30-day trial](https://stately.ai/pricing)!
 

--- a/blog/2023-06-14-supercharge-the-canvas/index.mdx
+++ b/blog/2023-06-14-supercharge-the-canvas/index.mdx
@@ -50,7 +50,7 @@ Being able to stay on the canvas keeps you closer to your content, lets interact
 
 For example, we enhanced the Edit Menu to support adding [actions](/docs/xstate-v5/actions#using-actions-in-stately-studio), tags, and other data to [states](/docs/xstate-v5/states#using-states-in-stately-studio) and [transitions](/docs/xstate-v5/transitions#using-transitions-and-events-in-stately-studio). And most items on the canvas can then be edited directly.
 
-<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/create-from-canvas.mp4" width="720" controls preload="none">
+<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/create-from-canvas.mp4#t=0.1" width="720" controls preload="metadata">
   <p><a href="https://youtube.com/watch?v=ck9uGikxJ8k">Watch this video on YouTube.</a></p>
 </video>
 
@@ -153,7 +153,7 @@ Because color will be used in diagrams in dynamic and varied ways, we implemente
 
 Set a color by selecting a state or transition and choosing the one you want from the Edit Menu above it. You can set colors separately on states and on transitions. Effect blocks and other attached details inherit their color. 
 
-<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4" width="720" controls preload="none">
+<video src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/colors-2.mp4#t=0.1" width="720" controls preload="metadata">
   <p><a href="https://youtube.com/watch?v=Yiij2FaGSd0">Watch this video on YouTube.</a></p>
 </video>
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1649,6 +1649,13 @@ html[data-theme='dark'] [role='tabpanel'] .theme-code-block pre {
   border-top-left-radius: 0;
 }
 
+/* Videos */
+
+video {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Blog */
 
 ul.blog-list {


### PR DESCRIPTION
This PR updates the videos in the latest blog post so they:

- Use the browser’s native `<video>` player
- MP4 files are hosted in a dedicated Supabase bucket so we don’t need to store them in our repo

Preview the videos in the post at https://docs-git-laurakalbag-sta-4559-embed-videos-in-392283-statelyai.vercel.app/blog/supercharge-the-canvas