### PR TITLE
Move Stately instructions to sub pages

### DIFF
--- a/blog/2023-06-14-supercharge-the-canvas/index.mdx
+++ b/blog/2023-06-14-supercharge-the-canvas/index.mdx
@@ -44,7 +44,7 @@ You can now do much more work on the canvas itself.
 
 Being able to stay on the canvas keeps you closer to your content, lets interactions be more intuitive, can help you stay focused, and can even give you more room to work.
 
-For example, we enhanced the Edit Menu to support adding [actions](/docs/actions#using-actions-in-stately-studio), tags, and other data to [states](/docs/states#using-states-in-stately-studio) and [transitions](/docs/transitions#using-transitions-and-events-in-stately-studio). And most items on the canvas can then be edited directly.
+For example, we enhanced the Edit Menu to support adding [actions](/docs/editor-invoke), tags, and other data to [states](/docs/editor-states) and [transitions](/docs/editor-transitions). And most items on the canvas can then be edited directly.
 
 <video
   src="https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/videos/create-from-canvas.mp4"
@@ -64,7 +64,7 @@ For example, we enhanced the Edit Menu to support adding [actions](/docs/actions
 
 Statecharts are great for modeling how a process goes from state to state when an event occurs. This is especially powerful since you can also make things happen by having effects run at specific times.
 
-The most important addition we’ve made with this release is that effects ([invoked actors](/docs/invoke#using-invoked-actors-in-stately-studio), entry actions, and exit actions) are now interactive. They are represented as blocks on the canvas that can be placed inside states and transitions.
+The most important addition we’ve made with this release is that effects ([invoked actors](/docs/editor-invoke), entry actions, and exit actions) are now interactive. They are represented as blocks on the canvas that can be placed inside states and transitions.
 
 This will make it easy to define, understand, and modify your app’s behavior as users step through your flow.
 

--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -44,13 +44,6 @@ Examples of actions:
 - Sending a message to another [actor](actors.mdx)
 - _Coming soon: more examples_
 
-<SkipDownLink
-  text="Jump to learning more about entry and exit actions in XState"
-  link="#entry-and-exit-actions"
-/>
-
-## Using actions in Stately Studio
-
 In our video player machine, we have entry and exit actions on the Playing state. We use the entry action of playVideo to fire an effect playing the video on entry to the Playing state. We use the exit action of pauseVideo to fire an effect pausing the video when the Playing state is exited.
 
 <EmbedMachine
@@ -58,116 +51,11 @@ In our video player machine, we have entry and exit actions on the Playing state
   embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=222e2d7a-0ed6-4f2c-843a-e6646d717000"
 />
 
-### Add a transition action
+:::studio
 
-First, select the event where you want an action to be fired.
+[Learn how to use actions in Stately’s editor](TODO).
 
-### On the canvas
-
-1. Use the <Plus size={18} /> plus icon button to open the edit menu.
-2. Choose <Zap size={18} /> **Action** from the menu to add an action block.
-3. Write your action’s name in the action’s text input.
-
-### Using the event details panel
-
-1. Open the event <Info size={18} /> **Details** panel from the right tool menu.
-2. Use the **+ Transition action** button to add an action block.
-3. Write your action’s name in the action’s text input.
-
-## Delete a transition action
-
-First, select the transition action block you want to delete.
-
-### Using backspace
-
-Use the <kbd>Backspace</kbd> key to delete the transition action.
-
-### Using the event details panel
-
-1. Open the event <Info size={18} /> **Details** panel from the right tool menu.
-2. Hover, focus, or select the transition action block to reveal the <Trash size={18} /> trash icon button.
-3. Use the <Trash size={18} /> trash icon button to delete the action.
-
-## Add an entry action or exit action to a state
-
-First, select the state you want to have an entry or exit action.
-
-### On the canvas
-
-1. Select the state where you want to add an action.
-2. Use the <Plus size={18} /> plus icon button to open the edit menu.
-3. Choose <Zap size={18} /> **Entry action** or <Zap size={18} /> **Exit action** from the menu to add an action block to the event.
-4. Write your action’s name in the action’s text input.
-
-### Using the event details panel
-
-1. Open the state <Info size={18} /> **Details** panel from the right tool menu.
-2. Use the **+ Effect** button to open the effects menu, and choose **Add entry action** or **Add exit action**.
-3. Write your action’s name in the action’s text input.
-
-## Delete an entry action or exit action from a state
-
-First, select the action block you want to delete.
-
-### Using backspace
-
-Use the <kbd>Backspace</kbd> key to delete the action.
-
-### Using the event details panel
-
-1. Open the event <Info size={18} /> **Details** panel from the right tool menu.
-2. Hover, focus, or select the action block to reveal the <Trash size={18} /> trash icon button.
-3. Use the <Trash size={18} /> trash icon button to delete the action.
-
-## Add a built-in action
-
-You can add built-in XState actions which will be formatted in your [exported code](export-as-code.mdx). The options are:
-
-- [assign](#assign-action): assigns data to the state context.
-- [raise](#raise-action): _raises_ an event that is received by the same machine.
-- [log](#log-action): an easy way to log messages to the console.
-- [sendTo](#send-to-action): sends an event to a specific actor.
-- [stop](#stop-action): stops a child actor.
-
-To add a built-in action, first add a [transition action](#add-a-transition-action), [entry action](#add-an-entry-action-or-exit-action-to-a-state), or [exit action](#add-an-entry-action-or-exit-action-to-a-state).
-
-### On the canvas
-
-1. Hover, focus, or select the action block to reveal the <Edit size={18} /> edit icon button.
-2. Use the <Edit size={18} /> edit icon button to open the **Action** panel.
-3. Choose your desired action from the dropdown menu at the top of the **Action** panel.
-4. Fill out the required corresponding action input fields.
-
-### Using the details panel
-
-1. Open the state, or event <Info size={18} /> **Details** panel from the right tool menu.
-1. Hover, focus, or select the action block to reveal the <Edit size={18} /> edit icon button.
-1. Use the <Edit size={18} /> edit icon button to open the **Action** panel.
-1. Choose your desired action from the dropdown menu at the top of the **Action** panel.
-1. Fill out the required corresponding action input fields.
-
-## Add a custom action
-
-You can also add custom actions with a custom action type and parameters which will be formatted as [XState action objects](#action-objects) in your [exported code](export-as-code.mdx).
-
-First, add a [transition action](#add-a-transition-action), [entry action](#add-an-entry-action-or-exit-action-to-a-state), or [exit action](#add-an-entry-action-or-exit-action-to-a-state).
-
-### On the canvas
-
-1. Hover, focus, or select the action block to reveal the <Edit size={18} /> edit icon button.
-2. Use the <Edit size={18} /> edit icon button to open the **Action** panel.
-3. Custom action is selected by default. Add your custom action type in the **Action type** text input.
-4. Add your custom **Action parameters** using the **Parameter key** and **Parameter value** text input pairs.
-
-[Read about action objects below for more on action types and and parameters](#action-objects).
-
-### Using the details panel
-
-1. Open the state, or event <Info size={18} /> **Details** panel from the right tool menu.
-1. Hover, focus, or select the action block to reveal the <Edit size={18} /> edit icon button.
-1. Use the <Edit size={18} /> edit icon button to open the **Action** panel.
-1. Custom action is selected by default. Add your custom action type in the **Action type** text input.
-1. Add your custom **Action parameters** using the **Parameter key** and **Parameter value** text input pairs.
+:::
 
 ## Entry and exit actions
 

--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -53,7 +53,7 @@ In our video player machine, we have entry and exit actions on the Playing state
 
 :::studio
 
-[Learn how to use actions in Stately’s editor](TODO).
+[Learn how to use actions in Stately’s editor](./editor-actions.mdx).
 
 :::
 

--- a/docs/actors.mdx
+++ b/docs/actors.mdx
@@ -19,7 +19,7 @@ Watch our [“What are invoked actors?” video on YouTube](https://www.youtube.
 
 ## Using actors in Stately Studio
 
-[Read about using invoked actors in Stately Studio](invoke.mdx#using-invoked-actors-in-stately-studio).
+[Read about using invoked actors in Stately Studio](./editor-invoke.mdx).
 
 ## Actor model
 

--- a/docs/context.mdx
+++ b/docs/context.mdx
@@ -30,18 +30,11 @@ feedbackActor.start();
 // logs 'Some feedback'
 ```
 
-<SkipDownLink
-  text="Jump to learning more about context in XState"
-  link="#initial-context"
-/>
+:::studio
 
-## Using context in Stately Studio
+[Read about setting context in Stately’s editor](TODO).
 
-- Coming soon… setting initial values
-- Coming soon… updating context with assign
-- Coming soon… JS/TS export
-
----
+:::
 
 ## Initial context
 

--- a/docs/context.mdx
+++ b/docs/context.mdx
@@ -32,7 +32,7 @@ feedbackActor.start();
 
 :::studio
 
-[Read about setting context in Stately’s editor](TODO).
+[Read about setting context in Stately’s editor](./editor-context.mdx).
 
 :::
 

--- a/docs/delayed-transitions.mdx
+++ b/docs/delayed-transitions.mdx
@@ -51,7 +51,7 @@ In a video player, want the video to be *Closed* out of fullscreen mode a few 
 
 :::studio
 
-[Learn how to use delayed transitions in Stately’s editor](TODO)
+[Learn how to use delayed transitions in Stately’s editor](./editor-delayed-transitions.mdx)
 
 :::
 

--- a/docs/delayed-transitions.mdx
+++ b/docs/delayed-transitions.mdx
@@ -40,11 +40,6 @@ Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtu
 
 :::
 
-<SkipDownLink
-  text="Jump to learning more about delays in XState"
-  link="#delays"
-/>
-
 <EmbedMachine
   name="Delayed (after) transitions"
   embedURL="https://stately.ai/registry/editor/embed/1c962847-2829-45e2-b6fc-5f42fa3f8b6b?machineId=5671366b-05cf-43f5-a09a-b88373ea27c1"
@@ -54,34 +49,11 @@ Watch our [“Delayed (after) transitions” video on YouTube](https://www.youtu
 
 In a video player, want the video to be *Closed* out of fullscreen mode a few seconds after the video has *Stopped*, instead of closing the fullscreen mode suddenly as soon as the video is stopped. The eventless transition above transitions from the *Stopped* state to the *Closed* state after 5 seconds.
 
-## Using delayed transitions in Stately Studio
+:::studio
 
-In Stately Studio, delayed transitions are labeled “after.”
+[Learn how to use delayed transitions in Stately’s editor](TODO)
 
-### Make an event into a delayed transition
-
-Delayed transitions have a default time interval of 500ms (0.5 seconds).
-
-#### On the canvas
-
-1. Select the event you want to replace with a delayed transition.
-1. Right-click the event to open the edit menu.
-1. From the **Event type** options, choose **After** to turn the event into a delayed transition.
-
-#### Using the transition Details panel
-
-1. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
-2. From the **Event type** dropdown menu, choose **After** to turn the event into a delayed transition.
-
-#### Specify delay time
-
-Your delay time interval will be displayed in a human-readable format on hover. For example, 15000ms will be displayed as 15 seconds.
-
-1. Select the delayed transition.
-2. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
-3. Use the **Delay** text input to specify the interval in milliseconds.
-
----
+:::
 
 ## Delays
 

--- a/docs/editor-actions.mdx
+++ b/docs/editor-actions.mdx
@@ -1,0 +1,70 @@
+---
+title: Actions in Stately’s editor
+---
+
+Actions are fire-and-forget effects. When a state machine transitions, it may execute actions. [Learn more about actions](actions.mdx).
+
+## Add an action
+
+First, select the state or event where you want an action to be fired.
+
+### On the canvas
+
+1. Use the <Plus size={18} /> plus icon button to open the edit menu.
+2. Choose <Zap size={18} /> **Action**, <Zap size={18} /> **Entry action**, or <Zap size={18} /> **Exit action** from the menu to add an action block.
+3. Write your action’s name in the action’s text input.
+
+### Using the state or event details panel
+
+1. Open the state or event <Info size={18} /> **Details** panel from the right tool menu.
+2. Use the **+ Effect** button to open the effects menu, and choose **Add entry action** or **Add exit action** to add an entry or exit action. Or use the **+ Transition action** button to add a transition action block.
+3. Write your action’s name in the action’s text input.
+
+## Delete an action
+
+First, select the transition action block you want to delete.
+
+### Using backspace
+
+Use the <kbd>Backspace</kbd> key to delete the transition action.
+
+### Using the state or event details panel
+
+1. Open the state or event <Info size={18} /> **Details** panel from the right tool menu.
+2. Hover, focus, or select the transition action block to reveal the <Trash size={18} /> trash icon button.
+3. Use the <Trash size={18} /> trash icon button to delete the action.
+
+## Add custom or built-in actions
+
+:::studio
+
+When you create an action in the Stately editor, it is a custom action by default. You can edit your actions to use XState’s built-in actions.
+
+:::
+
+Custom actions with a custom action type and parameters which will be formatted as [XState action objects](actions.mdx#action-objects) in your [exported code](export-as-code.mdx).
+
+Built-in XState actions will be formatted in your [exported code](export-as-code.mdx). The options are:
+
+- [assign](actions.mdx#assign-action): assigns data to the state context.
+- [raise](actions.mdx#raise-action): _raises_ an event that is received by the same machine.
+- [log](actions.mdx#log-action): an easy way to log messages to the console.
+- [sendTo](actions.mdx#send-to-action): sends an event to a specific actor.
+- [stop](actions.mdx#stop-action): stops a child actor.
+
+### On the canvas
+
+1. [Add an action](#add-an-action).
+1. Hover, focus, or select the action block to reveal the <Edit size={18} /> edit icon button.
+1. Use the <Edit size={18} /> edit icon button to open the **Action** panel.
+1. Choose your desired action from the dropdown menu at the top of the **Action** panel. Custom action is selected by default.
+1. Fill out the required corresponding action input fields. Add your custom action type in the **Action type** text input. Add your custom **Action parameters** using the **Parameter key** and **Parameter value** text input pairs.
+
+### Using the details panel
+
+1. [Add an action](#add-an-action).
+1. Open the state, or event <Info size={18} /> **Details** panel from the right tool menu.
+1. Hover, focus, or select the action block to reveal the <Edit size={18} /> edit icon button.
+1. Use the <Edit size={18} /> edit icon button to open the **Action** panel.
+1. Choose your desired action from the dropdown menu at the top of the **Action** panel. Custom action is selected by default.
+1. Fill out the required corresponding action input fields. Add your custom action type in the **Action type** text input. Add your custom **Action parameters** using the **Parameter key** and **Parameter value** text input pairs.

--- a/docs/editor-context.mdx
+++ b/docs/editor-context.mdx
@@ -1,0 +1,7 @@
+---
+title: Context in Stately’s editor
+---
+
+- Coming soon… setting initial values
+- Coming soon… updating context with assign
+- Coming soon… JS/TS export

--- a/docs/editor-delayed-transitions.mdx
+++ b/docs/editor-delayed-transitions.mdx
@@ -2,6 +2,8 @@
 title: Delayed (after) transitions in Stately’s editor
 ---
 
+[**Delayed transitions**](delayed-transitions.mdx) are transitions that only happen after a set amount of time. Delayed transitions are handy for building timeouts and intervals into your application logic. If another event occurs before the end of the timer, the transition doesn’t complete.
+
 In Stately, delayed transitions are labeled “after.”
 
 ## Make an event into a delayed transition

--- a/docs/editor-delayed-transitions.mdx
+++ b/docs/editor-delayed-transitions.mdx
@@ -1,0 +1,28 @@
+---
+title: Delayed (after) transitions in Stately’s editor
+---
+
+In Stately, delayed transitions are labeled “after.”
+
+## Make an event into a delayed transition
+
+Delayed transitions have a default time interval of 500ms (0.5 seconds).
+
+### On the canvas
+
+1. Select the event you want to replace with a delayed transition.
+1. Right-click the event to open the edit menu.
+1. From the **Event type** options, choose **After** to turn the event into a delayed transition.
+
+### Using the transition Details panel
+
+1. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
+2. From the **Event type** dropdown menu, choose **After** to turn the event into a delayed transition.
+
+### Specify delay time
+
+Your delay time interval will be displayed in a human-readable format on hover. For example, 15000ms will be displayed as 15 seconds.
+
+1. Select the delayed transition.
+2. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
+3. Use the **Delay** text input to specify the interval in milliseconds.

--- a/docs/editor-eventless-transitions.mdx
+++ b/docs/editor-eventless-transitions.mdx
@@ -2,6 +2,10 @@
 title: Eventless (always) transitions in Stately’s editor
 ---
 
+[**Eventless transitions**](eventless-transitions.mdx) are transitions that happen without an explicit event. These transitions are *always* taken when the transition is enabled.
+
+Eventless transitions are labeled “always” and often referred to as “always” transitions.
+
 ## Make an event into an eventless transition
 
 First, select the event you want to replace with an eventless transition. Then…

--- a/docs/editor-eventless-transitions.mdx
+++ b/docs/editor-eventless-transitions.mdx
@@ -1,0 +1,17 @@
+---
+title: Eventless (always) transitions in Stately’s editor
+---
+
+## Make an event into an eventless transition
+
+First, select the event you want to replace with an eventless transition. Then…
+
+### On the canvas
+
+1. Right-click the state to open the edit menu.
+2. From the **Event type** options, choose **Always** to turn the event into an eventless transition.
+
+### Using the transition Details panel
+
+1. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
+2. From the **Event type** dropdown menu, choose **Always** to turn the event into an eventless transition.

--- a/docs/editor-history-states.mdx
+++ b/docs/editor-history-states.mdx
@@ -1,0 +1,22 @@
+---
+title: History states in Stately’s editor
+---
+
+A [history state](history-state.mdx) is a special type of state (a _pseudostate_) that remembers the last [child state](parent-states.mdx) that was active before its parent state is exited. When a transition from outside the parent state targets a history state, the remembered child state is entered.
+
+## Make a state a history state
+
+First, select the state you want to set as a history state for the parent state. Then…
+
+### On the canvas
+
+1. Right-click the state to open the edit menu.
+2. From the **Type** options, choose **History**.
+
+### Using the state Details panel
+
+1. Select the state you want to make a history state.
+2. Open the state <Info size={18} /> **Details** panel from the right tool menu.
+3. From the type option, choose **History**.
+
+To set the state back as a normal state, follow the same steps and select the **Normal** type option.

--- a/docs/editor-history-states.mdx
+++ b/docs/editor-history-states.mdx
@@ -2,7 +2,7 @@
 title: History states in Stately’s editor
 ---
 
-A [history state](history-state.mdx) is a special type of state (a _pseudostate_) that remembers the last [child state](parent-states.mdx) that was active before its parent state is exited. When a transition from outside the parent state targets a history state, the remembered child state is entered.
+A [history state](history-states.mdx) is a special type of state (a _pseudostate_) that remembers the last [child state](parent-states.mdx) that was active before its parent state is exited. When a transition from outside the parent state targets a history state, the remembered child state is entered.
 
 ## Make a state a history state
 

--- a/docs/editor-invoke.mdx
+++ b/docs/editor-invoke.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Invoked actors in Stately’s editor'
+---
+
+XState is based on the [actor model](actors.mdx). [Invoked actors](invoke.mdx) are managed by the state machine. Invoked actors are created and started when the state is entered, and stopped when the state is exited.
+
+You can invoke multiple actors on a single state. Top-level final states cannot have invoked actors.
+
+<EmbedMachine
+  embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=66f77051-089e-4b0a-9fa9-42e1f7598135"
+  name="video player"
+/>
+
+In the video player above, the *startVideo* actor is invoked when the video player is in the *Opened* state.
+
+## Invoke actors on a state
+
+First, select the state where you want to invoke an actor.
+
+### On the canvas
+
+1. Select the state where you want to invoke an actor.
+2. Use the <Plus size={18} /> plus icon button to open the edit menu.
+3. Choose **Invoked actor** from the menu to add an invoked actor block to the event.
+4. Write your actor’s source in the invoked actors’s text input.
+
+### Add actor source logic and ID
+
+1. Use the <Edit size={18} /> edit icon button to open the **Invoked actor** panel.
+2. Enter the actor’s source logic in the **Source logic** text input.
+3. Enter the actor’s ID in the **Actor ID** text input.
+
+### Using the event details panel
+
+1. Select the state where you want to invoke an actor.
+2. Open the state <Info size={18} /> **Details** panel from the right tool menu.
+3. Use the **+ Effect** button to open the effects menu, and choose **Add invoked actor**.
+4. Use the <Edit size={18} /> edit icon button to open the **Invoked actor** panel.
+5. Enter the actor’s source logic in the **Source logic** text input.
+6. Enter the actor’s ID in the **Actor ID** text input.
+
+## Invoke done and invoke error events
+
+- An **invoke done event** transitions from a state once its invocation has been completed. An invoke done event is labeled “done:” followed by the invocation’s ID.
+- An **invoke error event** transitions from a state when an error occurs in its invocation. An invoke error event is labeled “error:” followed by the invocation’s ID.
+
+### How to create invoke done and invoke error events in Stately’s editor
+
+1. Select the state with an invoked actor where you want to add an invoke done and invoke error events.
+2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state. The newly-created event will automatically be created as an invoke done event.
+3. Again, press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state. This next newly-created event will automatically be created as an invoke error event.
+
+You can also change an existing event into an invoke done or invoke error event using the edit menu. The source state must have an invoked actor.
+
+1. Select the existing event you wish to change into an invoke done or invoke error event.
+2. Right-click the state to open the edit menu.
+3. From the **Event type** options, choose **Invocation done event** or **Invocation error event**.

--- a/docs/editor-parent-states.mdx
+++ b/docs/editor-parent-states.mdx
@@ -1,0 +1,39 @@
+---
+title: Parent states in Stately’s editor
+---
+
+States can contain more states, also known as **child states**. These child states are only active when the parent state is active.
+
+Child states are nested inside their parent states. Parent states are also known as **compound states**.
+
+[Read more about parent and child states](parent-states.mdx).
+
+## Add a child state
+
+1. Select the state that will become the parent state.
+2. Use the <Plus size={18} /> plus icon button to open the edit menu.
+3. Choose **Child state** from the menu to add a child state to your state.
+
+If a state already contains child states, you can double-click inside the parent state to create another child state.
+
+## Change the parent state of a child state
+
+Using the state <Info size={18} /> **Details** panel:
+
+1. Select the child state you want to reparent.
+2. Open the state <Info size={18} /> **Details** panel from the right tool menu.
+3. Choose your desired new parent from the **Parent** dropdown menu.
+
+### Using copy and paste from the edit menu
+
+1. Right-click the child state you want to reparent to open the edit menu.
+2. Select **Copy** to copy the state.
+3. Right-click the desired new parent to open the edit menu.
+4. Select **Paste** to paste the child state into the parent state.
+
+### Using copy and paste keyboard shortcuts
+
+1. Select the child state you want to reparent.
+2. Use **Command**/**Ctrl** + **C** to copy the state.
+3. Select the desired new parent state.
+4. Use **Command**/**Ctrl** + **V** to paste the child state into the parent state.

--- a/docs/editor-states.mdx
+++ b/docs/editor-states.mdx
@@ -1,0 +1,33 @@
+---
+title: States in Stately’s editor
+---
+
+In Stately, the rounded rectangle boxes are states. The **!** warning icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
+
+## Create a state
+
+:::tip
+
+The fastest way to create a new state is by double-clicking in any empty space on the canvas.
+
+:::
+
+### Create a new target state
+
+Each transition has a source state and a target state. To create a new target state from a source state:
+
+1. Select the source state.
+2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
+
+[Read more about transitioning between source and target states](transitions.mdx#using-transitions-and-events-in-stately-studio).
+
+### Create a new child state
+
+[How to create child and parent states](parent-states.mdx).
+
+## Delete a state
+
+First, select the state you want to delete.
+
+- Use the <MoreHorizontal size={18} /> triple dot icon button to open the Edit menu and choose **Delete** to delete the selected state.
+- Use the <kbd>Backspace</kbd> key to delete the selected state.

--- a/docs/editor-states.mdx
+++ b/docs/editor-states.mdx
@@ -23,11 +23,11 @@ Each transition has a source state and a target state. To create a new target st
 1. Select the source state.
 2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
 
-[Read more about transitioning between source and target states](transitions.mdx#using-transitions-and-events-in-stately-studio).
+[Read more about transitioning between source and target states](./editor-states.mdx).
 
 ### Create a new child state
 
-[How to create child and parent states](parent-states.mdx).
+[How to create child and parent states](./editor-parent-states.mdx).
 
 ## Delete a state
 

--- a/docs/editor-states.mdx
+++ b/docs/editor-states.mdx
@@ -2,6 +2,10 @@
 title: States in Stately’s editor
 ---
 
+A [state](states.mdx) describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
+
+These states are “finite”; the machine can only move through the states you’ve pre-defined.
+
 In Stately, the rounded rectangle boxes are states. The **!** warning icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
 
 ## Create a state

--- a/docs/editor-transitions.mdx
+++ b/docs/editor-transitions.mdx
@@ -1,0 +1,22 @@
+---
+title: Using transitions and events in Stately’s editor
+---
+
+A [**transition**](transitions.mdx) is a change from one finite state to another, triggered by an event.
+
+An **event** is a signal, trigger, or message that causes a transition. When an actor receives an event, its machine will determine if there are any enabled transitions for that event in the current state. If enabled transitions exist, the machine will take them and execute their actions.
+
+The arrows are transitions, and the rounded rectangles on the arrow’s lines are events. Each transition has a **source** state which comes before the transition, and a **target** state, which comes after the transition. The transition’s arrow starts from the source state and points to the target state.
+
+## Add a transition and event
+
+1. Select an existing state.
+2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
+
+## Change the source and target states for a transition or event
+
+First select the transition or event you want to change. Then…
+
+- On the canvas, right-click the transition or event, or use the <MoreHorizontal size={18} /> triple dot icon button, to open the Edit menu and choose **Switch source and target**.
+- Drag the transition’s handle connected to the state to connect it to a new state.
+- Open the transition <Info size={18} /> **Details** panel from the right tool menu. Choose a new source state from the **Source** dropdown options and a new target state from the **Target** dropdown options.

--- a/docs/eventless-transitions.mdx
+++ b/docs/eventless-transitions.mdx
@@ -26,7 +26,7 @@ Eventless transitions are labeled “always” and often referred to as “alway
 
 :::studio
 
-[Learn how to use eventless transitions in Stately’s editor](TODO)
+[Learn how to use eventless transitions in Stately’s editor](./editor-eventless-transitions.mdx)
 
 :::
 

--- a/docs/eventless-transitions.mdx
+++ b/docs/eventless-transitions.mdx
@@ -2,8 +2,6 @@
 title: Eventless (always) transitions
 ---
 
-import SkipDownLink from '@site/src/components/SkipDownLink';
-
 **Eventless transitions** are transitions that happen without an explicit event. These transitions are *always* taken when the transition is enabled.
 
 Eventless transitions are labeled “always” and often referred to as “always” transitions.

--- a/docs/eventless-transitions.mdx
+++ b/docs/eventless-transitions.mdx
@@ -26,26 +26,11 @@ Eventless transitions are labeled “always” and often referred to as “alway
 }
 ```
 
-<SkipDownLink
-  text="Jump to learning more about eventless transitions in XState"
-  link="#eventless-transitions-and-guards"
-/>
+:::studio
 
-## Using eventless transitions in Stately Studio
+[Learn how to use eventless transitions in Stately’s editor](TODO)
 
-### Make an event into an eventless transition
-
-First, select the event you want to replace with an eventless transition. Then…
-
-#### On the canvas
-
-1. Right-click the state to open the edit menu.
-2. From the **Event type** options, choose **Always** to turn the event into an eventless transition.
-
-#### Using the transition Details panel
-
-1. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
-2. From the **Event type** dropdown menu, choose **Always** to turn the event into an eventless transition.
+:::
 
 ## Eventless transitions and guards
 

--- a/docs/history-states.mdx
+++ b/docs/history-states.mdx
@@ -40,29 +40,11 @@ const checkoutMachine = createMachine({
 });
 ```
 
-<SkipDownLink
-  text="Jump to learning more about Shallow vs. deep history in XState"
-  link="#shallow-vs-deep-history"
-/>
+:::studio
 
-## Using history states in Stately Studio
+[Learn how to use history states in Stately’s editor](TODO)
 
-### Make a state a history state
-
-First, select the state you want to set as a history state for the parent state. Then…
-
-#### On the canvas
-
-1. Right-click the state to open the edit menu.
-2. From the **Type** options, choose **History**.
-
-#### Using the state Details panel
-
-1. Select the state you want to make a history state.
-2. Open the state <Info size={18} /> **Details** panel from the right tool menu.
-3. From the type option, choose **History**.
-
-To set the state back as a normal state, follow the same steps and select the **Normal** type option.
+:::
 
 ## Shallow vs. deep history
 

--- a/docs/history-states.mdx
+++ b/docs/history-states.mdx
@@ -42,7 +42,7 @@ const checkoutMachine = createMachine({
 
 :::studio
 
-[Learn how to use history states in Stately’s editor](TODO)
+[Learn how to use history states in Stately’s editor](./editor-history-states.mdx)
 
 :::
 

--- a/docs/invoke.mdx
+++ b/docs/invoke.mdx
@@ -16,7 +16,7 @@ Coming soon… example of invoking an actor at root.
 
 :::studio
 
-[Learn how to invoke actors in Stately’s editor](TODO).
+[Learn how to invoke actors in Stately’s editor](./editor-invoke.mdx).
 
 :::
 

--- a/docs/invoke.mdx
+++ b/docs/invoke.mdx
@@ -14,12 +14,11 @@ Coming soon… example of invoking an actor at root.
 [Read about the difference between invoking and spawning actors](actors.mdx#invoking-and-spawning-actors).
 :::
 
-<SkipDownLink
-  text="Jump to learning more about the invoked actors API in XState"
-  link="#api"
-/>
+:::studio
 
-## Using invoked actors in Stately Studio
+[Learn how to invoke actors in Stately’s editor](TODO).
+
+:::
 
 You can invoke multiple actors on a single state. Top-level final states cannot have invoked actors.
 
@@ -29,65 +28,6 @@ You can invoke multiple actors on a single state. Top-level final states cannot 
 />
 
 In the video player above, the *startVideo* actor is invoked when the video player is in the *Opened* state.
-
-### Invoke actors on a state
-
-First, select the state where you want to invoke an actor.
-
-### On the canvas
-
-1. Select the state where you want to invoke an actor.
-2. Use the <Plus size={18} /> plus icon button to open the edit menu.
-3. Choose **Invoked actor** from the menu to add an invoked actor block to the event.
-4. Write your actor’s source in the invoked actors’s text input.
-
-#### Add actor source logic and ID
-
-1. Use the <Edit size={18} /> edit icon button to open the **Invoked actor** panel.
-2. Enter the actor’s source logic in the **Source logic** text input.
-3. Enter the actor’s ID in the **Actor ID** text input.
-
-### Using the event details panel
-
-1. Select the state where you want to invoke an actor.
-2. Open the state <Info size={18} /> **Details** panel from the right tool menu.
-3. Use the **+ Effect** button to open the effects menu, and choose **Add invoked actor**.
-4. Use the <Edit size={18} /> edit icon button to open the **Invoked actor** panel.
-5. Enter the actor’s source logic in the **Source logic** text input.
-6. Enter the actor’s ID in the **Actor ID** text input.
-
-### Invoke done events
-
-An **invoke done event** transitions from a state once its invocation has been completed. An invoke done event is labeled “done:” followed by the invocation’s ID.
-
-#### How to create invoke done events in Stately Studio
-
-1. Select the state with an invoked actor where you want to add an invoke done event.
-2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
-3. The newly-created event will automatically be created as an invoke done event.
-
-You can also change an existing event into an invoked done event using the edit menu. The source state must have an invoked actor.
-
-1. Select the existing event you wish to change into an invoke done event.
-2. Right-click the state to open the edit menu.
-3. From the **Event type** options, choose **Invocation done event**.
-
-### Invoke error events
-
-An **invoke error event** transitions from a state when an error occurs in its invocation. An invoke error event is labeled “error:” followed by the invocation’s ID.
-
-#### How to create invoke error events in Stately Studio
-
-1. Select the state with an invoked actor where you want to add an invoke error event.
-2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
-3. The newly-created event will automatically be created as an invoke done event.
-4. When an invoke done event already exists from that state, creating another event will automatically create that event as an invoke error event.
-
-You can also change an existing event into an invoked error event using the edit menu. The source state must have an invoked actor.
-
-1. Select the existing event you wish to change into an invoke error event.
-2. Right-click the state to open the edit menu.
-3. From the **Event type** options, choose **Invocation error event**.
 
 ## API
 

--- a/docs/parent-states.mdx
+++ b/docs/parent-states.mdx
@@ -12,45 +12,18 @@ Watch our [“Parent and child states” video on YouTube](https://www.youtube.c
 
 :::
 
-<EmbedMachine name="Video player" embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa" />
+<EmbedMachine
+  name="Video player"
+  embedURL="https://stately.ai/registry/editor/embed/e13bef2b-bb13-4465-96ac-0bc25340688e?machineId=9ba5377c-aab3-4465-8909-4eea499622fa"
+/>
 
 In the video player above, the *Opened* state is a parent state to the *Playing*, *Paused*, and *Stopped* states. These states, their transitions, and their events are nested inside the *Opened* state.
 
-<SkipDownLink
-  text="Jump to learning more about parent and child states in XState"
-  link="#root-state"
-/>
+:::studio
 
-## Add a child state
+[Learn how to create parent and child states in Stately’s editor](TODO).
 
-1. Select the state that will become the parent state.
-2. Use the <Plus size={18} /> plus icon button to open the edit menu.
-3. Choose **Child state** from the menu to add a child state to your state.
-
-If a state already contains child states, you can double-click inside the parent state to create another child state.
-
-## Change the parent state of a child state
-
-Using the state <Info size={18} /> **Details** panel:
-
-1. Select the child state you want to reparent.
-2. Open the state <Info size={18} /> **Details** panel from the right tool menu.
-3. Choose your desired new parent from the **Parent** dropdown menu.
-
-### Using copy and paste from the edit menu
-
-1. Right-click the child state you want to reparent to open the edit menu.
-2. Select **Copy** to copy the state.
-3. Right-click the desired new parent to open the edit menu.
-4. Select **Paste** to paste the child state into the parent state.
-
-### Using copy and paste keyboard shortcuts
-
-1. Select the child state you want to reparent.
-2. Use **Command**/**Ctrl** + **C** to copy the state.
-3. Select the desired new parent state.
-4. Use **Command**/**Ctrl** + **V** to paste the child state into the parent state.
-
+:::
 
 ## Root state
 

--- a/docs/parent-states.mdx
+++ b/docs/parent-states.mdx
@@ -21,7 +21,7 @@ In the video player above, the *Opened* state is a parent state to the *Playi
 
 :::studio
 
-[Learn how to create parent and child states in Stately’s editor](TODO).
+[Learn how to create parent and child states in Stately’s editor](./editor-parent-states.mdx).
 
 :::
 

--- a/docs/states.mdx
+++ b/docs/states.mdx
@@ -21,7 +21,7 @@ Watch our [“What are states?” video on YouTube](https://www.youtube.com/watc
 
 :::studio
 
-[Read about how to create and use states in Stately’s editor](TODO).
+[Read about how to create and use states in Stately’s editor](./editor-states.mdx).
 
 :::
 

--- a/docs/states.mdx
+++ b/docs/states.mdx
@@ -3,7 +3,6 @@ title: State
 ---
 
 import EmbedMachine from '@site/src/components/EmbedMachine';
-import SkipDownLink from '@site/src/components/SkipDownLink';
 
 A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
 
@@ -20,48 +19,11 @@ Watch our [“What are states?” video on YouTube](https://www.youtube.com/watc
 
 :::
 
-<SkipDownLink
-  text="Jump to learning more about the state object in XState"
-  link="#state-object"
-/>
+:::studio
 
-## Using states in Stately Studio
-
-In Stately Studio, the rounded rectangle boxes are states. The **!** warning icon in the machine above indicates an unreachable state. The state is unreachable because it isn’t connected to the [initial state](initial-states.mdx) by a [transition](transitions.mdx).
-
-### Create a state
-
-:::tip
-
-The fastest way to create a new state is by double-clicking in any empty space on the canvas.
+[Read about how to create and use states in Stately’s editor](states.mdx).
 
 :::
-
-#### Create a new target state
-
-Each transition has a source state and a target state. To create a new target state from a source state:
-
-1. Select the source state.
-2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
-
-[Read more about transitioning between source and target states](transitions.mdx#using-transitions-and-events-in-stately-studio).
-
-#### Create a new child state
-
-[How to create child and parent states](parent-states.mdx).
-
-### Delete a state
-
-First, select the state you want to delete.
-
-#### Using the context menu
-
-1. Use the <MoreHorizontal size={18} /> triple dot icon button to open the Edit menu.
-2. Choose **Delete** to delete the selected state.
-
-#### Using backspace
-
-Use the <kbd>Backspace</kbd> key to delete the selected state.
 
 ## State object
 

--- a/docs/states.mdx
+++ b/docs/states.mdx
@@ -21,7 +21,7 @@ Watch our [“What are states?” video on YouTube](https://www.youtube.com/watc
 
 :::studio
 
-[Read about how to create and use states in Stately’s editor](states.mdx).
+[Read about how to create and use states in Stately’s editor](TODO).
 
 :::
 

--- a/docs/transitions.mdx
+++ b/docs/transitions.mdx
@@ -35,7 +35,7 @@ const feedbackMachine = createMachine({
 
 :::studio
 
-[Learn how to use transitions and events in Stately’s editor](TODO).
+[Learn how to use transitions and events in Stately’s editor](./editor-transitions.mdx).
 
 :::
 

--- a/docs/transitions.mdx
+++ b/docs/transitions.mdx
@@ -33,39 +33,11 @@ const feedbackMachine = createMachine({
 });
 ```
 
-<SkipDownLink
-  text="Jump to learning more about event objects in XState"
-  link="#event-objects"
-/>
+:::studio
 
-## Using transitions and events in Stately Studio
+[Learn how to use transitions and events in Stately’s editor](TODO).
 
-The arrows are transitions, and the rounded rectangles on the arrow’s lines are events. Each transition has a **source** state which comes before the transition, and a **target** state, which comes after the transition. The transition’s arrow starts from the source state and points to the target state.
-
-### Add a transition and event
-
-1. Select an existing state.
-2. Press or drag from one of the <Plus size={18} /> handles on the left, right and bottom sides of the selected state, and release to create a connecting transition, event and new state.
-
-### Change the source and target states for a transition or event
-
-First select the transition or event you want to change. Then…
-
-#### On the canvas
-
-1. Right-click the transition or event, or use the <MoreHorizontal size={18} /> triple dot icon button, to open the Edit menu.
-2. Choose **Switch source and target**.
-
-#### Dragging the transition handles
-
-1. Drag the transition’s handle connected to the source state to connect it to a new source state.
-2. Drag the transition’s handle connected to the target state to connect it to a new target state.
-
-#### Using the transition details panel
-
-1. Open the transition <Info size={18} /> **Details** panel from the right tool menu.
-2. Choose a new source state from the **Source** dropdown options.
-3. Choose a new target state from the **Target** dropdown options.
+:::
 
 ## Event objects
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -274,11 +274,53 @@ const sidebars = {
             },
           ],
         },
-        'context',
+        {
+          type: 'category',
+          label: 'Context',
+          link: {
+            type: 'doc',
+            id: 'context',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-context',
+            },
+          ],
+        },
         'input',
         'transitions',
-        'eventless-transitions',
-        'delayed-transitions',
+        {
+          type: 'category',
+          label: 'Eventless transitions',
+          link: {
+            type: 'doc',
+            id: 'eventless-transitions',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-eventless-transitions',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Delayed transitions',
+          link: {
+            type: 'doc',
+            id: 'delayed-transitions',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-delayed-transitions',
+            },
+          ],
+        },
         {
           type: 'category',
           label: 'Actions',

--- a/sidebars.js
+++ b/sidebars.js
@@ -374,7 +374,26 @@ const sidebars = {
       },
       collapsed: false,
       collapsible: true,
-      items: ['actors', 'invoke', 'spawn', 'system'],
+      items: [
+        'actors',
+        {
+          type: 'category',
+          label: 'Invoke',
+          link: {
+            type: 'doc',
+            id: 'invoke',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-invoke',
+            },
+          ],
+        },
+        'spawn',
+        'system',
+      ],
     },
     {
       type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -300,7 +300,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'Transitions in Stately',
               id: 'editor-transitions',
             },
           ],
@@ -315,7 +315,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'Eventless transitions in Stately',
               id: 'editor-eventless-transitions',
             },
           ],
@@ -330,7 +330,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'Delayed transitions in Stately',
               id: 'editor-delayed-transitions',
             },
           ],
@@ -345,7 +345,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'Actions in Stately',
               id: 'editor-actions',
             },
           ],
@@ -362,7 +362,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'Parent states in Stately',
               id: 'editor-parent-states',
             },
           ],
@@ -380,7 +380,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'History states in Stately',
               id: 'editor-history-states',
             },
           ],
@@ -414,7 +414,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately’s editor',
+              label: 'Actors in Stately',
               id: 'editor-invoke',
             },
           ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -342,7 +342,21 @@ const sidebars = {
         'parallel-states',
         'initial-states',
         'final-states',
-        'history-states',
+        {
+          type: 'category',
+          label: 'History states',
+          link: {
+            type: 'doc',
+            id: 'history-states',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-history-states',
+            },
+          ],
+        },
         'persistence',
         'tags',
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -269,7 +269,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              label: 'In Stately editor',
+              label: 'In Stately’s editor',
               id: 'editor-states',
             },
           ],
@@ -279,7 +279,21 @@ const sidebars = {
         'transitions',
         'eventless-transitions',
         'delayed-transitions',
-        'actions',
+        {
+          type: 'category',
+          label: 'Actions',
+          link: {
+            type: 'doc',
+            id: 'actions',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-actions',
+            },
+          ],
+        },
         'guards',
         'finite-states',
         'parent-states',

--- a/sidebars.js
+++ b/sidebars.js
@@ -259,7 +259,21 @@ const sidebars = {
       collapsible: true,
       items: [
         'machines',
-        'states',
+        {
+          type: 'category',
+          label: 'States',
+          link: {
+            type: 'doc',
+            id: 'states',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately editor',
+              id: 'editor-states',
+            },
+          ],
+        },
         'context',
         'input',
         'transitions',

--- a/sidebars.js
+++ b/sidebars.js
@@ -290,7 +290,21 @@ const sidebars = {
           ],
         },
         'input',
-        'transitions',
+        {
+          type: 'category',
+          label: 'Transitions',
+          link: {
+            type: 'doc',
+            id: 'transitions',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-transitions',
+            },
+          ],
+        },
         {
           type: 'category',
           label: 'Eventless transitions',
@@ -338,7 +352,21 @@ const sidebars = {
         },
         'guards',
         'finite-states',
-        'parent-states',
+        {
+          type: 'category',
+          label: 'Parent states',
+          link: {
+            type: 'doc',
+            id: 'parent-states',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'In Stately’s editor',
+              id: 'editor-parent-states',
+            },
+          ],
+        },
         'parallel-states',
         'initial-states',
         'final-states',

--- a/versioned_docs/version-4/states/intro.mdx
+++ b/versioned_docs/version-4/states/intro.mdx
@@ -1,6 +1,6 @@
 ---
 title: States
-description: "A state describes a state machine’s status or mode, which could be as simple as Paused and Playing. A state machine can only be in one state at a time."
+description: 'A state describes a state machine’s status or mode, which could be as simple as Paused and Playing. A state machine can only be in one state at a time.'
 ---
 
 A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.


### PR DESCRIPTION
This PR moves the Stately how-to info for state machine concepts into subpages.

Each subpage is a top-level file in `/docs` but appears in the sidebar as a sub-page of its concept. Currently using `X in Stately` as the sidebar label for these pages but I’m open to better ideas!

![CleanShot 2023-10-31 at 11 59 30@2x](https://github.com/statelyai/docs/assets/266663/b473f137-5b56-4346-80f8-f461849714be)