### PR TITLE
Update slug for nested typegen blog post

### DIFF
--- a/blog/2022-06-13-nesting-typegen-files/index.mdx
+++ b/blog/2022-06-13-nesting-typegen-files/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Nesting XState typegen files"
+title: 'Nesting XState typegen files'
 description: What is file nesting in VS Code and how to enable it for XState's generated type files.
 tags: [stately, extension, open source, xstate, vscode]
 authors: [anders]
 image: /blog/2022-06-13-nesting-typegen-files.png
-slug: 2022-06-13-nesting-typegen-files
-date:  2022-06-13
+slug: nesting-typegen-files
+date: 2022-06-13
 ---
 
 Our latest update to the [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) has made it easy to enable file nesting for typegen files. But what is file nesting?

--- a/blog/2022-07-06-whats-new-july-2022/index.mdx
+++ b/blog/2022-07-06-whats-new-july-2022/index.mdx
@@ -28,7 +28,7 @@ Trackpad fans rejoice; you can now pinch to zoom in and out to navigate the edit
 
 ## Nesting typegen files
 
-You’re missing out if you’re not using [our XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) yet! After a top tip from our friend Erik Rasmussen, Anders added the feature to our VS Code extension. Read [Anders’ blog post on nesting XState typegen files](/blog/nesting-typegen-files/index.mdx) for more details.
+You’re missing out if you’re not using [our XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) yet! After a top tip from our friend Erik Rasmussen, Anders added the feature to our VS Code extension. Read [Anders’ blog post on nesting XState typegen files](/blog/nesting-typegen-files) for more details.
 
 ## Labels on quick action buttons
 

--- a/blog/2022-07-06-whats-new-july-2022/index.mdx
+++ b/blog/2022-07-06-whats-new-july-2022/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: "What’s new in July 2022?"
+title: 'What’s new in July 2022?'
 description: Search for machines, pinch to zoom, nest typegen files and more! Find out the latest features in the Stately editor and XState VS Code extension.
 tags: [stately, xstate, announcement, editor, search, typegen, survey, roadmap]
 authors: [laura]
 image: /blog/2022-07-06-whats-new-july-2022.png
 slug: 2022-07-06-whats-new-july-2022
-date:  2022-07-06
+date: 2022-07-06
 ---
 
 On top of our usual minor improvements and bug fixes, we’ve got great new features to share with you in July!
@@ -28,7 +28,7 @@ Trackpad fans rejoice; you can now pinch to zoom in and out to navigate the edit
 
 ## Nesting typegen files
 
-You’re missing out if you’re not using [our XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) yet! After a top tip from our friend Erik Rasmussen, Anders added the feature to our VS Code extension. Read [Anders’ blog post on nesting XState typegen files](/blog/2022-06-13-nesting-typegen-files/index.mdx) for more details.
+You’re missing out if you’re not using [our XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) yet! After a top tip from our friend Erik Rasmussen, Anders added the feature to our VS Code extension. Read [Anders’ blog post on nesting XState typegen files](/blog/nesting-typegen-files/index.mdx) for more details.
 
 ## Labels on quick action buttons
 
@@ -38,7 +38,7 @@ The quick action buttons for adding states and guarded transitions are now label
 
 ## More upcoming features
 
-We’ve got many more features coming up. Watch [our office hours from last week](https://www.youtube.com/watch?v=4v_M3HcZc3U) and [office hours from June 24](https://www.youtube.com/watch?v=qmbeYvcA3Ks) for demos of [smoother transition lines](https://www.youtube.com/watch?v=qmbeYvcA3Ks&t=530s), [fit to content on initial render](https://www.youtube.com/watch?v=4v_M3HcZc3U&t=1214s) and [parity between XState and the Stately editor](https://www.youtube.com/watch?v=4v_M3HcZc3U&t=208s). 
+We’ve got many more features coming up. Watch [our office hours from last week](https://www.youtube.com/watch?v=4v_M3HcZc3U) and [office hours from June 24](https://www.youtube.com/watch?v=qmbeYvcA3Ks) for demos of [smoother transition lines](https://www.youtube.com/watch?v=qmbeYvcA3Ks&t=530s), [fit to content on initial render](https://www.youtube.com/watch?v=4v_M3HcZc3U&t=1214s) and [parity between XState and the Stately editor](https://www.youtube.com/watch?v=4v_M3HcZc3U&t=208s).
 
 ## Suggest features and help us prioritize our roadmap
 

--- a/docs/xstate/typescript/typegen.mdx
+++ b/docs/xstate/typescript/typegen.mdx
@@ -241,7 +241,7 @@ Instead of enums, use typegen and rely on the strength of the type-safety provid
 
 ## Nesting typegen files
 
-When you use typegen, you'll notice that it generates new type files. If you use VS Code we have made it easy for you to nest these files. Our extension will automatically ask you if you want to enable nesting. If you want to know more about file-nesting, you can [read the blog post where we introduced nesting typegen files](https://stately.ai/blog/2022-06-13-nesting-typegen-files).
+When you use typegen, you'll notice that it generates new type files. If you use VS Code we have made it easy for you to nest these files. Our extension will automatically ask you if you want to enable nesting. If you want to know more about file-nesting, you can [read the blog post where we introduced nesting typegen files](/blog/nesting-typegen-files).
 
 ## Known limitations
 


### PR DESCRIPTION
This PR updates the nested typegen blog post slug to match the URL we show in the extension popup. Searching for the blog post will fail in the preview deployment; it won't work with the updated slug before the Algolia index gets updated.