### PR TITLE
Lock docs (Document the machine locking Pro feature)

### DIFF
--- a/docs/lock-machines.mdx
+++ b/docs/lock-machines.mdx
@@ -1,0 +1,37 @@
+---
+title: Lock machines
+---
+
+You can lock a machine anytime to prevent accidental edits. Locked machines have a <Lock size={18} /> **Locked** status displayed in the editor’s top bar. 
+
+Hover over the <Lock size={18} /> **Locked** text to view who locked the machine and when.
+
+:::studio
+
+Locking machines is a Pro feature of the Studio. [Check out the features on our Pro plan](/studio-pro-plan.mdx) or [upgrade to try the Pro plan with a 30-day free trial](https://stately.ai/registry/billing).
+
+:::
+
+Locking a machine prevents you, or anyone else on your team, from the following:
+
+- Editing the machine
+- Delete the machine
+- Rename the machine
+- [Import code](import-from-code.mdx) to replace the machine
+
+If somebody else is viewing or editing the machine when it is locked, their changes will not be saved, and they will be notified that the machine is now locked.
+
+## How to lock and unlock a machine
+
+From the editor menu, go to **Machine** > <Unlock size={18} /> **Lock machine** / <Lock size={18} /> **Unlock machine**.
+
+From the machine’s <Info size={18} /> **Details** panel, use the <Unlock size={18} /> Lock machine / <Lock size={18} /> Unlock machine icon button.
+
+## Team roles and locking machines
+
+All team members can view locked machines. Only team owners, Admins, and Editors can lock and unlock machines.
+
+| Capability                           | Owner  | Admin  | Editor | Viewer |
+| ------------------------------------ | ------ | ------ | ------ | ------ |
+| View locked machine                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Lock and unlock machine              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |

--- a/docs/studio-pro-plan.mdx
+++ b/docs/studio-pro-plan.mdx
@@ -13,6 +13,7 @@ title: Stately Studio Pro plan
 - [Version history](/versions.mdx)
 - [Import from GitHub](/import-from-github.mdx)
 - [Live simulation mode](/live-simulation.mdx)
+- [Lock machines](/lock-machines.mdx)
 - [Color states and transitions](/colors.mdx)
 - [Priority support](/studio-pro-plan.mdx#priority-support)
 - GitHub Sync (coming soon!)

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -35,6 +35,7 @@ The following table is an overview of the capabilities of each team role:
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
+| Lock team machines                       | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Reassign Admin, Editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Invite new team members                  | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Change project visibility                | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
@@ -53,6 +54,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - View team members
 - Give team members Admin, Editor, and Viewer roles
 - Create team projects
+- Lock team machines
 - Edit, fork, export, and view team projects and machines
 
 #### Teams members and Pro plan seats
@@ -69,6 +71,7 @@ Users with the Admin role can:
 - View team members
 - Give team members Editor and Viewer roles
 - Create team projects
+- Lock team machines
 - Edit, fork, export, and view team projects and machines
 
 ### Editor role
@@ -77,6 +80,7 @@ Users with the Editor role can:
 
 - View team members
 - Create team projects
+- Lock team machines
 - Edit, fork, export, and view team projects and machines
 
 ### Viewer role

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -31,6 +31,7 @@ The following table is an overview of the capabilities of each team role:
 | ---------------------------------------- | ------ | ------ | ------ | ------ |
 | View team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | View other team members                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Export team machines                     | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
@@ -52,7 +53,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - View team members
 - Give team members Admin, Editor, and Viewer roles
 - Create team projects
-- Edit, fork, and view team projects and machines
+- Edit, fork, export, and view team projects and machines
 
 #### Teams members and Pro plan seats
 
@@ -68,7 +69,7 @@ Users with the Admin role can:
 - View team members
 - Give team members Editor and Viewer roles
 - Create team projects
-- Edit, fork, and view team projects and machines
+- Edit, fork, export, and view team projects and machines
 
 ### Editor role
 
@@ -76,7 +77,7 @@ Users with the Editor role can:
 
 - View team members
 - Create team projects
-- Edit, fork, and view team projects and machines
+- Edit, fork, export, and view team projects and machines
 
 ### Viewer role
 
@@ -84,6 +85,7 @@ Users with the Viewer role can:
 
 - View team members
 - View team projects and machines
+- Export team machines
 
 ## Create a team
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -176,6 +176,12 @@ const sidebars = {
             },
           ],
         },
+        {
+          "type": "doc",
+          "label": "Lock machines",
+          "id": "lock-machines",
+          "className": "pro-feature"
+        },
         "keyboard-shortcuts",
         'canvas-view-controls',
         'user-preferences'

--- a/versioned_docs/version-5/lock-machines.mdx
+++ b/versioned_docs/version-5/lock-machines.mdx
@@ -1,0 +1,37 @@
+---
+title: Lock machines
+---
+
+You can lock a machine anytime to prevent accidental edits. Locked machines have a <Lock size={18} /> **Locked** status displayed in the editor’s top bar. 
+
+Hover over the <Lock size={18} /> **Locked** text to view who locked the machine and when.
+
+:::studio
+
+Locking machines is a Pro feature of the Studio. [Check out the features on our Pro plan](/studio-pro-plan.mdx) or [upgrade to try the Pro plan with a 30-day free trial](https://stately.ai/registry/billing).
+
+:::
+
+Locking a machine prevents you, or anyone else on your team, from the following:
+
+- Editing the machine
+- Delete the machine
+- Rename the machine
+- [Import code](import-from-code.mdx) to replace the machine
+
+If somebody else is viewing or editing the machine when it is locked, their changes will not be saved, and they will be notified that the machine is now locked.
+
+## How to lock and unlock a machine
+
+From the editor menu, go to **Machine** > <Unlock size={18} /> **Lock machine** / <Lock size={18} /> **Unlock machine**.
+
+From the machine’s <Info size={18} /> **Details** panel, use the <Unlock size={18} /> Lock machine / <Lock size={18} /> Unlock machine icon button.
+
+## Team roles and locking machines
+
+All team members can view locked machines. Only team owners, Admins, and Editors can lock and unlock machines.
+
+| Capability                           | Owner  | Admin  | Editor | Viewer |
+| ------------------------------------ | ------ | ------ | ------ | ------ |
+| View locked machine                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Lock and unlock machine              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |

--- a/versioned_docs/version-5/studio-pro-plan.mdx
+++ b/versioned_docs/version-5/studio-pro-plan.mdx
@@ -13,6 +13,7 @@ title: Stately Studio Pro plan
 - [Version history](/versions.mdx)
 - [Import from GitHub](/import-from-github.mdx)
 - [Live simulation mode](/live-simulation.mdx)
+- [Lock machines](/lock-machines.mdx)
 - [Color states and transitions](/colors.mdx)
 - [Priority support](/studio-pro-plan.mdx#priority-support)
 - GitHub Sync (coming soon!)

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -35,6 +35,7 @@ The following table is an overview of the capabilities of each team role:
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
+| Lock team machines                       | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Reassign Admin, Editor, and Viewer roles | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Invite new team members                  | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
 | Change project visibility                | ✅ Yes | ✅ Yes | 🚫 No  | 🚫 No  |
@@ -53,6 +54,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - View team members
 - Give team members Admin, Editor, and Viewer roles
 - Create team projects
+- Lock team machines
 - Edit, fork, export, and view team projects and machines
 
 #### Teams members and Pro plan seats
@@ -69,6 +71,7 @@ Users with the Admin role can:
 - View team members
 - Give team members Editor and Viewer roles
 - Create team projects
+- Lock team machines
 - Edit, fork, export, and view team projects and machines
 
 ### Editor role
@@ -77,6 +80,7 @@ Users with the Editor role can:
 
 - View team members
 - Create team projects
+- Lock team machines
 - Edit, fork, export, and view team projects and machines
 
 ### Viewer role
@@ -86,6 +90,7 @@ Users with the Viewer role can:
 - View team members
 - View team projects and machines
 - Export team machines
+
 
 ## Create a team
 

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -31,6 +31,7 @@ The following table is an overview of the capabilities of each team role:
 | ---------------------------------------- | ------ | ------ | ------ | ------ |
 | View team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | View other team members                  | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Export team machines                     | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | Fork team projects and machines          | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Edit existing team projects              | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
 | Create team projects                     | ✅ Yes | ✅ Yes | ✅ Yes | 🚫 No  |
@@ -52,7 +53,7 @@ Pro subscribers can create teams and they become their teams' owner by default. 
 - View team members
 - Give team members Admin, Editor, and Viewer roles
 - Create team projects
-- Edit, fork, and view team projects and machines
+- Edit, fork, export, and view team projects and machines
 
 #### Teams members and Pro plan seats
 
@@ -68,7 +69,7 @@ Users with the Admin role can:
 - View team members
 - Give team members Editor and Viewer roles
 - Create team projects
-- Edit, fork, and view team projects and machines
+- Edit, fork, export, and view team projects and machines
 
 ### Editor role
 
@@ -76,7 +77,7 @@ Users with the Editor role can:
 
 - View team members
 - Create team projects
-- Edit, fork, and view team projects and machines
+- Edit, fork, export, and view team projects and machines
 
 ### Viewer role
 
@@ -84,6 +85,7 @@ Users with the Viewer role can:
 
 - View team members
 - View team projects and machines
+- Export team machines
 
 ## Create a team
 

--- a/versioned_sidebars/version-5-sidebars.json
+++ b/versioned_sidebars/version-5-sidebars.json
@@ -211,6 +211,12 @@
             }
           ]
         },
+        {
+          "type": "doc",
+          "label": "Lock machines",
+          "id": "lock-machines",
+          "className": "pro-feature"
+        },
         "keyboard-shortcuts",
         "canvas-view-controls",
         "user-preferences"


### PR DESCRIPTION
Pages have been added for both V4 and V5 docs with the same content.

Preview: []().