### PR TITLE
Fix landing page styles

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,6 +2,7 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 require('dotenv').config();
 const a11yEmoji = require('@fec/remark-a11y-emoji');
+const { themes } = require('prism-react-renderer');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -256,8 +257,8 @@ const config = {
         respectPrefersColorScheme: true,
       },
       prism: {
-        theme: require('prism-react-renderer/dist/index').themes.vsLight,
-        darkTheme: require('prism-react-renderer/dist/index').themes.vsDark,
+        theme: themes.vsLight,
+        darkTheme: themes.vsDark,
       },
     }),
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@docusaurus/tsconfig": "^3.0.0",
     "@docusaurus/types": "^3.0.0",
     "@fec/remark-a11y-emoji": "^4.0.2",
-    "@tsconfig/docusaurus": "^2.0.2",
     "concurrently": "^8.2.2",
     "dotenv": "^16.3.1",
     "remark-cli": "^12.0.0",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import Head from '@docusaurus/Head';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Benefits } from '../components/landing/Benefits';
 import { FinalCallToAction } from '../components/landing/FinalCallToAction';
 import { Footer } from '../components/landing/Footer';
@@ -8,7 +8,6 @@ import { Navbar } from '../components/landing/Navbar';
 import { Testimonials } from '../components/landing/Testimonials';
 import '../css/landing-page.css';
 import '../css/landing-styles.css';
-// import '../css/preflight.css';
 
 export default function Index() {
   useEffect(() => {
@@ -27,7 +26,8 @@ export default function Index() {
   }, []);
 
   return (
-    <>
+    // We need the class name `twp` here to ensure the Tailwind reset gets applied to all children.
+    <div className="twp">
       <Head>
         <title>Stately | Your intelligent assistant for robust logic</title>
         <meta
@@ -74,19 +74,17 @@ export default function Index() {
         ></script>
       </Head>
 
-      {/* We need the class name `twp` here to ensure the Tailwind reset gets applied to all children. */}
-      <header className="bg-blue-950/20 border-b-white/[0.08] border-b fixed w-full z-10 backdrop-blur-md twp">
+      <header className="bg-blue-950/20 border-b-white/[0.08] border-b fixed w-full z-10 backdrop-blur-md">
         <Navbar />
       </header>
 
-      {/* We need the class name `twp` here to ensure the Tailwind reset gets applied to all children. */}
-      <main className="bg-blue-950 twp">
+      <main className="bg-blue-950">
         <Intro />
         <Benefits />
         <Testimonials />
         <FinalCallToAction />
       </main>
       <Footer />
-    </>
+    </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2581,11 +2581,6 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@tsconfig/docusaurus@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-2.0.2.tgz#f96c7453ce9969ef938284eac74441e2d646efd7"
-  integrity sha512-12HWfYmgUl4M2o76/TFufGtI68wl2k/b8qPrIrG7ci9YJLrpAtadpy897Bz5v29Mlkr7a1Hq4KHdQTKtU+2rhQ==
-
 "@types/acorn@^4.0.0":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"


### PR DESCRIPTION
This PR fixes some styling issues on the landing page after moving to v3.

For example, the bottom links had underlines:
![CleanShot 2023-11-28 at 08 39 25](https://github.com/statelyai/docs/assets/167574/76731c9c-f66f-4063-bcd4-f383de89d39f)

But they should look like this, which they do now:
![CleanShot 2023-11-28 at 08 39 43](https://github.com/statelyai/docs/assets/167574/43e0017f-cfce-4395-b035-3cfac1b90a1c)
