### PR TITLE
patch: Update migration.mdx

### DIFF
--- a/versioned_docs/version-5/migration.mdx
+++ b/versioned_docs/version-5/migration.mdx
@@ -88,7 +88,7 @@ const actor = createActor(machine);
 <TabItem value="v4" label="XState v4">
 
 ```ts
-import { createMachine, createActor } from 'xstate';
+import { createMachine, interpret } from 'xstate';
 
 const machine = createMachine(/* ... */);
 


### PR DESCRIPTION
Quick typo fix in import statement for `interpret`

Re:
https://stately.ai/docs/xstate-v5/migration#use-createactor-not-interpret