### PR TITLE
Fix too much space above headings in tip boxes (admonitions)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1428,6 +1428,7 @@ details summary::before {
 .alert:not(details) h6 {
   color: inherit;
   font-size: 1.1rem;
+  margin-top: 0;
   margin-bottom: calc(var(--ifm-alert-padding-vertical) * 0.5);
 }
 


### PR DESCRIPTION
Before: 
![CleanShot 2023-10-06 at 18 06 39@2x](https://github.com/statelyai/docs/assets/266663/e8be3474-9368-4f0c-99df-f03efb836872)

After:
![CleanShot 2023-10-06 at 18 07 17@2x](https://github.com/statelyai/docs/assets/266663/4ad2491b-81aa-4735-b5a6-d206af7e7ddd)
