### PR TITLE
Update docs for XState viz to note deprecation

### DIFF
--- a/docs/visualizer.mdx
+++ b/docs/visualizer.mdx
@@ -2,7 +2,7 @@
 title: Visualizer
 ---
 
-# Visualizer
+# Visualizer (Legacy)
 
 :::studio
 
@@ -14,24 +14,20 @@ Are you looking for the _Stately Studio_ visual _editor_? Check out the [Stately
 
 The [Stately Visualizer](https://stately.ai/viz) is a tool for creating and inspecting statecharts to visualize the state of your applications. You can use the viz as a playground for exploring XState’s capabilities.
 
-:::tip
+:::caution
 
-Stately still supports the Stately Visualizer, but you will find many more advanced features, including Stately Studio [visual editor](/studio.mdx#stately-studios-editor), teams, and shared projects.
+The XState Visualizer is deprecated and is no longer maintained.
 
 :::
 
-As a visual tool, the Visualizer helps developers get an overview of their application logic and makes it easy to share with designers, project managers and the rest of the team.
+We recommend you only continue using the legacy visualizer if you need to execute actions and guards or visualize multiple machines simultaneously. These features are coming to the [Stately editor](studio.mdx) very soon.
 
-- Write your application logic and immediately visualize it.
-- Save your statecharts to the Stately Registry and share them with anybody.
-- Share your statecharts in your team’s documentation with embedded mode and live-updating snapshot images.
+## Use the Visualizer
 
-## Try the Visualizer
-
-- [Take me to the Visualizer!](https://stately.ai/viz)
+- [Take me to the Visualizer](https://stately.ai/viz)
 - [Try the Visualizer in Inspect mode](https://stately.ai/viz?inspect).
 
-The Visualizer is available now and will be free and open source forever. Contributions are welcome!
+The Visualizer is deprecated and we encourage you to migrate your projects to use the [Stately editor](studio.mdx).
 
 ## Feedback and bug reports
 


### PR DESCRIPTION
This PR is a small update to the viz docs with info about the XState Viz’s deprecation. We will link to this from the XState Viz.

Preview: https://docs-jjpgqij6d-statelyai.vercel.app/docs/visualizer