### PR TITLE
Fix duplicate sentence in actor docs

### DIFF
--- a/docs/actors.mdx
+++ b/docs/actors.mdx
@@ -187,8 +187,6 @@ See [persistence](persistence.mdx) for more details.
 
 You can wait for an actor’s snapshot to satisfy a predicate using the `waitFor(actor, predicate, options?)` helper function. The `waitFor(...)` function returns a promise that is:
 
-You can wait for an actor’s snapshot to satisfy a predicate using the `waitFor(actor, predicate, options?)` helper function. The `waitFor(...)` function returns a promise that is:
-
 - Resolved when the emitted snapshot satisfies the `predicate` function
 - Resolved immediately if the current snapshot already satisfies the `predicate` function
 - Rejected if an error is thrown or the `options.timeout` value is elapsed.


### PR DESCRIPTION
While reading the documentation on actors I discovered some duplicate sentences. This commit gets rid of the duplicate.
Interestingly the docs also show a second duplicate sentence, but in the source it is only visible once: 
![image](https://github.com/statelyai/docs/assets/6529243/7bf620d0-7416-4adc-9f49-232a33afe6cf)
