### PR TITLE
Unbreak more links

### DIFF
--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -18,8 +18,9 @@ hide_title: true
       />
     </h2>
     <p>
-      <a href="./studio">Stately Studio</a> is a suite of tools for visualizing
-      and collaborating on your application logic, powered by XState.
+      <a href="./docs/studio">Stately Studio</a> is a suite of tools for
+      visualizing and collaborating on your application logic, powered by
+      XState.
     </p>
   </div>
   <div class="docs-intro-xstate">
@@ -33,8 +34,8 @@ hide_title: true
       />
     </h2>
     <p>
-      <a href="./xstate">XState</a> is a best-in-class open source library for
-      orchestrating and managing state in JavaScript and TypeScript apps.
+      <a href="./docs/xstate">XState</a> is a best-in-class open source library
+      for orchestrating and managing state in JavaScript and TypeScript apps.
     </p>
   </div>
 </div>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,6 +105,36 @@ const config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Unbreak specific pages we know are broken where the structure changed between XState v4 and v5
+        redirects: [
+          {
+            to: '/docs/xstate-v4/xstate/model-based-testing/intro',
+            from: '/docs/category/xstate-model-based-testing',
+          },
+          {
+            to: '/docs/xstate-v4/xstate/actors/parent-child-communication',
+            from: '/docs/xstate/actors/parent-child-communication',
+          },
+          {
+            to: '/docs/xstate-v4/xstate/typescript/type-helpers',
+            from: '/docs/xstate/typescript/type-helpers',
+          },
+        ],
+        createRedirects(existingPath) {
+          if (existingPath.includes('/docs')) {
+            // Redirect everything from /docs/xstate-v5 to /docs (to unbreak Google search results)
+            return [existingPath.replace('/docs', '/docs/xstate-v5')];
+          }
+          return undefined; // Return a falsy value: no redirect created
+        },
+      },
+    ],
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.3",
+    "@docusaurus/plugin-client-redirects": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",
     "@docusaurus/remark-plugin-npm2yarn": "^2.4.3",
     "@mdx-js/react": "^1.6.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,6 +1484,21 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
+"@docusaurus/plugin-client-redirects@^2.4.3":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.3.tgz#0da7e6facadbca3bd7cb8d0453f21bea7f4f1721"
+  integrity sha512-iCwc/zH8X6eNtLYdyUJFY6+GbsbRgMgvAC/TmSmCYTmwnoN5Y1Bc5OwUkdtoch0XKizotJMRAmGIAhP8sAetdQ==
+  dependencies:
+    "@docusaurus/core" "2.4.3"
+    "@docusaurus/logger" "2.4.3"
+    "@docusaurus/utils" "2.4.3"
+    "@docusaurus/utils-common" "2.4.3"
+    "@docusaurus/utils-validation" "2.4.3"
+    eta "^2.0.0"
+    fs-extra "^10.1.0"
+    lodash "^4.17.21"
+    tslib "^2.4.0"
+
 "@docusaurus/plugin-content-blog@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.3.tgz#6473b974acab98e967414d8bbb0d37e0cedcea14"


### PR DESCRIPTION
This pull request adds a pattern to redirect all traffic from `/docs/xstate-v5/*` to `/docs/*`. It also fixes a few specific pages that we know are broken and are not covered by the pattern redirect due to changes in their structure.