### PR TITLE
Update and match Pro features on v4 and v5 docs

### DIFF
--- a/blog/2022-07-06-whats-new-july-2022/index.mdx
+++ b/blog/2022-07-06-whats-new-july-2022/index.mdx
@@ -42,9 +42,9 @@ We’ve got many more features coming up. Watch [our office hours from last week
 
 ## Suggest features and help us prioritize our roadmap
 
-We’ve also started using Canny to collect your feedback and help us prioritize planned features in the last month. If there’s anything you want from XState or our Stately tools, please create a post or [upvote and give feedback on proposed features](https://statelyai.canny.io).
+We’ve also started using Canny to collect your feedback and help us prioritize planned features in the last month. If there’s anything you want from XState or our Stately tools, please create a post or [upvote and give feedback on proposed features](https://feedback.stately.ai).
 
-Visit [our Canny roadmap](https://statelyai.canny.io) to make feature requests, submit feedback, view the roadmap and vote on features.
+Visit [our Canny roadmap](https://feedback.stately.ai) to make feature requests, submit feedback, view the roadmap and vote on features.
 
 ![The Stately roadmap showing options to give feedback on the Editor, XState, Documentation, Workflows, Devtools and Registry, as well as a roadmap showing Planned, In Progress and Complete features](2022-07-06-canny.png)
 

--- a/blog/2022-10-18-stately-studio-1-0/index.mdx
+++ b/blog/2022-10-18-stately-studio-1-0/index.mdx
@@ -16,7 +16,7 @@ We’re excited to announce the release of Stately Studio 1.0! 🚀 Our mission 
 
 Earlier this year, we released [the first beta of Stately Editor & Stately Registry](/blog/2022-2-6-stately-editor-public-beta/index.mdx) (together called the Stately Studio). We also released [Stately Viz](https://stately.ai/viz), a visualizer for XState machines, and the [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode). Since then, over 10,000 of you have tried our tools out, creating and sharing tens of thousands of machines (we don’t know the exact number because machines built with the extension are always private!) 
 
-Thank you for giving our tools a go and for all the valuable feedback you’ve given us; we’ve been blown away by the response. We’re listening and continuing to improve the Stately Studio. As always, you can [create and upvote feature requests on our Canny roadmap](https://statelyai.canny.io).
+Thank you for giving our tools a go and for all the valuable feedback you’ve given us; we’ve been blown away by the response. We’re listening and continuing to improve the Stately Studio. As always, you can [create and upvote feature requests on our Canny roadmap](https://feedback.stately.ai).
 
 ## Teams
 
@@ -62,7 +62,7 @@ You asked, and we listened (we’re currently in the listening state). We’ve a
 - SVG, PNG, PDF
 - And others 
 
-[Request your favorite export options on our Canny roadmap](https://statelyai.canny.io).
+[Request your favorite export options on our Canny roadmap](https://feedback.stately.ai).
 
 ![The code popover panel showing over a video player machine. The Code options are JSON, JavaScript and TypeScript. The JavaScript option is selected, alongside a button to copy to clipboard. The code is shown in a text area below as JavaScript object describing the video player machine.](studio-1-0-export.png)
 

--- a/blog/2022-10-27-studio-tutorials/index.mdx
+++ b/blog/2022-10-27-studio-tutorials/index.mdx
@@ -64,4 +64,4 @@ Each video explains a concept with an example machine and shows you how to use t
 
 ## More videos coming soon
 
-We’ll be adding more videos to the playlist very soon! Do you want us to make tutorials for a concept you need help understanding? Or how to use a particular feature in the Stately Studio? [Leave us a request on our Canny roadmap](https://statelyai.canny.io).
+We’ll be adding more videos to the playlist very soon! Do you want us to make tutorials for a concept you need help understanding? Or how to use a particular feature in the Stately Studio? [Leave us a request on our Canny roadmap](https://feedback.stately.ai).

--- a/blog/2022-11-22-studio-update/index.mdx
+++ b/blog/2022-11-22-studio-update/index.mdx
@@ -26,7 +26,7 @@ You can now log into the Stately Studio with Twitter or Google, or set up an acc
 
 ![The Stately Studio sign up page with login options for GitHub, Google, Twitter, as well as email address and password fields for sign up.](2022-11-22-studio-update-login-providers.png)
 
-Are there any login providers we should add? Please let us know as a [feature request on our Studio board](https://statelyai.canny.io/studio). Many options are available to us, and we aim to support the community’s most popular providers.
+Are there any login providers we should add? Please let us know as a [feature request on our Studio board](https://feedback.stately.ai/studio). Many options are available to us, and we aim to support the community’s most popular providers.
 
 ## More editor improvements
 
@@ -44,4 +44,4 @@ If you want to keep up with the team’s latest work-in-progress, [subscribe to 
 
 ## Request the features you want
 
-If you’ve watched [our office hours](https://www.youtube.com/watch?v=JBckQTgeD9g&list=PLvWgkXBB3dd6PXbSoctwDXjWX-AQrxhds), you know the team listens to every feature request and loves to make our community happy. You can request features, upvote other people’s suggestions, and check out what’s in progress on [our Canny roadmap](https://statelyai.canny.io).
+If you’ve watched [our office hours](https://www.youtube.com/watch?v=JBckQTgeD9g&list=PLvWgkXBB3dd6PXbSoctwDXjWX-AQrxhds), you know the team listens to every feature request and loves to make our community happy. You can request features, upvote other people’s suggestions, and check out what’s in progress on [our Canny roadmap](https://feedback.stately.ai).

--- a/blog/2022-11-29-import-from-code/index.mdx
+++ b/blog/2022-11-29-import-from-code/index.mdx
@@ -28,7 +28,7 @@ Your code should be formatted as a [`createMachine()` factory function](https://
 
 ![Left drawer open in the Studio showing the Machines list New machine dialog with the Import Code slider switched on. There’s JavaScript already in the text area and the cursor is hovering over the Create machine button.](2022-11-29-import-from-code-create-machine.png)
 
-And please import your code into an existing machine with caution! Importing code from the code panel will overwrite the current machine in the editor. You may have multiple `createMachine`s included in the code you insert in the text area, but the Studio will currently only import the first machine found in the code. We plan to support importing multiple machines in the future, if that’s a feature you’d love, please [upvote the multiple machine import feature request](https://statelyai.canny.io/editor/p/import-multiple-machines-from-one-code-import) on our board.
+And please import your code into an existing machine with caution! Importing code from the code panel will overwrite the current machine in the editor. You may have multiple `createMachine`s included in the code you insert in the text area, but the Studio will currently only import the first machine found in the code. We plan to support importing multiple machines in the future, if that’s a feature you’d love, please [upvote the multiple machine import feature request](https://feedback.stately.ai/editor/p/import-multiple-machines-from-one-code-import) on our board.
 
 ![Import Code modal. There’s JavaScript formatted as a createMachine factory function inside the text area. A warning at the top of the dialog warns you that importing from JSON will overwrite all data in “My new machine”.](2022-11-29-import-from-code-importer.png)
 
@@ -40,4 +40,4 @@ Using the export icon button in the editor’s top bar, you can also export as c
 
 ## Please give us your feedback!
 
-Have you used the import and export features yet? We’d love to hear your thoughts! The team loves hearing your feedback [on our Stately Discord](https://discord.gg/xstate) or during our next [office hours live stream](https://youtube.com/statelyai). If you have any feature requests, please add them to our [feature request board](https://statelyai.canny.io), and we’ll keep you updated if it’s planned, in progress, or complete!
+Have you used the import and export features yet? We’d love to hear your thoughts! The team loves hearing your feedback [on our Stately Discord](https://discord.gg/xstate) or during our next [office hours live stream](https://youtube.com/statelyai). If you have any feature requests, please add them to our [feature request board](https://feedback.stately.ai), and we’ll keep you updated if it’s planned, in progress, or complete!

--- a/blog/2023-01-19-introducing-the-stately-docs/index.mdx
+++ b/blog/2023-01-19-introducing-the-stately-docs/index.mdx
@@ -45,6 +45,6 @@ At the end of every page, we have an **Edit this page on GitHub** link, which ta
 
 ## Still in beta
 
-These docs are still in beta, and we want your feedback! At Stately, we care a great deal about accessible and valuable education. Our docs are a living iterable product, and we want to continuously improve them to make them as valuable a resource as possible. Please [let us know in Discord](https://discord.gg/xstate) or [on Twitter](https://twitter.com/statelyai) if you have suggestions for improvements or where we could make the docs clearer or better for you. Use [our Canny documentation request board](https://statelyai.canny.io/docs) if you have a page, feature, or example request. 
+These docs are still in beta, and we want your feedback! At Stately, we care a great deal about accessible and valuable education. Our docs are a living iterable product, and we want to continuously improve them to make them as valuable a resource as possible. Please [let us know in Discord](https://discord.gg/xstate) or [on Twitter](https://twitter.com/statelyai) if you have suggestions for improvements or where we could make the docs clearer or better for you. Use [our Canny documentation request board](https://feedback.stately.ai/docs) if you have a page, feature, or example request. 
 
 We hope you like our new, improved docs, and we’re looking forward to hearing from you!

--- a/docs/examples/intro.mdx
+++ b/docs/examples/intro.mdx
@@ -2,6 +2,6 @@
 title: 'Request examples'
 ---
 
-**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our Canny request board](https://statelyai.canny.io/examples) or upvote an existing suggestion. 
+**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our Canny request board](https://feedback.stately.ai/examples) or upvote an existing suggestion. 
 
 If you have an example you want to share, [let us know on our Stately Discord](https://discord.gg/xstate).

--- a/docs/studio-community-plan.mdx
+++ b/docs/studio-community-plan.mdx
@@ -4,7 +4,7 @@ title: Stately Studio Community plan
 
 # Stately Studio Community
 
-**The Stately Studio will always be free to our Community users** on this free plan, and we will make many future features available on every plan. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.io).
+**The Stately Studio will always be free to our Community users** on this free plan, and we will make many future features available on every plan. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
 :::studio
 

--- a/docs/studio-pro-plan.mdx
+++ b/docs/studio-pro-plan.mdx
@@ -19,7 +19,7 @@ title: Stately Studio Pro plan
 - Workflows (coming soon!)
 - Live collaboration (coming soon!)
 
-We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.io).
+We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
 We offer a **30-day free trial** on the Stately Studio Pro account so you can explore how our Pro features work for you and your team.
 

--- a/docs/studio-pro-plan.mdx
+++ b/docs/studio-pro-plan.mdx
@@ -8,13 +8,18 @@ title: Stately Studio Pro plan
 
 ## Pro features
 
-- [Teams](/teams.mdx)
-- [Versions](/versions.mdx)
+- [Teams and shared projects](/teams.mdx)
 - [Private and unlisted projects](/projects.mdx#change-a-projects-visibility)
+- [Version history](/versions.mdx)
 - [Import from GitHub](/import-from-github.mdx)
+- [Live simulation mode](/live-simulation.mdx)
+- [Color states and transitions](/colors.mdx)
 - [Priority support](/studio-pro-plan.mdx#priority-support)
+- GitHub Sync (coming soon!)
+- Workflows (coming soon!)
+- Live collaboration (coming soon!)
 
-We have many more pro features planned. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.io).
+We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.io).
 
 We offer a **30-day free trial** on the Stately Studio Pro account so you can explore how our Pro features work for you and your team.
 

--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -130,7 +130,7 @@ Are you seeking inspiration for your machine? Or do you want to learn from how s
 
 ## Our roadmap
 
-Do you want to request a feature in the Stately Studio? [Check out our Canny roadmap](https://statelyai.canny.io) to post your feature idea and upvote other features. Our roadmap also shows you the features we have planned and those already in progress.
+Do you want to request a feature in the Stately Studio? [Check out our Canny roadmap](https://feedback.stately.ai) to post your feature idea and upvote other features. Our roadmap also shows you the features we have planned and those already in progress.
 
 You can also keep up with the Stately team’s work in progress at our regular [office hour live streams](https://youtube.com/statelyai).
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,7 +149,7 @@ const config = {
         links: [
           {
             label: 'Roadmap',
-            href: 'https://statelyai.canny.io',
+            href: 'https://feedback.stately.ai',
             target: '_self',
           },
           {

--- a/versioned_docs/version-5/migration.mdx
+++ b/versioned_docs/version-5/migration.mdx
@@ -1154,22 +1154,22 @@ We hope to release XState V5 as a stable major release this year (2023) but canâ
 5. Release candidates
 6. Release XState V5 stable
 
-Upvote or comment on [XState V5 in our roadmap](https://statelyai.canny.io/xstate/p/xstate-v5) to be the first to find out when V5 is released.
+Upvote or comment on [XState V5 in our roadmap](https://feedback.stately.ai/xstate/p/xstate-v5) to be the first to find out when V5 is released.
 
 ### When will Stately Studio be compatible with XState V5?
 
 We are currently working on [Stately Studio](studio.mdx) compatibility with XState V5. Exporting to XState V5 (JavaScript or TypeScript) will happen soonest, followed by support for new XState V5 features, such as higher-order guards, partial event wildcards, and machine input/output.
 
-Upvote or comment on [Stately Studio + XState V5 compatibility in our roadmap](https://statelyai.canny.io/editor/p/stately-studio-xstate-v5-compatibility) to stay updated on our progress.
+Upvote or comment on [Stately Studio + XState V5 compatibility in our roadmap](https://feedback.stately.ai/editor/p/stately-studio-xstate-v5-compatibility) to stay updated on our progress.
 
 ### When will the XState VS Code extension be compatible with XState V5?
 
 The [XState VS Code extension](xstate-vscode-extension.mdx) is not yet compatible with XState v5. The extension is a priority for us, and work is already underway.
 
-Upvote or comment on [XState V5 compatibility for VS Code extension in our roadmap](https://statelyai.canny.io/devtools/p/xstate-v5-compatibility-for-vs-code-extension) to stay updated on our progress.
+Upvote or comment on [XState V5 compatibility for VS Code extension in our roadmap](https://feedback.stately.ai/devtools/p/xstate-v5-compatibility-for-vs-code-extension) to stay updated on our progress.
 
 ### When will XState V5 have typegen?
 
 [Typegen](typegen.mdx) automatically generates intelligent typings for XState and is not yet compatible with XState v5. Weâ€™re working on Typegen alongside the VS Code extension.
 
-Upvote or comment on [Typegen for XState V5 in our roadmap](https://statelyai.canny.io/xstate/p/typegen-for-xstate-v5) to stay updated on our progress.
+Upvote or comment on [Typegen for XState V5 in our roadmap](https://feedback.stately.ai/xstate/p/typegen-for-xstate-v5) to stay updated on our progress.

--- a/versioned_docs/version-5/studio-pro-plan.mdx
+++ b/versioned_docs/version-5/studio-pro-plan.mdx
@@ -19,7 +19,7 @@ title: Stately Studio Pro plan
 - Workflows (coming soon!)
 - Live collaboration (coming soon!)
 
-We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.io).
+We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
 We offer a **30-day free trial** on the Stately Studio Pro account so you can explore how our Pro features work for you and your team.
 

--- a/versioned_docs/version-5/studio-pro-plan.mdx
+++ b/versioned_docs/version-5/studio-pro-plan.mdx
@@ -8,18 +8,24 @@ title: Stately Studio Pro plan
 
 ## Pro features
 
-- [Teams](teams.mdx)
-<!-- - Versions -->
-- [Private and unlisted projects](projects.mdx#change-a-projects-visibility)
-- [Priority support](studio-pro-plan.mdx#priority-support)
+- [Teams and shared projects](/teams.mdx)
+- [Private and unlisted projects](/projects.mdx#change-a-projects-visibility)
+- [Version history](/versions.mdx)
+- [Import from GitHub](/import-from-github.mdx)
+- [Live simulation mode](/live-simulation.mdx)
+- [Color states and transitions](/colors.mdx)
+- [Priority support](/studio-pro-plan.mdx#priority-support)
+- GitHub Sync (coming soon!)
+- Workflows (coming soon!)
+- Live collaboration (coming soon!)
 
-We have many more pro features planned. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.ai).
+We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://statelyai.canny.io).
 
-We offer a **30-day free trial** on Stately Studio Pro account so you can explore how our Pro features work for you and your team.
+We offer a **30-day free trial** on the Stately Studio Pro account so you can explore how our Pro features work for you and your team.
 
 :::studio
 
-**Stately Studio will always be free to our Community users** on the free plan, and we will make many future features available on every plan.
+**The Stately Studio will always be free to our Community users** on the free plan, and we will make many future features available on every plan.
 
 :::
 
@@ -27,15 +33,23 @@ We offer a **30-day free trial** on Stately Studio Pro account so you can explor
 
 You can choose between monthly or yearly billing on our Pro accounts and how many seats you require for your team.
 
+:::studio
+
+### Pro features as a team member
+
+If you are a team member of another user’s [team](/teams.mdx), you also have access to [Pro features](#pro-features)! However, if you want to create your own teams, you need to [upgrade to your own Pro subscription](/upgrade.mdx).
+
+:::
+
 ### How to sign up
 
 You can sign up for a Stately Studio account from the [**Sign in page**](https://stately.ai/registry/login) or the **Sign in** button in [the editor](https://stately.ai/editor)’s top bar.
 
-Read more about [signing up for Stately Studio](sign-up.mdx).
+Read more about [signing up for the Stately Studio](sign-up.mdx).
 
 ### How to upgrade
 
-You can [upgrade](upgrade.mdx) when you’re signed into Stately Studio using the **Upgrade** button in the editor’s header.
+You can [upgrade](upgrade.mdx) when you’re signed into the Stately Studio using the **Upgrade** button in the editor’s header.
 
 ## Priority support
 


### PR DESCRIPTION
Preview for V4: https://docs-8tfi56ase-statelyai.vercel.app/docs/studio-pro-plan
Preview for V5: https://docs-8tfi56ase-statelyai.vercel.app/docs/xstate-v5/studio-pro-plan

Also updated the links from `statelyai.canny.io` to `feedback.stately.ai`.