### PR TITLE
Update landing page pricing to the yearly option

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import React, { useEffect } from 'react';
 import { drawArrows } from '../components/landing-page-arrows';
+import '/landing-page/styles.css'; // import the CSS file before the HTML file to avoid layout shifts
 
 // https://github.com/facebook/docusaurus/discussions/8387#discussioncomment-6067944
 // Loading a static HTML only works during SSR, so we use this hack to make it work during CSR

--- a/static/landing-page/styles.css
+++ b/static/landing-page/styles.css
@@ -339,7 +339,7 @@ h2 {
   font-family: 'TTCommons', Arial, sans-serif;
   font-weight: 750;
   margin: 0.83em 0;
-} 
+}
 
 p {
   margin: 1em 0;
@@ -2226,9 +2226,10 @@ h2.pricing-heading {
 
 .pricing-text.details-bold {
   font-size: var(--font-xxsmall);
-  color: var(--chakra-colors-gray-50);
+  color: var(--chakra-colors-gray-200) !important;
   margin-top: 0.5rem;
-  font-variation-settings: 'wght' 600;
+  font-variation-settings: 'wght' 200;
+  max-width: 8em;
 }
 
 .pricing-text.description {

--- a/static/pricing/index.html
+++ b/static/pricing/index.html
@@ -111,7 +111,7 @@
                     <p class="pricing-text details">per seat/month</p>
                     <p class="pricing-text details">billed yearly</p>
                     <p class="pricing-text details details-bold">
-                      15$ per seat when billed monthly
+                      $15 per seat when billed monthly
                     </p>
                   </div>
                 </div>

--- a/static/pricing/index.html
+++ b/static/pricing/index.html
@@ -106,7 +106,7 @@
               <div class="tier-header">
                 <h2 class="pricing-heading">Professional</h2>
                 <div class="horizontal">
-                  <p class="pricing-text price-number">$12.5</p>
+                  <p class="pricing-text price-number">$12.50</p>
                   <div class="details-wrapper">
                     <p class="pricing-text details">per seat/month</p>
                     <p class="pricing-text details">billed yearly</p>

--- a/static/pricing/index.html
+++ b/static/pricing/index.html
@@ -106,12 +106,12 @@
               <div class="tier-header">
                 <h2 class="pricing-heading">Professional</h2>
                 <div class="horizontal">
-                  <p class="pricing-text price-number">$15</p>
+                  <p class="pricing-text price-number">$12.5</p>
                   <div class="details-wrapper">
                     <p class="pricing-text details">per seat/month</p>
-                    <p class="pricing-text details">billed monthly</p>
+                    <p class="pricing-text details">billed yearly</p>
                     <p class="pricing-text details details-bold">
-                      Save 17% billed yearly
+                      15$ per seat when billed monthly
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
- The pricing page now shows the yearly price of 12.5$, when billed yearly.
- Preloads the CSS for the landing page to avoid layout shifts (not fixed completely, but seems slightly better)
![CleanShot 2023-09-10 at 11 57 32@2x](https://github.com/statelyai/docs/assets/167574/fdee3163-8b3f-49fa-a840-3fa8e4ef4ec6)

