### PR TITLE
Match pricing page enterprise features to studio billing page

### DIFF
--- a/static/pricing/index.html
+++ b/static/pricing/index.html
@@ -187,18 +187,20 @@
                 >
               </div>
               <ul class="feature-list">
-                <li class="pricing-text">Everything from Community and Pro</li>
+                <li class="pricing-text">
+                  Everything from the Community and Pro plans
+                </li>
+                <li class="pricing-text">Unlimited generated flows</li>
                 <li class="pricing-text">Flexible hosting</li>
-                <li class="pricing-text">Dedicated support</li>
+                <li class="pricing-text">Dedicated priority support</li>
                 <li class="pricing-text">Custom server locations</li>
-                <li class="pricing-text">User provisioning</li>
                 <li class="pricing-text">Single sign-on (SSO)</li>
                 <li class="pricing-text">Audit logs</li>
-                <li class="pricing-text">Embed Stately</li>
+                <li class="pricing-text">Embed Stately into your own apps</li>
                 <li class="pricing-text">
-                  Custom action and invoked actor collections
+                  Custom effect collections (actions, actors, and more)
                 </li>
-                <li class="pricing-text">Custom formats for export</li>
+                <li class="pricing-text">Custom export formats</li>
                 <li class="pricing-text">Prioritized feature requests</li>
                 <li class="pricing-text">
                   A custom plan tailored to the requirements of your


### PR DESCRIPTION
This PR updates the features in the Enterprise plan on the pricing page to match those on the Studio billing page

Preview at: https://docs-qztml5mok-statelyai.vercel.app/pricing

Before:
![CleanShot 2023-10-26 at 10 29 02@2x](https://github.com/statelyai/docs/assets/266663/4a29f772-48e8-4934-9105-2cb03d09a6c2)


After:
![CleanShot 2023-10-26 at 10 26 14@2x](https://github.com/statelyai/docs/assets/266663/642da908-1510-463d-b5c8-8483abcdf424)

Spot the difference 😉 