### PR TITLE
Add info on the free Viewer role and fix broken links

### DIFF
--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -23,7 +23,7 @@ Teams and shared projects are Pro features of Stately Studio. [Check out the fea
 
 ## Team roles
 
-Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [Editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
+Team members can have one of the following roles: [Owner](./teams#owner-role), [Admin](./teams#admin-role), [Editor](./teams#editor-role), or [Viewer](./teams#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
 
 The following table is an overview of the capabilities of each team role:
 
@@ -85,6 +85,12 @@ Users with the Editor role can:
 
 ### Viewer role
 
+:::studio
+
+A Viewer is free of charge and does not count toward your number of seats.
+
+:::
+
 Users with the Viewer role can:
 
 - View team members
@@ -96,7 +102,7 @@ Users with the Viewer role can:
 1. Use the **Create team** link in the left sidebar of Stately Studio’s workspace to open the Create team form.
 2. Name your team and use the **Create team** button to create your team.
 
-By default, teams have only one member, the creator and Owner. [Invite new members](/#invite-new-members-to-a-team) to add more members to your team.
+By default, teams have only one member, the creator and Owner. [Invite new members](./teams#invite-new-members-to-a-team) to add more members to your team.
 
 ## Edit the team name
 
@@ -106,7 +112,7 @@ By default, teams have only one member, the creator and Owner. [Invite new membe
 
 ## Invite new members to a team
 
-You need to have [enough seats on your Pro plan](/#teams-members-and-pro-plan-seats) to add more members to your team.
+You need to have [enough seats on your Pro plan](./teams#teams-members-and-pro-plan-seats) to add more members to your team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. On your team page, use the **Members** tab to view existing members and their roles and invite new members.
@@ -133,7 +139,7 @@ A subscription seat is only taken up at the time of accepting the invitation. An
 
 ## Change a team member’s role
 
-To change a team member’s role, you must have the [Owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
+To change a team member’s role, you must have the [Owner role](./teams#owner-role) or [Admin role](./teams#admin-role) for that team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
@@ -151,7 +157,7 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 ## Remove a member from a team
 
-To remove a member from a team, you must have the [owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
+To remove a member from a team, you must have the [owner role](./teams#owner-role) or [Admin role](./teams#admin-role) for that team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.

--- a/versioned_docs/version-5/teams.mdx
+++ b/versioned_docs/version-5/teams.mdx
@@ -23,7 +23,7 @@ Teams and shared projects are Pro features of Stately Studio. [Check out the fea
 
 ## Team roles
 
-Team members can have one of the following roles: [Owner](/#owner-role), [Admin](/#admin-role), [Editor](/#editor-role), or [Viewer](/#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
+Team members can have one of the following roles: [Owner](./teams#owner-role), [Admin](./teams#admin-role), [Editor](./teams#editor-role), or [Viewer](./teams#viewer-role). Team owners or admins assign the role to the new team member when inviting them to join the team.
 
 The following table is an overview of the capabilities of each team role:
 
@@ -85,19 +85,24 @@ Users with the Editor role can:
 
 ### Viewer role
 
+:::studio
+
+A Viewer is free of charge and does not count toward your number of seats.
+
+:::
+
 Users with the Viewer role can:
 
 - View team members
 - View team projects and machines
 - Export team machines
 
-
 ## Create a team
 
 1. Use the **Create team** link in the left sidebar of Stately Studio’s workspace to open the Create team form.
 2. Name your team and use the **Create team** button to create your team.
 
-By default, teams have only one member, the creator and Owner. [Invite new members](/#invite-new-members-to-a-team) to add more members to your team.
+By default, teams have only one member, the creator and Owner. [Invite new members](./teams#invite-new-members-to-a-team) to add more members to your team.
 
 ## Edit the team name
 
@@ -107,7 +112,7 @@ By default, teams have only one member, the creator and Owner. [Invite new membe
 
 ## Invite new members to a team
 
-You need to have [enough seats on your Pro plan](/#teams-members-and-pro-plan-seats) to add more members to your team.
+You need to have [enough seats on your Pro plan](./teams#teams-members-and-pro-plan-seats) to add more members to your team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. On your team page, use the **Members** tab to view existing members and their roles and invite new members.
@@ -134,7 +139,7 @@ A subscription seat is only taken up at the time of accepting the invitation. An
 
 ## Change a team member’s role
 
-To change a team member’s role, you must have the [Owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
+To change a team member’s role, you must have the [Owner role](./teams#owner-role) or [Admin role](./teams#admin-role) for that team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.
@@ -152,7 +157,7 @@ To change a team member’s role, you must have the [Owner role](/#owner-role) o
 
 ## Remove a member from a team
 
-To remove a member from a team, you must have the [owner role](/#owner-role) or [Admin role](/#admin-role) for that team.
+To remove a member from a team, you must have the [owner role](./teams#owner-role) or [Admin role](./teams#admin-role) for that team.
 
 1. Navigate to the team page from the left sidebar of Stately Studio’s workspace.
 2. Navigate to the **Members** tab on the team page.


### PR DESCRIPTION
This PR adds info about the Viewer role being free of charge and fixes some broken links on the Team page.
![CleanShot 2023-09-14 at 09 35 33](https://github.com/statelyai/docs/assets/167574/e79c8266-48f6-4be9-bf1a-6076ff909a5a)
