### PR TITLE
Update other-state-attributes.mdx

### DIFF
--- a/docs/xstate/states/other-state-attributes.mdx
+++ b/docs/xstate/states/other-state-attributes.mdx
@@ -170,7 +170,7 @@ For instance, if the machine above is in the `timedOut` state, the `meta` will b
 ```js
 {
   timedOut: {
-    alert: 'Timeout error!'
+    error: 'Timeout error!'
   },
 }
 ```


### PR DESCRIPTION
Fix docs error - wrong property in result of example code

`alert` should be `error` based on the generating code sample:

https://github.com/statelyai/docs/blob/23d3b1c2c82aa2f6100cbce4fff4159c538268d5/docs/xstate/states/other-state-attributes.mdx#L154