### PR TITLE
Fix a few broken links on the docs landing page

### DIFF
--- a/docs/studio.mdx
+++ b/docs/studio.mdx
@@ -9,19 +9,19 @@ Here you can find all the documentation for the Stately Studio and [XState](/xst
 
 <ul className="content-boxes">
   <li>
-    <a className="link-box" href="states/intro">
+    <a className="link-box" href="docs/states/intro">
       🏁 <strong>Get started</strong> Jump straight into learning how to use the
       editor, starting with states.
     </a>
   </li>
   <li>
-    <a className="link-box" href="#stately-studio-editor">
+    <a className="link-box" href="#stately-studios-editor">
       ⬇️ <strong>Editor overview</strong> Keep reading to find out more about
       Stately Studio’s editor.
     </a>
   </li>
   <li>
-    <a className="link-box" href="state-machines-and-statecharts">
+    <a className="link-box" href="docs/state-machines-and-statecharts">
       🧠 <strong>Learn state machines and statecharts</strong> With our no-code
       introduction.
     </a>
@@ -69,6 +69,7 @@ Stately Studio’s editor supports everything you need to visually build state m
 You can access quick start tutorials from the blue <HelpCircle size={12} /> Help button in the editor.
 
 When you first visit the Editor, you’ll be shown two short videos (7m36s) as a quick start guide. You can access these videos again anytime from:
+
 - Editor menu > Help > <GraduationCap size={12} /> **Learn Stately**.
 - The <HelpCircle size={12} /> Help button > <GraduationCap size={12} /> **Learn Stately**.
 


### PR DESCRIPTION
This fixes a few broken links on the docs landing page