### PR TITLE
Add types and tweak styles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -660,7 +660,7 @@ h1 {
 }
 
 .markdown h1, .markdown h1:first-child, .index-page h1 {
-  --ifm-h1-font-size: 2.5rem;
+  --ifm-h1-font-size: 1.875rem;
 }
 
 h2 {
@@ -781,7 +781,7 @@ a:hover {
 article,
 .index-page {
   margin: 0 auto;
-  max-width: 66ch;
+  max-width: 50rem;
 }
 
 /* back to top button */
@@ -1077,7 +1077,7 @@ html [class*='toggleButton'] {
 
 .theme-doc-sidebar-item-category-level-1 a,
 .theme-doc-sidebar-item-link-level-1 a {
-  color: var(--st-text);
+  color: var(--ifm-color-emphasis-0);
 }
 
 .theme-doc-sidebar-item-category-level-1 ul li,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -24,7 +24,7 @@ html,
 body {
   font-weight: var(--ifm-font-weight-normal);
   letter-spacing: -0.011rem;
-  line-height: 1.45;
+  line-height: 1.625;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -331,7 +331,7 @@ html[data-theme='light'] body {
   --st-text: var(--st-gray-800);
   --st-text-highlight: var(--st-gray-900);
   --st-heading: var(--st-text-highlight);
-  --st-text-secondary: var(--st-gray-700);
+  --st-text-secondary: var(--st-gray-600);
   --st-text-link: var(--st-blue-700);
   --st-text-link-hover: var(--st-blue-600);
   --st-text-link-active: var(--st-blue-500);
@@ -481,9 +481,9 @@ html[data-theme='dark'] body {
   --st-background: var(--st-gray-900);
   --st-background-secondary: var(--st-gray-800);
   --st-text: var(--st-gray-200);
-  --st-text-highlight: var(--st-gray-100);
+  --st-text-highlight: var(--st-gray-50);
   --st-heading: var(--st-text-highlight);
-  --st-text-secondary: var(--st-gray-200);
+  --st-text-secondary: var(--st-gray-400);
   --st-text-link: var(--st-blue-300);
   --st-text-link-hover: var(--st-blue-400);
   --st-text-link-active: var(--st-blue-400);
@@ -664,7 +664,7 @@ h1 {
 }
 
 .markdown h1, .markdown h1:first-child, .index-page h1 {
-  --ifm-h1-font-size: 1.875rem;
+  --ifm-h1-font-size: 2rem;
 }
 
 h2 {
@@ -672,31 +672,33 @@ h2 {
 }
 
 .markdown h2 {
-  --ifm-h2-font-size: 2rem;
+  margin-top: 4.5rem;
+  --ifm-h2-font-size: 1.5rem;
 }
 
 h3 {
   letter-spacing: -0.019rem;
+  color: var(--st-heading);
 }
 
 .markdown h3 {
-  --ifm-h3-font-size: 1.5rem;
+  --ifm-h3-font-size: 1.25rem;
 }
 
 .markdown > h3 {
-    margin-top: calc(var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
+  margin-top: 3rem;
 }
 
 .markdown h4 {
-  --ifm-h4-font-size: 1.2rem;
+  --ifm-h4-font-size: 1.15rem;
 }
 
 .markdown h5 {
-  --ifm-h5-font-size: 1.1rem;
+  --ifm-h5-font-size: 1.05rem;
 }
 
 .markdown h6 {
-  --ifm-h6-font-size: 1.05rem;
+  --ifm-h6-font-size: 1rem;
 }
 
 .text--bold,
@@ -786,6 +788,9 @@ article,
 .index-page {
   margin: 0 auto;
   max-width: 50rem;
+  /* adds more side padding when in column mode */
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 /* back to top button */
@@ -850,6 +855,11 @@ code {
     margin-right: 0;
     width: calc(var(--doc-sidebar-width) - 1rem);
   }
+  article, .index-page {
+  /* Let content breath some on a not-huge screen */
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
 }
 
 .navbar__logo {
@@ -1113,6 +1123,7 @@ html [class*='toggleButton'] {
 }
 .menu__list-item:last-of-type {
   padding-bottom: 0.2rem;
+  margin-bottom: 0.5rem;
 }
 .menu__list-item:not(:first-child) {
   margin-top: 0;
@@ -1164,6 +1175,7 @@ html [class*='toggleButton'] {
 .menu__list-item .menu__list-item .menu__link--active {
   border-left: 3px solid var(--st-menu-link-border-active);
   margin-left: -4px;
+  color: var(--ifm-color-emphasis-0);
 }
 
 .menu__list-item .menu__list-item .menu__list-item .menu__link--active {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -592,7 +592,7 @@ html[data-theme='dark'] body {
   --docsearch-footer-shadow: inset 0 1px 0 0 var(--st-gray-700);
 
   /* navbar */
-  --ifm-navbar-background-color: var(--st-navbar-background);
+  --ifm-navbar-background-color: var(--ifm-background-color);
   --ifm-navbar-shadow: none;
 
   /* contents list */
@@ -603,6 +603,10 @@ html[data-theme='dark'] body {
   --st-tag-border: 1px solid rgba(69, 71, 79, .5);/* var(--st-gray-700) in rgba */
   --st-tag-text: var(--st-gray-50);
   --st-tag-background: var(--st-gray-850);
+
+  /* background */
+  --ifm-background-color: #15151d;
+  --ifm-footer-background-color: var(--ifm-background-color);
 }
 
 /* Code examples */
@@ -1699,7 +1703,6 @@ ul.blog-list {
 /* Footer */
 
 .footer {
-  background: var(--st-background);
   border-top: 1px solid var(--st-header-border);
   padding: 0.5rem;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -116,7 +116,7 @@ body {
   --st-violet-50: #fcecff;
 
   /* Gray */
-  --st-gray-900: #151618;
+  --st-gray-900: #15151d;
   --st-gray-850: #212226;
   --st-gray-825: #27282a;
   --st-gray-800: #2d2e34;
@@ -159,6 +159,7 @@ body {
   --ifm-link-decoration: underline;
   --docusaurus-highlighted-code-line-bg: var(--st-code-highlight-background);
   --ifm-heading-vertical-rhythm-bottom: 0.75;
+  --ifm-footer-background-color: var(--st-background);
   --ifm-code-background: var(--st-code-highlight-background);
   --ifm-code-border-radius: 0.25em;
   --ifm-code-font-size: 95%;
@@ -301,7 +302,7 @@ body {
   /* tables */
   --ifm-table-border-color: var(--st-layout-border);
   --ifm-table-background: transparent;
-  --ifm-table-stripe-background: rgba(255,255,255,0.6);
+  --ifm-table-stripe-background: rgba(255, 255, 255, 0.6);
   --ifm-footer-link-color: var(--st-footer-link);
 
   /* admonitions */
@@ -349,7 +350,7 @@ html[data-theme='light'] body {
   --st-layout-border-secondary: var(--st-gray-100);
   --st-code-border: var(--st-gray-100);
   --st-codeblock-background: white;
-  --st-code-inline-border: 1px solid rgba(191, 227, 248, .5);/* var(--st-blue-100) in rgba */
+  --st-code-inline-border: 1px solid rgba(191, 227, 248, 0.5); /* var(--st-blue-100) in rgba */
   --st-code-inline-text: var(--st-blue-900);
   --st-code-highlight-background: var(--st-blue-50);
   --st-copy-button-background: var(--st-blue-100);
@@ -413,7 +414,7 @@ html[data-theme='light'] body {
   --docsearch-footer-shadow: inset 0 1px 0 0 var(--st-gray-100);
 
   /* tags */
-  --st-tag-border: 1px solid rgba(191, 227, 248, .5);/* var(--st-blue-100) in rgba */
+  --st-tag-border: 1px solid rgba(191, 227, 248, 0.5); /* var(--st-blue-100) in rgba */
   --st-tag-text: var(--st-blue-900);
   --st-tag-background: var(--st-blue-50);
 
@@ -502,7 +503,7 @@ html[data-theme='dark'] body {
   --st-layout-border: var(--st-gray-700);
   --st-layout-border-secondary: var(--st-gray-700);
   --st-code-border: transparent;
-  --st-code-inline-border: 1px solid rgba(69, 71, 79, .5);/* var(--st-gray-700) in rgba */
+  --st-code-inline-border: 1px solid rgba(69, 71, 79, 0.5); /* var(--st-gray-700) in rgba */
   --st-code-inline-text: var(--st-gray-50);
   --st-codeblock-background: var(--st-gray-850);
   --st-code-highlight-background: var(--st-gray-800);
@@ -592,7 +593,7 @@ html[data-theme='dark'] body {
   --docsearch-footer-shadow: inset 0 1px 0 0 var(--st-gray-700);
 
   /* navbar */
-  --ifm-navbar-background-color: var(--ifm-background-color);
+  --ifm-navbar-background-color: var(--st-navbar-background);
   --ifm-navbar-shadow: none;
 
   /* contents list */
@@ -600,13 +601,9 @@ html[data-theme='dark'] body {
   --ifm-toc-link-color: var(--st-text);
 
   /* tags */
-  --st-tag-border: 1px solid rgba(69, 71, 79, .5);/* var(--st-gray-700) in rgba */
+  --st-tag-border: 1px solid rgba(69, 71, 79, 0.5); /* var(--st-gray-700) in rgba */
   --st-tag-text: var(--st-gray-50);
   --st-tag-background: var(--st-gray-850);
-
-  /* background */
-  --ifm-background-color: #15151d;
-  --ifm-footer-background-color: var(--ifm-background-color);
 }
 
 /* Code examples */
@@ -663,7 +660,9 @@ h1 {
   letter-spacing: -0.022rem;
 }
 
-.markdown h1, .markdown h1:first-child, .index-page h1 {
+.markdown h1,
+.markdown h1:first-child,
+.index-page h1 {
   --ifm-h1-font-size: 2rem;
 }
 
@@ -855,11 +854,12 @@ code {
     margin-right: 0;
     width: calc(var(--doc-sidebar-width) - 1rem);
   }
-  article, .index-page {
-  /* Let content breath some on a not-huge screen */
-  padding-left: 2rem;
-  padding-right: 2rem;
-}
+  article,
+  .index-page {
+    /* Let content breath some on a not-huge screen */
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
 }
 
 .navbar__logo {
@@ -1380,7 +1380,8 @@ details summary::before {
   --ifm-alert-border-color: var(--st-tip-accent);
 }
 
-.alert--danger, .alert--breakingchange {
+.alert--danger,
+.alert--breakingchange {
   --ifm-alert-background-color: var(--st-danger-background);
   --ifm-alert-background-color-highlight: var(--st-danger-accent);
   --ifm-alert-foreground-color: var(--st-danger-text);
@@ -1395,7 +1396,8 @@ details summary::before {
   --ifm-alert-border-color: var(--st-warning-accent);
 }
 
-.alert--v4compatible, .alert--breakingchange {
+.alert--v4compatible,
+.alert--breakingchange {
   width: fit-content;
   padding: 4px 10px;
 }
@@ -1586,8 +1588,8 @@ a.link-box strong {
   text-align: center;
 }
 
-.docs-intro h2:hover a.hash-link  {
- opacity: 0;
+.docs-intro h2:hover a.hash-link {
+  opacity: 0;
 }
 
 .docs-intro-studio,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,6 +22,7 @@
 
 html,
 body {
+  background-color: var(--st-background);
   font-weight: var(--ifm-font-weight-normal);
   letter-spacing: -0.011rem;
   line-height: 1.625;
@@ -1091,7 +1092,7 @@ html [class*='toggleButton'] {
 
 .theme-doc-sidebar-item-category-level-1 a,
 .theme-doc-sidebar-item-link-level-1 a {
-  color: var(--ifm-color-emphasis-0);
+  color: var(--st-text-highlight);
 }
 
 .theme-doc-sidebar-item-category-level-1 ul li,
@@ -1175,7 +1176,7 @@ html [class*='toggleButton'] {
 .menu__list-item .menu__list-item .menu__link--active {
   border-left: 3px solid var(--st-menu-link-border-active);
   margin-left: -4px;
-  color: var(--ifm-color-emphasis-0);
+  color: var(--st-text-highlight);
 }
 
 .menu__list-item .menu__list-item .menu__list-item .menu__link--active {
@@ -1717,6 +1718,7 @@ ul.blog-list {
 /* Footer */
 
 .footer {
+  background: var(--st-background);
   border-top: 1px solid var(--st-header-border);
   padding: 0.5rem;
 }

--- a/versioned_docs/version-5/actions.mdx
+++ b/versioned_docs/version-5/actions.mdx
@@ -524,7 +524,29 @@ const countMachine = createMachine({
 
 ## TypeScript
 
-_Coming soon_
+You can strongly type the `actions` of your machine in the `types.actions` property of the machine config.
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    // highlight-start
+    actions:
+      | {
+          type: 'track';
+          params: {
+            response: string;
+          };
+        }
+      | { type: 'increment'; params: { value: number } };
+    // highlight-end
+  },
+  // ...
+  entry: [
+    { type: 'track', params: { response: 'good' } },
+    { type: 'increment', params: { value: 1 } },
+  ],
+});
+```
 
 ## Cheatsheet
 

--- a/versioned_docs/version-5/actors.mdx
+++ b/versioned_docs/version-5/actors.mdx
@@ -413,7 +413,39 @@ function Component(props: { actor?: AnyActorRef }) {
 
 ## TypeScript
 
-_Coming soon_
+You can strongly type the `actors` of your machine in the `types.actors` property of the machine config.
+
+```ts
+const fetcher = fromPromise(
+  async ({ input }: { input: { userId: string } }) => {
+    const user = await fetchUser(input.userId);
+
+    return user;
+  },
+);
+
+const machine = createMachine({
+  types: {} as {
+    // highlight-start
+    actors: {
+      src: 'fetchData'; // src name (inline behaviors ideally inferred)
+      id: 'fetch1' | 'fetch2'; // possible ids (optional)
+      logic: typeof fetcher;
+    };
+    // highlight-end
+  },
+  invoke: {
+    src: 'fetchData', // strongly typed
+    id: 'fetch2', // strongly typed
+    onDone: {
+      actions: ({ event }) => {
+        event.output; // strongly typed as { result: string }
+      },
+    },
+    input: { userId: '42' }, // strongly typed
+  },
+});
+```
 
 ## Cheatsheet
 

--- a/versioned_docs/version-5/context.mdx
+++ b/versioned_docs/version-5/context.mdx
@@ -151,13 +151,22 @@ feedbackActor.send({
 
 ## TypeScript
 
+You can strongly type the `context` of your machine in the `types.context` property of the machine config.
+
 ```ts
 const machine = createMachine({
-  schema: {} as {
+  types: {} as {
+    // highlight-start
     context: {
       feedback: string;
       rating: number;
     };
+    // highlight-end
+  },
+  // Initial context
+  context: {
+    feedback: '',
+    rating: 5,
   },
   entry: ({ context }) => {
     context.feedback; // string

--- a/versioned_docs/version-5/delayed-transitions.mdx
+++ b/versioned_docs/version-5/delayed-transitions.mdx
@@ -72,14 +72,14 @@ Delayed transitions have a default time interval of 500ms (0.5 seconds).
 
 1. Select the event you want to replace with a delayed transition.
 1. Right-click the event to open the edit menu.
-2. From the **Event type** options, choose **After** to turn the event into a delayed transition.
+1. From the **Event type** options, choose **After** to turn the event into a delayed transition.
 
 #### Using the transition Details panel
 
 1. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
 2. From the **Event type** dropdown menu, choose **After** to turn the event into a delayed transition.
 
-#### Specify delay time 
+#### Specify delay time
 
 Your delay time interval will be displayed in a human-readable format on hover. For example, 15000ms will be displayed as 15 seconds.
 
@@ -160,7 +160,36 @@ Delayed transition timers are canceled when the state is exited.
 
 ## TypeScript
 
-_Coming soon_
+You can strongly type the `delays` of your machine in the `types.delays` property of the machine config.
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    // highlight-start
+    delays: 'shortTimeout' | 'longTimeout' | 'eventually';
+    // highlight-end
+    // ...
+  },
+  // ...
+  after: {
+    // Autocompleted
+    shortTimeout: {
+      /* ... */
+    },
+  },
+  on: {
+    someEvent: {
+      actions: raise(
+        { type: 'anotherEvent' },
+        {
+          // Autocompleted
+          delay: 'eventually',
+        },
+      ),
+    },
+  },
+});
+```
 
 ## Cheatsheet
 

--- a/versioned_docs/version-5/eventless-transitions.mdx
+++ b/versioned_docs/version-5/eventless-transitions.mdx
@@ -26,7 +26,10 @@ Eventless transitions are labeled “always” and often referred to as “alway
 }
 ```
 
-<SkipDownLink text="Jump to learning more about eventless transitions in XState" link="#eventless-transitions-and-guards"/>
+<SkipDownLink
+  text="Jump to learning more about eventless transitions in XState"
+  link="#eventless-transitions-and-guards"
+/>
 
 ## Using eventless transitions in Stately Studio
 
@@ -77,7 +80,24 @@ Coming soon… examples
 
 ## TypeScript
 
-_Coming soon_
+Eventless transitions can potentially be enabled by any event, so the `event` type is the union of all possible events.
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    events: { type: 'greet'; message: string } | { type: 'submit' };
+  },
+  // ...
+  always: {
+    actions: ({ event }) => {
+      event.type; // 'greet' | 'submit'
+    },
+    guard: ({ event }) => {
+      event.type; // 'greet' | 'submit'
+    },
+  },
+});
+```
 
 ## Cheatsheet
 

--- a/versioned_docs/version-5/finite-states.mdx
+++ b/versioned_docs/version-5/finite-states.mdx
@@ -167,25 +167,7 @@ console.log(feedbackActor..getSnapshot().hasTag('visible'));
 // logs true
 ```
 
-### Using tags in Stately Studio
-
-You can add tags to states and events in Stately Studio.
-
-First, select the state or event you want to tag.
-
-#### On the canvas
-
-1. Use the <Plus size={18} /> plus icon button to open the edit menu.
-2. Choose <Tag size={18} /> **Tag** from the menu to add a tag block.
-3. Write your tag’s name in the tag’s text input.
-4. Use the <PlusSquare size={18} /> plus icon button alongside your recent tag to add more tags.
-
-#### Using the event details panel
-
-1. Open the state or event <Info size={18} /> **Details** panel from the right tool menu.
-2. Use the **+ Tag** button to add a tag block.
-3. Write your tag’s name in the tag’s text input.
-4. Use the <PlusSquare size={18} /> plus icon button alongside your recent tag to add more tags.
+Read more about [tags](tags.mdx).
 
 ## Meta
 

--- a/versioned_docs/version-5/guards.mdx
+++ b/versioned_docs/version-5/guards.mdx
@@ -235,7 +235,31 @@ on: {
 
 ## TypeScript
 
-_Coming soon_.
+You can strongly type the `guards` of your machine in the `types.guards` property of the machine config.
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    // highlight-start
+    guards:
+      | {
+          type: 'isGreaterThan';
+          params: {
+            count: number;
+          };
+        }
+      | { type: 'isAllowed' };
+    // highlight-end
+  },
+  // ...
+  on: {
+    event: {
+      guard: { type: 'isGreaterThan', params: { count: 5 } },
+      // ...
+    },
+  },
+});
+```
 
 ## Cheatsheet
 

--- a/versioned_docs/version-5/input.mdx
+++ b/versioned_docs/version-5/input.mdx
@@ -253,16 +253,36 @@ const Component = (props) => {
 
 ## TypeScript
 
+You can strongly type the `input` of your machine in the `types.input` property of the machine config.
+
 ```ts
 import { createActor, createMachine } from 'xstate';
 
 const machine = createMachine({
   types: {} as {
+    // highlight-start
     input: {
       userId: string;
       defaultRating: number;
     };
-    // ...
+    // highlight-end
+    context: {
+      userId: string;
+      feedback: string;
+      rating: number;
+    };
+  },
+  context: ({ input }) => ({
+    userId: input.userId,
+    feedback: '',
+    rating: input.defaultRating,
+  }),
+});
+
+const actor = createActor(machine, {
+  input: {
+    userId: '123',
+    defaultRating: 5,
   },
 });
 ```

--- a/versioned_docs/version-5/studio.mdx
+++ b/versioned_docs/version-5/studio.mdx
@@ -37,6 +37,7 @@ Stately Studio’s editor supports everything you need to visually build state m
 You can access quick start tutorials from the blue <HelpCircle size={12} /> Help button in the editor.
 
 When you first visit the Editor, you’ll be shown two short videos (7m36s) as a quick start guide. You can access these videos again anytime from:
+
 - Editor menu > Help > <GraduationCap size={12} /> **Learn Stately**.
 - The <HelpCircle size={12} /> Help button > <GraduationCap size={12} /> **Learn Stately**.
 

--- a/versioned_docs/version-5/tags.mdx
+++ b/versioned_docs/version-5/tags.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Tags'
+---
+
+State nodes can have **tags**, which are string terms that help group or categorize the state node. For example, you can signify which state nodes represent states in which data is being loaded by using a "loading" tag, and determine if a state contains those tagged state nodes with `state.hasTag(tag)`:
+
+```ts
+const feedbackMachine = createMachine({
+  id: 'feedback',
+  initial: 'prompt',
+  states: {
+    prompt: {
+      tags: ['visible'],
+      // ...
+    },
+    form: {
+      tags: ['visible'],
+      // ...
+    },
+    thanks: {
+      tags: ['visible', 'confetti'],
+      // ...
+    },
+    closed: {
+      tags: ['hidden'],
+    },
+  },
+});
+
+const feedbackActor = createActor(feedbackMachine).start();
+
+console.log(feedbackActor..getSnapshot().hasTag('visible'));
+// logs true
+```
+
+## Using tags in Stately Studio
+
+You can add tags to states and events in Stately Studio.
+
+First, select the state or event you want to tag.
+
+### On the canvas
+
+1. Use the <Plus size={18} /> plus icon button to open the edit menu.
+2. Choose <Tag size={18} /> **Tag** from the menu to add a tag block.
+3. Write your tag’s name in the tag’s text input.
+4. Use the <PlusSquare size={18} /> plus icon button alongside your recent tag to add more tags.
+
+### Using the event details panel
+
+1. Open the state or event <Info size={18} /> **Details** panel from the right tool menu.
+2. Use the **+ Tag** button to add a tag block.
+3. Write your tag’s name in the tag’s text input.
+4. Use the <PlusSquare size={18} /> plus icon button alongside your recent tag to add more tags.
+
+## TypeScript
+
+You can strongly type the `guards` of your machine in the `types.guards` property of the machine config.
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    // highlight-start
+    tags: 'pending' | 'success' | 'error';
+    // highlight-end
+  },
+  // ...
+  states: {
+    loadingUser: {
+      tags: ['pending'],
+    },
+  },
+});
+
+const actor = createActor(machine).start();
+
+actor
+  .getSnapshot()
+  // Autocompleted
+  .hasTag('pending');
+```

--- a/versioned_docs/version-5/transitions.mdx
+++ b/versioned_docs/version-5/transitions.mdx
@@ -6,7 +6,10 @@ A **transition** is a change from one finite state to another, triggered by an e
 
 An **event** is a signal, trigger, or message that causes a transition. When an actor receives an event, its machine will determine if there are any enabled transitions for that event in the current state. If enabled transitions exist, the machine will take them and execute their actions.
 
-<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9630e3b7-9f8e-4dc9-8b55-661f854d28b7"/>
+<EmbedMachine
+  name="Video player"
+  embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9630e3b7-9f8e-4dc9-8b55-661f854d28b7"
+/>
 
 Transitions are “deterministic”; each combination of state and event always points to the same next state. When a state machine receives an event, only the active finite states are checked to see if any of them have a transition for that event. Those transitions are called **enabled transitions**. If there is an enabled transition, the state machine will execute the transition's actions, and then transition to the target state.
 
@@ -30,7 +33,10 @@ const feedbackMachine = createMachine({
 });
 ```
 
-<SkipDownLink text="Jump to learning more about event objects in XState" link="#event-objects"/>
+<SkipDownLink
+  text="Jump to learning more about event objects in XState"
+  link="#event-objects"
+/>
 
 ## Using transitions and events in Stately Studio
 
@@ -155,7 +161,7 @@ In XState v4, re-entering transitions were known as **external transitions**, an
 
 Coming soon… illustration showing no re-enter vs. re-enter
 
-Coming soon…  example with `{ target: '.child', reenter: true }`
+Coming soon… example with `{ target: '.child', reenter: true }`
 
 ## Transitions to any state
 
@@ -247,7 +253,7 @@ Since parallel states have multiple regions that can be active at the same time,
 
 Multiple targets are specified as an array of strings:
 
-Coming soon…  example.
+Coming soon… example.
 
 ## Other transitions
 
@@ -302,7 +308,24 @@ Using the string target shorthand is useful for quickly prototyping state machin
 
 ## TypeScript
 
-_Coming soon_
+Transitions mainly use the event type that they are enabled by.
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    events: { type: 'greet'; message: string } | { type: 'submit' };
+  },
+  // ...
+  on: {
+    greet: {
+      actions: ({ event }) => {
+        event.type; // 'greet'
+        event.message; // string
+      },
+    },
+  },
+});
+```
 
 ## Cheatsheet
 

--- a/versioned_sidebars/version-5-sidebars.json
+++ b/versioned_sidebars/version-5-sidebars.json
@@ -244,7 +244,8 @@
         "initial-states",
         "final-states",
         "history-states",
-        "persistence"
+        "persistence",
+        "tags"
       ]
     },
     {


### PR DESCRIPTION
This PR fills out the TypeScript section wherever applicable with the latest way of strongly typing via XState v5.

I also did a couple of style tweaks (asking for forgiveness @laurakalbag)

![CleanShot 2023-09-10 at 17 14 58@2x](https://github.com/statelyai/docs/assets/1093738/89fb09d9-eea9-4ff7-af74-9c448035b4c6)
![CleanShot 2023-09-10 at 16 40 06@2x](https://github.com/statelyai/docs/assets/1093738/b74cffe7-bbbc-440e-9587-4e8d82516b7d)

Side-by-side docs style tweaks:

<img width="1725" alt="CleanShot 2023-09-10 at 19 56 45@2x" src="https://github.com/statelyai/docs/assets/1093738/e021ab07-72c9-4d66-a3d3-42609f110c9b">

