### PR TITLE
Make sidebar hidable `true`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,6 +144,11 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       image: 'static/docs-default.png',
+      docs: {
+        sidebar: {
+          hideable: true,
+        }
+      },
       navbar: {
         title: '',
         logo: {


### PR DESCRIPTION
Make sidebar hidable by [docusaurus basic feature](https://docusaurus.io/docs/2.x/sidebar#hideable-sidebar)

This can be very useful when i'm working with a document open on a portrait-oriented monitor.