### PR TITLE
Add Crisp chat box to landing page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,22 @@ export default function Index() {
       // Convert the response to text
       .then((response) => response.text())
       // Set the HTML
-      .then((html) => setHtml(html));
+      .then((html) => {
+        setHtml(html);
+
+        // Add the crisp chat script after the dynamic html has been loaded
+        // @ts-ignore
+        window.$crisp = [];
+        // @ts-ignore
+        window.CRISP_WEBSITE_ID = 'dff22f8a-0d73-4a83-91be-1f448410c464';
+        (function () {
+          let d = document;
+          let s = d.createElement('script');
+          s.src = 'https://client.crisp.chat/l.js';
+          s.async = true;
+          d.getElementsByTagName('head')[0].appendChild(s);
+        })();
+      });
   }, []);
 
   // Draw the arrows after any changes to the HTML

--- a/static/index.html
+++ b/static/index.html
@@ -47,6 +47,17 @@
       src="https://plausible.io/js/plausible.js"
     ></script>
     <script defer src="./landing-page/bundle.js"></script>
+    <script type="text/javascript">
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = 'dff22f8a-0d73-4a83-91be-1f448410c464';
+      (function () {
+        d = document;
+        s = d.createElement('script');
+        s.src = 'https://client.crisp.chat/l.js';
+        s.async = 1;
+        d.getElementsByTagName('head')[0].appendChild(s);
+      })();
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
Add the [Crisp chatbox](https://crisp.chat/en/livechat/) to the landing page. This will make it easier for visitors to quickly get in touch with us.