### PR TITLE
Update docs examples page

### DIFF
--- a/docs/examples/intro.mdx
+++ b/docs/examples/intro.mdx
@@ -2,6 +2,6 @@
 title: 'Request examples'
 ---
 
-**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our Canny request board](https://feedback.stately.ai/examples) or upvote an existing suggestion. 
+**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion. 
 
 If you have an example you want to share, [let us know on our Stately Discord](https://discord.gg/xstate).

--- a/docs/examples/intro.mdx
+++ b/docs/examples/intro.mdx
@@ -2,6 +2,8 @@
 title: 'Request examples'
 ---
 
-**Examples are coming soon**. If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion. 
+**Find [examples for XState V5 beta](/docs/xstate-v5/examples) in the XState V5 section of these docs.**
+
+If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion. 
 
 If you have an example you want to share, [let us know on our Stately Discord](https://discord.gg/xstate).

--- a/versioned_docs/version-5/examples.mdx
+++ b/versioned_docs/version-5/examples.mdx
@@ -2,7 +2,7 @@
 title: XState examples
 ---
 
-XState v5 beta examples are also available in the [`/examples` directory](https://github.com/statelyai/xstate/tree/next/examples). Each example has a CodeSandbox link where you can run the example in your browser.
+XState v5 beta examples are also available in the [`/examples` directory](https://github.com/statelyai/xstate/tree/next/examples). Many of the examples have a CodeSandbox link where you can run the example in your browser.
 
 ## Simple fetch example 
 
@@ -117,6 +117,233 @@ A simple toggle built with:
 - [Toggle on GitHub](https://github.com/statelyai/xstate/tree/next/examples/toggle)
 - [Toggle on CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/next/examples/toggle)
 
-**More examples are coming soon**. If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion.
+
+## Hello world workflow 
+
+Serverless hello world workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Hello-World-Example) built with:
+
+- XState v5 beta
+
+[Hello world workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-hello)
+
+
+## Greeting workflow 
+
+Serverless greeting workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Greeting-Example) built with:
+
+- XState v5 beta
+
+[Greeting workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-greeting)
+
+
+## Event-based greeting workflow 
+
+Serverless event-based greeting workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Event-Based-Greeting-Example) built with:
+
+- XState v5 beta
+
+[Event-based greeting workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-event-greeting)
+
+
+## Solving math problems 
+
+Serverless math solving problem workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Solving-Math-Problems-Example) built with:
+
+- XState v5 beta
+
+[Solving math problems on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-math-problem)
+
+
+## Parallel execution workflow 
+
+Serverless parallel execution workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Parallel-Execution-Example) built with:
+
+- XState v5 beta
+
+[Parallel execution workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-parallel)
+
+
+## Async function invocation workflow 
+
+Serverless async function invocation workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Async-Function-Invocation-Example) built with:
+
+- XState v5 beta
+
+[Async function invocation workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-async-function)
+
+
+## Async subflow invocation workflow 
+
+Serverless async subflow invocation workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Async-SubFlow-Invocation-Example) built with:
+
+- XState v5 beta
+
+[Async subflow invocation workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-async-subflow)
+
+
+## Event-based transitions (event-based switch) workflow 
+
+Serverless event-based transitions workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Event-Based-Transitions-Example) built with:
+
+- XState v5 beta
+
+[Event-based transitions workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-event-based)
+
+
+## Applicant request decision workflow 
+
+Serverless applicant request decision workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Applicant-Request-Decision-Example) built with:
+
+- XState v5 beta
+
+[Applicant request decision workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-applicant-request)
+
+
+## Provision orders (error handling) workflow 
+
+Serverless provision orders (error handling) workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Provision-Orders-Example) built with:
+
+- XState v5 beta
+
+[Provision orders (error handling) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-provision-orders)
+
+
+## Monitor job for completion (polling) workflow 
+
+Serverless monitor job for completion (polling) workflow  from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Monitor-Job-Example) built with:
+
+- XState v5 beta
+
+[Monitor job for completion (polling) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-monitor-job)
+
+
+## Send CloudEvent on workflow completion 
+
+Serverless send CloudEvent on workflow completion workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Send-CloudEvent-On-Workflow-Completion-Example) built with:
+
+- XState v5 beta
+
+[Send CloudEvent on workflow completion on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-send-cloudevent)
+
+
+## Monitor patient vital signs workflow 
+
+Serverless monitor patient vital signs workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Monitor-Patient-Vital-Signs-Example) built with:
+
+- XState v5 beta
+
+[Monitor patient vital signs workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-monitor-patient)
+
+
+## Finalize college application workflow 
+
+Serverless finalize college application workflow  from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Finalize-College-Application-Example) built with:
+
+- XState v5 beta
+
+[Finalize college application workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-finalize-college-app)
+
+
+## Perform customer credit check workflow 
+
+Serverless perform customer credit check workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Perform-Customer-Credit-Check-Example) built with:
+
+- XState v5 beta
+
+[Perform customer credit check workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-credit-check)
+
+
+## Handle car auction bids (scheduled start) workflow 
+
+Serverless handle car auction bids (scheduled start) workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Handle-Car-Auction-Bids-Example) built with:
+
+- XState v5 beta
+
+[Handle car auction bids (scheduled start) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-car-auction-bids)
+
+
+## Check inbox periodically (cron-based workflow start) 
+
+Serverless check inbox periodically (cron-based workflow start) from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Check-Inbox-Periodically) built with:
+
+- XState v5 beta
+
+[Check inbox periodically (cron-based workflow start) on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-check-inbox)
+
+
+## Event-based service workflow 
+
+Serverless event-based service workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Event-Based-Service-Invocation) built with:
+
+- XState v5 beta
+
+[Event-based service workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-event-based-service)
+
+
+## Reusing function and event definitions workflow 
+
+Serverless reusing function and event definitions workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Reusing-Function-And-Event-Definitions) built with:
+
+- XState v5 beta
+
+[Reusing function and event definitions workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-reusing-functions)
+
+
+## New patient onboarding (error checking and retries) workflow 
+
+Serverless new patient onboarding (error checking and retries) workflow  from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#new-patient-onboarding).
+
+[New patient onboarding (error checking and retries) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-new-patient-onboarding)
+
+
+## Purchase order deadline (ExecTimeout) workflow 
+
+Serverless purchase order deadline (ExecTimeout) workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#purchase-order-deadline) built with:
+
+- XState v5 beta
+
+[Purchase order deadline (ExecTimeout) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-purchase-order-deadline)
+
+
+## Accumulate room readings and create timely reports (ExecTimeout and KeepActive) workflow 
+
+Serverless accumulate room readings and create timely reports (ExecTimeout and KeepActive) workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#accumulate-room-readings) built with:
+
+- XState v5 beta
+
+[Accumulate room readings and create timely reports (ExecTimeout and KeepActive) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-accumulate-room-readings)
+
+
+## Car vitals checks (SubFlow Repeat) workflow 
+
+Store a single bid when the car auction is active.
+
+Serverless car vitals checks (SubFlow Repeat) workflow  from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#handle-car-auction-bids-example) built with:
+
+- XState v5 beta
+
+[Car vitals checks (SubFlow Repeat) workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-car-vitals)
+
+
+## Book lending workflow 
+
+Serverless book lending workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#book-lending) built with:
+
+- XState v5 beta
+
+[Book lending workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-book-lending)
+
+
+## Filling a glass of water workflow 
+
+Serverless filling a glass of water workflow from the [CNCF Serverless Workflow examples](https://github.com/serverlessworkflow/specification/tree/main/examples#Filling-a-glass-of-water) built with:
+
+- XState v5 beta
+
+[Filling a glass of water workflow on GitHub](https://github.com/statelyai/xstate/tree/next/examples/workflow-filling-water)
+
+## More examples coming soon
+
+If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion.
 
 If you have an example you want to share, [contribute your example to the XState repository](https://github.com/statelyai/xstate/tree/next/examples#contributing-an-example).


### PR DESCRIPTION
This PR:

- Adds all the workflow examples to the [V5 examples page](https://docs-l7xlijalm-statelyai.vercel.app/docs/xstate-v5/examples)
- Links to the V5 examples page from the slightly emptier [V4 examples page](https://docs-l7xlijalm-statelyai.vercel.app/docs/examples/intro)