### PR TITLE
Add Sky to the TOC

### DIFF
--- a/docs/stately-sky-getting-started.mdx
+++ b/docs/stately-sky-getting-started.mdx
@@ -25,7 +25,7 @@ Please note that Sky is currently in beta and will be changing rapidly.
 
 Create a project and compose your machine in the [Stately editor](https://stately.ai/editor) with the transitions and states you want.
 
-For this example, we’ll create a simple traffic light machine with three states: `green`, `yellow`, and `red`. Feel free to fork [our traffic light example](https://stately.ai/registry/editor/eb3e89f5-5936-439f-8254-2f6ea4303659?machineId=15fd8071-b80c-4a6f-b9f5-60b6cf578ee5) to test. See a deployed version of this traffic light machine [here](https://sky-starter.stately.ai/?page=trafficlight).
+For this example, we’ll create a simple traffic light machine with three states: `green`, `yellow`, and `red`. Feel free to fork [our traffic light example](https://stately.ai/registry/editor/eb3e89f5-5936-439f-8254-2f6ea4303659?machineId=15fd8071-b80c-4a6f-b9f5-60b6cf578ee5) to test. Check out a [deployed version of this traffic light machine](https://sky-starter.stately.ai/?page=trafficlight).
 
 <EmbedMachine
   embedURL="https://stately.ai/registry/editor/embed/eb3e89f5-5936-439f-8254-2f6ea4303659?machineId=15fd8071-b80c-4a6f-b9f5-60b6cf578ee5"

--- a/docs/stately-sky-getting-started.mdx
+++ b/docs/stately-sky-getting-started.mdx
@@ -8,7 +8,7 @@ This guide will walk you through deploying a simple traffic light state machine 
 
 :::caution
 
-Please note that Sky is currently in alpha and will be changing rapidly.
+Please note that Sky is currently in beta and will be changing rapidly.
 
 :::
 
@@ -25,7 +25,7 @@ Please note that Sky is currently in alpha and will be changing rapidly.
 
 Create a project and compose your machine in the [Stately editor](https://stately.ai/editor) with the transitions and states you want.
 
-For this example, we’ll create a simple traffic light machine with three states: `green`, `yellow`, and `red`. Feel free to fork [our traffic light example](https://stately.ai/registry/editor/eb3e89f5-5936-439f-8254-2f6ea4303659?machineId=15fd8071-b80c-4a6f-b9f5-60b6cf578ee5) to test.
+For this example, we’ll create a simple traffic light machine with three states: `green`, `yellow`, and `red`. Feel free to fork [our traffic light example](https://stately.ai/registry/editor/eb3e89f5-5936-439f-8254-2f6ea4303659?machineId=15fd8071-b80c-4a6f-b9f5-60b6cf578ee5) to test. See a deployed version of this traffic light machine [here](https://sky-starter.stately.ai/?page=trafficlight).
 
 <EmbedMachine
   embedURL="https://stately.ai/registry/editor/embed/eb3e89f5-5936-439f-8254-2f6ea4303659?machineId=15fd8071-b80c-4a6f-b9f5-60b6cf578ee5"

--- a/sidebars.js
+++ b/sidebars.js
@@ -151,6 +151,22 @@ const sidebars = {
         },
         'projects',
         {
+          type: 'category',
+          label: 'Stately Sky',
+          link: {
+            type: 'doc',
+            id: 'stately-sky-getting-started',
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'Getting started',
+              id: 'stately-sky-getting-started',
+              className: 'pro-feature',
+            },
+          ],
+        },
+        {
           type: 'doc',
           label: 'Teams',
           className: 'pro-feature',


### PR DESCRIPTION
This adds the Stately Sky getting started guide to the TOC.