### PR TITLE
Make /docs/sky link work

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,6 +123,11 @@ const config = {
             to: '/docs/xstate-v4/xstate/typescript/type-helpers',
             from: '/docs/xstate/typescript/type-helpers',
           },
+          {
+            // Redirect to the new "Getting Started" page from the Sky category page (until we have a Sky category page)
+            to: '/docs/stately-sky-getting-started',
+            from: '/docs/sky',
+          },
         ],
         createRedirects(existingPath) {
           if (existingPath.includes('/docs')) {


### PR DESCRIPTION
This PR adds a redirect from `/docs/sky` to the getting started page. Reason we need this now is that the xstate CLI tells users to open this URL if they run into errors running `xstate sky`, example:
```
$ xstate sky "./src/**/counter.ts?(x)" -r
apiKey undefined
Error: API key is required to connect to Stately, but none was found. Read more here https://stately.ai/docs/sky.
```