### PR TITLE
Update Plausible script to track events across docs + blog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
 
   scripts: [
     {
-      src: 'https://plausible.io/js/script.js',
+      src: 'https://plausible.io/js/script.tagged-events.js',
       defer: true,
       'data-domain': 'stately.ai',
     },


### PR DESCRIPTION
Previously we were only doing this on the landing page.