### PR TITLE
Use custom admonitions instead of v4 banner on v4 docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
             4: {
               label: 'XState v4',
               path: 'xstate-v4',
-              banner: 'unmaintained',
+              banner: 'none',
             },
           },
 

--- a/versioned_docs/version-4/actions-and-actors/actors.mdx
+++ b/versioned_docs/version-4/actions-and-actors/actors.mdx
@@ -3,6 +3,16 @@ title: Actors
 description: 'When you run a statechart, it becomes an actor: a running process that can receive and send messages, and change its behavior based on messages it receives.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+Read about [actors](/docs/actors) and [the actor model](/docs/the-actor-model) in XState v5.
+
+:::
+
 When you run a statechart, it becomes an actor: a running process that can receive messages, send messages and change its behavior based on the messages it receives, which can cause effects outside of the actor.
 
 An invoked actor is an actor that can execute its own actions and communicate with the machine. These invoked actors are started in a state and stopped when the state is exited.

--- a/versioned_docs/version-4/actions-and-actors/actors.mdx
+++ b/versioned_docs/version-4/actions-and-actors/actors.mdx
@@ -9,7 +9,7 @@ description: 'When you run a statechart, it becomes an actor: a running process 
 
 This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
 
-Read about [actors](/docs/actors) and [the actor model](/docs/the-actor-model) in XState v5.
+Read about [actors](/docs/actors) and [the actor model](/docs/actor-model) in XState v5.
 
 :::
 

--- a/versioned_docs/version-4/actions-and-actors/entry-and-exit-actions.mdx
+++ b/versioned_docs/version-4/actions-and-actors/entry-and-exit-actions.mdx
@@ -3,6 +3,16 @@ title: Entry & exit actions
 description: 'While the statechart is running, it can execute other effects called actions. Actions are “fire-and-forget effects.”'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about entry and exit actions in XState v5](/docs/actions).
+
+:::
+
 While the statechart is running, it can execute other effects called actions.
 
 An action can be fired upon entry or exit of a state. Actions are “fire-and-forget effects”; once the machine has fired the action, it moves on and forgets the action. You can also fire actions on transitions.

--- a/versioned_docs/version-4/examples/intro.mdx
+++ b/versioned_docs/version-4/examples/intro.mdx
@@ -3,7 +3,15 @@ title: 'Request examples'
 description: 'Examples are coming soon. If you have any examples you want us to make, please add a request or upvote an existing suggestion.'
 ---
 
-**Find [examples for XState V5](/docs/examples) in the XState V5 section of these docs.**
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Check out the examples for XState V5](/docs/examples).
+
+:::
 
 If you have any examples you want us to make, please [add a request to our feedback board](https://feedback.stately.ai/examples) or upvote an existing suggestion.
 

--- a/versioned_docs/version-4/glossary.mdx
+++ b/versioned_docs/version-4/glossary.mdx
@@ -2,6 +2,16 @@
 title: Glossary
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Check out the glossary for XState V5](/docs/glossary).
+
+:::
+
 This glossary is an alphabetical guide to the most common terms in statecharts and state machines.
 
 :::tip

--- a/versioned_docs/version-4/state-machines-and-statecharts.mdx
+++ b/versioned_docs/version-4/state-machines-and-statecharts.mdx
@@ -2,6 +2,16 @@
 title: What are state machines and statecharts?
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read our up-to-date introduction to state machines and statecharts](/docs/state-machines-and-statecharts).
+
+:::
+
 State machines help us model how a process goes from state to state when an event occurs.
 
 State machines are useful in software development because they help us capture all the states, events and transitions between them. Using state machines makes it easier to find impossible states and spot undesirable transitions.

--- a/versioned_docs/version-4/states/final-states.mdx
+++ b/versioned_docs/version-4/states/final-states.mdx
@@ -3,6 +3,16 @@ title: Final states
 description: 'When a machine reaches the final state, it can no longer receive any events, and anything running inside it is canceled and cleaned up.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about final states in XState v5](/docs/final-states).
+
+:::
+
 When a machine reaches the final state, it can no longer receive any events, and anything running inside it is canceled and cleaned up. The box with a surrounding border icon represents the final state.
 
 :::video

--- a/versioned_docs/version-4/states/history-states.mdx
+++ b/versioned_docs/version-4/states/history-states.mdx
@@ -3,14 +3,22 @@ title: History states
 description: 'In statecharts, a history state returns the parent state to its most recently active child state. The box with an H inside represents the history state.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about history states in XState v5](/docs/history-states).
+
+:::
+
 A history state returns the parent state to its most recently active child state. The box with an **H** inside represents the history state.
 
 The history state can be deep or shallow:
 
 - A shallow history state remembers the immediate child’s state.
 - A deep history state remembers the deepest active state or states inside its child states.
-
-<!--TODO: Why you might use a history state with example.-->
 
 ## Make a state a history state
 

--- a/versioned_docs/version-4/states/initial-states.mdx
+++ b/versioned_docs/version-4/states/initial-states.mdx
@@ -3,6 +3,16 @@ title: Initial states
 description: 'When a state machine starts, it enters the initial state first. A machine can only have one top-level initial state. Parent states also have initial states.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about initial states in XState v5](/docs/initial-states).
+
+:::
+
 When a state machine starts, it enters the **initial state** first. A machine can only have one top-level initial state; if there were multiple initial states, the machine wouldn’t know where to start!
 
 :::video

--- a/versioned_docs/version-4/states/intro.mdx
+++ b/versioned_docs/version-4/states/intro.mdx
@@ -3,6 +3,16 @@ title: States
 description: 'A state describes a state machine’s status or mode, which could be as simple as Paused and Playing. A state machine can only be in one state at a time.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about states in XState v5](/docs/states).
+
+:::
+
 A state describes the machine’s status or mode, which could be as simple as *Paused* and *Playing*. A state machine can only be in one state at a time.
 
 :::video

--- a/versioned_docs/version-4/states/parallel-states.mdx
+++ b/versioned_docs/version-4/states/parallel-states.mdx
@@ -3,6 +3,16 @@ title: Parallel states
 description: 'In statecharts, a parallel state is a state separated into multiple regions of child states, where each region is active simultaneously.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about parallel states in XState v5](/docs/parallel-states).
+
+:::
+
 A parallel state is a state separated into multiple regions of child states, where each region is active simultaneously.
 
 A dashed line borders each region.

--- a/versioned_docs/version-4/states/parent-states.mdx
+++ b/versioned_docs/version-4/states/parent-states.mdx
@@ -3,6 +3,16 @@ title: Parent states
 description: 'Parent states can contain more states, also known as child states. These child states are only active when the parent state is active.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about parent and child states in XState v5](/docs/parent-states).
+
+:::
+
 States can contain more states, also known as **child states**. These child states are only active when the parent state is active.
 
 Child states are nested inside their parent states.

--- a/versioned_docs/version-4/studio.mdx
+++ b/versioned_docs/version-4/studio.mdx
@@ -1,6 +1,17 @@
 ---
 title: Welcome to the Stately docs
 ---
+<p></p>
+
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Jump to the XState v5 homepage](/docs/xstate).
+
+:::
 
 # Welcome to the Stately docs
 

--- a/versioned_docs/version-4/tools/developer-tools.mdx
+++ b/versioned_docs/version-4/tools/developer-tools.mdx
@@ -3,6 +3,16 @@ title: 'Developer tools'
 description: 'Find out more about the Stately XState CLI (Command Line Interface) and other dev tools available for Stately and XState.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about our developer tools for XState v5](/docs/developer-tools).
+
+:::
+
 Find more about our [XState CLI (Command Line Interface)](#xstate-cli-command-line-interface) below. We plan to make extensions for more IDEs (Integrated Development Environments) in the future.
 
 :::xstate

--- a/versioned_docs/version-4/tools/inspector.mdx
+++ b/versioned_docs/version-4/tools/inspector.mdx
@@ -5,6 +5,17 @@ description: '@xstate/inspect enables you to inspect and manipulate machines whi
 
 # Inspector
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about our inspection tools for XState v5](/docs/inspector).
+
+:::
+
+
 `@xstate/inspect` enables you to inspect and manipulate machines _while they’re running_ in your app. [Check out the @xstate/inspect package on GitHub](https://github.com/statelyai/xstate/tree/main/packages/xstate-inspect).
 
 Currently, `@xstate/inspect` only works in _frontend applications_ , but we’re working on a version that can inspect machines running in [Node](https://nodejs.org/).

--- a/versioned_docs/version-4/tools/visualizer.mdx
+++ b/versioned_docs/version-4/tools/visualizer.mdx
@@ -5,6 +5,13 @@ description: 'The Stately Viz is a legacy tool for creating and inspecting state
 
 # Visualizer
 
+:::warning
+
+**The Stately Viz has been deprecated**. Use the [Stately Studio](/docs/studio) instead.
+
+:::
+
+
 The [Stately Visualizer](https://stately.ai/viz) is a tool for creating and inspecting statecharts to visualize the state of your applications. You can use the viz as a playground for exploring XState’s capabilities.
 
 :::studio

--- a/versioned_docs/version-4/tools/xstate-vscode-extension.mdx
+++ b/versioned_docs/version-4/tools/xstate-vscode-extension.mdx
@@ -3,6 +3,16 @@ title: 'XState VS Code extension'
 description: 'The XState VS Code extension enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about our XState VS Code extension for XState v5](/docs/xstate-vscode-extension).
+
+:::
+
 # XState VS Code extension
 
 The [XState VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) enhances the XState development experience by providing VS Code users with autocomplete, typegen, linting, and a visual editor inside VS Code.

--- a/versioned_docs/version-4/transitions-and-events/delayed-transitions.mdx
+++ b/versioned_docs/version-4/transitions-and-events/delayed-transitions.mdx
@@ -3,6 +3,16 @@ title: Delayed (after) transitions
 description: 'Delayed transitions (also known as after transitions) are transitions that only happen after a specified interval of time.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about delayed (after) transitions in XState v5](/docs/delayed-transitions).
+
+:::
+
 **Delayed transitions** are transitions that only happen after a specified interval of time. If another event happens before the end of the timer, the transition doesn’t complete. Delayed transitions are handy if you need to build timeouts and intervals into your application logic.
 
 Delayed transitions are labeled “after” and often referred to as “after” transitions.

--- a/versioned_docs/version-4/transitions-and-events/eventless-transitions.mdx
+++ b/versioned_docs/version-4/transitions-and-events/eventless-transitions.mdx
@@ -3,6 +3,16 @@ title: Eventless (always) transitions
 description: 'Eventless transitions (also known as always transitions) are transitions without events. These transitions are always taken.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about eventless (always) transitions in XState v5](/docs/eventless-transitions).
+
+:::
+
 **Eventless transitions** are transitions without events. These transitions are *always* taken after any transition in their state is enabled.
 
 Eventless transitions are labeled “always” and often referred to as “always” transitions.

--- a/versioned_docs/version-4/transitions-and-events/guards.mdx
+++ b/versioned_docs/version-4/transitions-and-events/guards.mdx
@@ -3,6 +3,16 @@ title: Guards
 description: 'A guard is a condition that the machine checks when it goes through an event. If the condition is true, the machine follows the transition to the next state.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about guards in XState v5](/docs/guards).
+
+:::
+
 A **guard** is a condition that the machine checks when it goes through an event. If the condition is true, the machine follows the transition to the next state. If the condition is false, the machine follows the rest of the conditions to the next state. Any transition can be a guarded transition.
 
 <p>

--- a/versioned_docs/version-4/transitions-and-events/intro.mdx
+++ b/versioned_docs/version-4/transitions-and-events/intro.mdx
@@ -3,6 +3,16 @@ title: Transitions and events
 description: 'A machine moves from state to state through transitions. Transitions are caused by events; when an event happens, the machine transitions to the next state.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about transitions and events in XState v5](/docs/transitions).
+
+:::
+
 A machine moves from state to state through **transitions**. Transitions are caused by events; when an event happens, the machine transitions to the next state.
 
 :::video

--- a/versioned_docs/version-4/transitions-and-events/invoke-done-events.mdx
+++ b/versioned_docs/version-4/transitions-and-events/invoke-done-events.mdx
@@ -3,9 +3,15 @@ title: Invoke done events
 description: 'An invoke done event transitions from a state once its invocation has been completed. An invoke done event is labeled “done:” followed by the invocation’s ID.'
 ---
 
-An **invoke done event** transitions from a state once its invocation has been completed. An invoke done event is labeled “done:” followed by the invocation’s ID.
+:::warning
 
-<!-- TODO: Why you might use invoke done events with example -->
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+:::
+
+An **invoke done event** transitions from a state once its invocation has been completed. An invoke done event is labeled “done:” followed by the invocation’s ID.
 
 ### Create invoke done events
 

--- a/versioned_docs/version-4/transitions-and-events/invoke-error-events.mdx
+++ b/versioned_docs/version-4/transitions-and-events/invoke-error-events.mdx
@@ -3,9 +3,15 @@ title: Invoke error events
 description: 'An invoke error event transitions from a state when an error occurs in its invocation. An invoke error event is labeled “error.”'
 ---
 
-An **invoke error event** transitions from a state when an error occurs in its invocation. An invoke error event is labeled “error:” followed by the invocation’s ID.
+:::warning
 
-<!--TODO: Why you might use invoke error events with example-->
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+:::
+
+An **invoke error event** transitions from a state when an error occurs in its invocation. An invoke error event is labeled “error:” followed by the invocation’s ID.
 
 ## How to create invoke error events
 

--- a/versioned_docs/version-4/transitions-and-events/self-transitions.mdx
+++ b/versioned_docs/version-4/transitions-and-events/self-transitions.mdx
@@ -3,6 +3,16 @@ title: Self transitions
 description: 'A self-transition (also known as a self-event) starts and ends in the same state. Self-transitions can be used to restart a state.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about self-transitions in XState v5](/docs/transitions#self-transitions).
+
+:::
+
 A **self-transition** starts and ends in the same state.
 
 Self-transitions can be used to restart a state.

--- a/versioned_docs/version-4/transitions-and-events/state-done-events.mdx
+++ b/versioned_docs/version-4/transitions-and-events/state-done-events.mdx
@@ -3,6 +3,14 @@ title: State done events
 description: 'A state done event transitions from a parent state when one of its child states reaches its final state. State done events are labeled “onDone.”'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+:::
+
 A **state done event** transitions from a parent state when one of its child states reaches its final state. State done events are labeled “onDone.”
 
 :::video

--- a/versioned_docs/version-4/xstate/actions/actions.mdx
+++ b/versioned_docs/version-4/xstate/actions/actions.mdx
@@ -3,6 +3,16 @@ title: Actions
 description: 'Statecharts give you a great deal of control over running side effects in your app. The first method is through actions.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about actions in XState v5](/docs/actions).
+
+:::
+
 Statecharts give you a great deal of control over running side effects in your app. The first method is through actions.
 
 ## Side effects

--- a/versioned_docs/version-4/xstate/actions/built-in-actions.mdx
+++ b/versioned_docs/version-4/xstate/actions/built-in-actions.mdx
@@ -5,12 +5,20 @@ description: 'Along with the assign action, XState has several other built-in ac
 
 # Built-in actions
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about XState v5’s built-in actions](/docs/actions#assign-action).
+
+:::
+
 Along with the [`assign`](context.mdx#assign-action) action, XState has several other built-in actions which can do different things in a state machine. We’ll introduce a couple of built-in actions for now and learn about the others later.
 
 ## Send action
 
-<!-- deps:
-  ["actions", "transitions-and-events", "self-transitions"] -->
 
 XState’s built-in `send` action is useful for when statecharts need to send events back to themselves.
 
@@ -120,15 +128,11 @@ Click on both `STEP` and `RAISE` events in the [visualizer](https://stately.ai/v
 
 ## Pure action
 
-<!-- deps: ["actions", "self-transitions"] -->
-
 The `pure` action is useful when you need to run a dynamic number of actions depending on the current machine’s state.
 
 `pure` lets you pass a function to the machine, which calculates the type and number of actions to be executed.
 
 In the example below, we check `context` to find which actions the machine should run.
-
-<!-- Remove noErrors when pure TS issue (https://github.com/statelyai/xstate/pull/3233) is fixed-->
 
 ```ts
 import { actions, createMachine } from 'xstate';

--- a/versioned_docs/version-4/xstate/actions/context.mdx
+++ b/versioned_docs/version-4/xstate/actions/context.mdx
@@ -5,7 +5,15 @@ description: 'States are used for handling your apps states which you know about
 
 # Context
 
-<!-- deps: ["states", "transitions-and-events", "actions"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about context in XState V5](/docs/context).
+
+:::
 
 Statecharts represent their finite state using `states` but can also handle states which are _not_ finite. These states might be:
 
@@ -29,8 +37,6 @@ const machine = createMachine({
 Next, we’ll see how to update the context using the assign action.
 
 ## Assign action
-
-<!-- deps: ["context", "actions", "self-transitions"] -->
 
 Assigning new values to the context in XState is done through the `assign` action and is the only way to change a machine’s context. **Never mutate a machine’s `context` externally**. Every context change should happen explicitly due to an event.
 
@@ -134,8 +140,6 @@ You can pass several `assign` actions in an array and they’ll be executed sequ
 
 ## Using context in actions
 
-<!-- deps: ["actions", "context"] -->
-
 When XState fires an action, the action receives several arguments. The first argument is the current `context` of the machine. The second argument is the most recent `event` sent to the machine.
 
 ```ts
@@ -167,8 +171,6 @@ createMachine(
 ```
 
 :::typescript TypeScript
-
-<!-- deps: [context, assign-action] -->
 
 ## TypeScript
 

--- a/versioned_docs/version-4/xstate/actors/actions-vs-actors.mdx
+++ b/versioned_docs/version-4/xstate/actors/actions-vs-actors.mdx
@@ -5,6 +5,17 @@ description: 'Sometimes it’s unclear whether you should use an action or an ac
 
 # Actions vs. actors
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+- [Read about actions in XState V5](/docs/actions).
+- [Read about actors in XState V5](/docs/actors).
+
+:::
+
 Sometimes it’s unclear whether you should use an action or an actor. Both appear to do similar things, executing side effects. Let’s break down the differences:
 
 Actions are “fire-and-forget”; as soon as their execution starts, the statechart running the actions forgets about them. If you specify an action as `async`, **the action won’t be awaited before moving to the next state**. Below is an example:

--- a/versioned_docs/version-4/xstate/actors/callbacks.mdx
+++ b/versioned_docs/version-4/xstate/actors/callbacks.mdx
@@ -3,6 +3,17 @@ title: Callbacks
 description: 'Promise actors let you model promises, but not every actor will be a promise. Callback actors give you a flexible API for managing a long-running actor.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about callback logic in XState v5](/docs/actors#fromcallback).
+
+:::
+
+
 Promise actors let you model promises declaratively but not every actor will be a promise. **Callback actors** give you a flexible API for managing a long-running actor that can do several things a promise can’t, like:
 
 - Send events back to its parent

--- a/versioned_docs/version-4/xstate/actors/cheatsheet.mdx
+++ b/versioned_docs/version-4/xstate/actors/cheatsheet.mdx
@@ -3,6 +3,17 @@ title: Actor cheatsheet
 description: 'Get working quickly with actors using our quick reference XState cheatsheet, including spawning, sending, and receiving.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Check out our XState v5 actor cheatsheet](/docs/actors#cheatsheet).
+
+:::
+
+
 Get working quickly with actors using our quick reference cheatsheet.
 
 ## Import `spawn` to spawn actors

--- a/versioned_docs/version-4/xstate/actors/intro.mdx
+++ b/versioned_docs/version-4/xstate/actors/intro.mdx
@@ -5,6 +5,16 @@ description: 'When you run a statechart, it becomes an actor, a running process 
 
 # Actors
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about actors in XState V5](/docs/actors).
+
+:::
+
 When you run a statechart, it becomes an _actor_, a running process that can receive events. Often, you’ll need your actor to run _other actors_; spawning new statecharts, waiting for promises, or subscribing to observables.
 
 We use the `invoke` attribute on a state to _invoke_ an actor in our machine. You can invoke an actor on any state, including the root node.
@@ -29,12 +39,6 @@ const machine = createMachine(
   },
 );
 ```
-
-:::warningxstate
-
-XState v5 is in beta. [Check out XState v5 Beta on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-beta.13).
-
-:::
 
 You can also run several invocations at the same time by specifying `invoke` as an array:
 

--- a/versioned_docs/version-4/xstate/actors/machines.mdx
+++ b/versioned_docs/version-4/xstate/actors/machines.mdx
@@ -3,6 +3,16 @@ title: Machines
 description: 'Machine actors enable you to create machines that can act as reusable modules across your application. You can pass a machine directly to the invoke src.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about actor logic in XState v5](/docs/actors).
+
+:::
+
 Callback actors are one way to start invoking long-lived actors and are useful for simple to intermediate cases. But sometimes, you’ll want to use all the power of a statechart.
 
 _Machine actors_ are valuable for such use cases. You can pass a machine directly to the `invoke` `src` property to invoke the machine in that state.

--- a/versioned_docs/version-4/xstate/actors/observables.mdx
+++ b/versioned_docs/version-4/xstate/actors/observables.mdx
@@ -5,6 +5,16 @@ description: 'Observables are streams of values emitted over time. Observables c
 
 # Observables
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about observable logic in XState v5](/docs/actors#fromobservable).
+
+:::
+
 [Observables](https://github.com/tc39/proposal-observable) are streams of values emitted over time. They could be considered an array or collection whose values are emitted asynchronously instead of all at once. There are many implementations of observables in JavaScript; the most popular one is [RxJS](https://github.com/ReactiveX/rxjs).
 
 Observables can be invoked, sending events to the parent machine. An observable invocation is a function that takes `context` and `event` as arguments and returns an observable stream of events. The observable is unsubscribed when the state on which the observable is invoked is exited.

--- a/versioned_docs/version-4/xstate/actors/parent-child-communication.mdx
+++ b/versioned_docs/version-4/xstate/actors/parent-child-communication.mdx
@@ -3,6 +3,16 @@ title: Parent to child communication
 description: 'Invoked actors can send events to their parent using the sendParent and sendBack methods. Child actors can also receive events from the parent.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about the `send-to` action in XState v5](/docs/actions#send-to-action).
+
+:::
+
 We’ve learned that invoked actors can send events to their parent via the invoked machine’s `sendParent` action and the invoked callback’s `sendBack` method. Child actors can also _receive_ events from the parent, allowing for bidirectional communication.
 
 You must give invoked actors a unique id with `invoke.id` to enable parent to child communication:

--- a/versioned_docs/version-4/xstate/actors/promises.mdx
+++ b/versioned_docs/version-4/xstate/actors/promises.mdx
@@ -3,6 +3,16 @@ title: Promises
 description: 'The most common type of actors you’ll invoke are promise actors. Promise actors allow you to await the result of a promise before deciding what to do next.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about promises in XState V5](/docs/actors/#frompromise).
+
+:::
+
 The most common type of actors you’ll invoke are **promise actors**. Promise actors allow you to await the result of a promise before deciding what to do next.
 
 ```ts
@@ -31,12 +41,6 @@ const userMachine = createMachine(
   },
 );
 ```
-
-:::warningxstate
-
-XState v5 is in beta. [Check out XState v5 Beta on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-beta.13).
-
-:::
 
 When a promise actor is resolved, a `done.invoke` event is sent back to the machine which includes its data, placed under the `data` property. For example:
 

--- a/versioned_docs/version-4/xstate/actors/spawn.mdx
+++ b/versioned_docs/version-4/xstate/actors/spawn.mdx
@@ -5,7 +5,16 @@ description: 'You can use spawn to run actors. Actors created with spawn are spa
 
 # Spawning actors
 
-<!-- deps: ["assign-action", "machine-actors"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about spawning actors in XState v5](/docs/spawn).
+
+:::
+
 
 Sometimes invoking actors may not be flexible enough for your needs. In such cases, you might want to:
 
@@ -58,8 +67,6 @@ const parentMachine = createMachine({
 
 ## Sending events to spawned machines
 
-<!-- deps: ["spawning-machines"] -->
-
 Events can be sent to spawned actors by passing a function to `send` or `forwardTo`:
 
 ```ts
@@ -67,8 +74,6 @@ send({ type: 'INC' }, { to: (context) => context.counterRef });
 
 forwardTo((context) => context.counterRef);
 ```
-
-<!-- TODO - are there any other API's which need to be mentioned here?-->
 
 You can also forward _all_ events to the child by passing `autoForward` as an option to `spawn`:
 
@@ -89,8 +94,6 @@ const machine = createMachine({
 Passing `autoForward` will ensure that every event sent to the `machine` also gets forwarded to `childMachine`.
 
 ## Stopping spawned actors
-
-<!-- deps: [spawning-machines] -->
 
 When you want to stop a spawned actor, you can either stop the parent machine, which will stop all child actors automatically, or stop the actor via the `stop` action.
 
@@ -138,8 +141,6 @@ const parentMachine = createMachine(
 
 ## Spawning callbacks
 
-<!-- deps: ["spawning-machines"] -->
-
 Just like invoking callbacks, callbacks can be spawned as actors.
 
 ```ts
@@ -165,8 +166,6 @@ const machine = createMachine({
 Spawned callbacks behave exactly the same as invoked callbacks but with all the flexibility of `spawn`.
 
 ## Spawning observables
-
-<!-- deps: [spawning-machines, "observable-actors"] -->
 
 Just like invoking observables, observables can be spawned as actors:
 

--- a/versioned_docs/version-4/xstate/advanced/react-patterns.mdx
+++ b/versioned_docs/version-4/xstate/advanced/react-patterns.mdx
@@ -5,6 +5,16 @@ description: 'Using React hooks are the easiest way to use state machines in you
 
 # React Patterns
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about using React with XState v5](/docs/xstate-react).
+
+:::
+
 At [Stately](https://stately.ai), we love this combo. It’s our go-to stack for creating internal applications.
 
 To ask for help, check out the [`#react-help` channel in our Discord community](https://discord.gg/vedXj62MfQ).

--- a/versioned_docs/version-4/xstate/advanced/scxml.mdx
+++ b/versioned_docs/version-4/xstate/advanced/scxml.mdx
@@ -5,6 +5,17 @@ description: 'XState is compatible with the SCXML (State Chart XML: State Machin
 
 # SCXML
 
+
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Check out the XState v5 docs](/docs/xstate).
+
+:::
+
 XState is compatible with the [SCXML (State Chart XML: State Machine Notation for Control Abstraction) specification](https://www.w3.org/TR/scxml/). This page contains details on where our API relates to the SCXML specification.
 
 ## Events

--- a/versioned_docs/version-4/xstate/basics/inline-vs-named-options.mdx
+++ b/versioned_docs/version-4/xstate/basics/inline-vs-named-options.mdx
@@ -5,7 +5,15 @@ description: 'Named actions are when you pass options into the config using name
 
 # Inline vs. named Options
 
-<!-- deps: ["options-api"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about providing implementations for your machines in XState v5](/docs/machines#providing-implementations).
+
+:::
 
 In the examples so far, we’ve passed options into the config using names:
 

--- a/versioned_docs/version-4/xstate/basics/options.mdx
+++ b/versioned_docs/version-4/xstate/basics/options.mdx
@@ -3,6 +3,16 @@ title: Options
 description: 'The statechart’s config describes how the machine behaves, the machine’s options are implementation details that expand the machine’s capabilities.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about providing implementations for your machines in XState v5](/docs/machines#providing-implementations).
+
+:::
+
 Statecharts require that a machine is separated into two parts. The first part is the machine’s **config**. The config describes _how the machine behaves_ — its states, events and transitions.
 
 The second part is a machine’s **options** — implementation details that expand the machine’s capabilities.
@@ -32,8 +42,6 @@ const helloMachine = createMachine({
 });
 ```
 
-<!-- Add visualisation to the above \-->
-
 As a visualization, the config is readable. But the machine doesn’t _do_ anything yet.
 
 **Options** let us pass an implementation for the `sayHello` action.
@@ -56,9 +64,6 @@ const helloMachine = createMachine(
 The separation between “what your code does” and “how your code does it” is powerful because it allows you to understand its purpose without requiring you to read through the implementation details.
 
 ## Option types
-
-<!-- deps: ["options-intro"] -->
-<!-- loom: 6b2dd2d32acf4e5cbf2d8910ab826616 -->
 
 There are four types of options you can pass to your statechart.
 
@@ -145,8 +150,6 @@ Delays are used in XState to represent timers and intervals. We’ll revisit del
 
 ## Options API
 
-<!-- deps: ["options-intro", "guards-actions-actors-delays-intro"] -->
-
 You can specify machine options in several places. Firstly, you can set options inside the machine itself:
 
 ```ts
@@ -166,12 +169,6 @@ const machine = createMachine(
   },
 );
 ```
-
-:::warningxstate
-
-XState v5 is in beta. [Check out XState v5 Beta on NPM](https://www.npmjs.com/package/xstate/v/5.0.0-beta.13).
-
-:::
 
 Or, you can specify options later with a `.withConfig` call:
 

--- a/versioned_docs/version-4/xstate/basics/what-is-a-statechart.mdx
+++ b/versioned_docs/version-4/xstate/basics/what-is-a-statechart.mdx
@@ -5,6 +5,16 @@ description: 'An XState cheatsheet for statechart basics, including installation
 
 # What is a statechart?
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about state machines in XState v5](/docs/machines).
+
+:::
+
 [Install XState](/xstate/installation.mdx) and create a statechart by importing `createMachine` from `xstate`.
 
 ```ts

--- a/versioned_docs/version-4/xstate/installation.mdx
+++ b/versioned_docs/version-4/xstate/installation.mdx
@@ -4,6 +4,16 @@ title: Installation
 
 # Installation
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about installation for XState v5](/docs/installation).
+
+:::
+
 You can install XState using your favorite package manager or embed the `<script>` directly from a CDN.
 
 ## Installation Snippets

--- a/versioned_docs/version-4/xstate/intro.mdx
+++ b/versioned_docs/version-4/xstate/intro.mdx
@@ -3,6 +3,16 @@ title: XState
 slug: '/xstate'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read more about XState v5](/docs/xstate).
+
+:::
+
 XState is a JavaScript and TypeScript library for creating, interpreting, and executing finite state machines and statecharts, as well as managing invocations of those machines as actors.
 
 - [Install XState](/xstate/installation.mdx)

--- a/versioned_docs/version-4/xstate/model-based-testing/assertions.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/assertions.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: How to use the setup and assert p
 
 # Assertions
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 If you’ve done testing before, you might be familiar with the **setup, then assert** pattern for writing tests:
 
 1. **Setup** to get the app into the desired state.

--- a/versioned_docs/version-4/xstate/model-based-testing/cypress.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/cypress.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: How to implement model-based test
 
 # Cypress
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 Integrating with [Cypress](https://www.cypress.io) is simple with `@xstate/test`.
 
 ```js

--- a/versioned_docs/version-4/xstate/model-based-testing/event-cases.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/event-cases.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: how to use eventCases in your tes
 
 # Event cases
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 Sometimes you want to test your system with a variety of different values. For example, you might be testing a payment system where you can pay with many different currencies, and you need to ensure that `GBP`, `EUR` and `USD` all work.
 
 You can use `eventCases` to test with these different values:

--- a/versioned_docs/version-4/xstate/model-based-testing/intro.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/intro.mdx
@@ -4,13 +4,21 @@ title: Model-based testing
 
 # Model-based testing
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 Adopting model-based testing can lead to **self-documenting, easy-to-maintain tests** which are far more **[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)** than regular tests.
 
 You create a visual model, tell it how to interact with your app, and execute the model to **test your app automatically**.
 
 ## Imperative testing
-
-<!-- deps: ["transitions-and-events"] -->
 
 If you’ve done any automated application testing before, you’ve likely come across code like this:
 

--- a/versioned_docs/version-4/xstate/model-based-testing/jest.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/jest.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: How to implement model-based test
 
 # Jest
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 Integrating with [Jest](https://jestjs.io) is simple with `@xstate/test`.
 
 ```ts

--- a/versioned_docs/version-4/xstate/model-based-testing/playwright.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/playwright.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: How to implement model-based test
 
 # Playwright
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 Integrating with [Playwright](https://playwright.dev) is simple with `@xstate/test`.
 
 ```ts

--- a/versioned_docs/version-4/xstate/model-based-testing/quickstart.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/quickstart.mdx
@@ -5,7 +5,15 @@ description: 'Model-based testing with XState: How to get started quickly with m
 
 # Quickstart
 
-<!-- deps: ["testing-intro"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
 
 1. Install `xstate` and `@xstate/test`:
 

--- a/versioned_docs/version-4/xstate/model-based-testing/test-paths.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/test-paths.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: Understanding test paths, includi
 
 # Test paths
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 `@xstate/test` generates _test paths_ that it walks through to execute your tests. Knowing how these paths are generated will make your tests more predictable.
 
 ## Coverage

--- a/versioned_docs/version-4/xstate/model-based-testing/vitest.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/vitest.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: How to implement model-based test
 
 # Vitest
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 Integrating with [Vitest](https://vitest.dev) is simple with `@xstate/test`.
 
 ```js

--- a/versioned_docs/version-4/xstate/model-based-testing/when-to-use.mdx
+++ b/versioned_docs/version-4/xstate/model-based-testing/when-to-use.mdx
@@ -5,6 +5,16 @@ description: 'Model-based testing with XState: Model-based testing is good for m
 
 # When to use `@xstate/test`
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about testing in XState V5](/docs/testing).
+
+:::
+
 When you discover a new tool, it’s tempting to use that tool for everything. Model-based testing is good for many use cases but not for all use cases.
 
 Let’s explore what makes a _good_ candidate for model-based testing.

--- a/versioned_docs/version-4/xstate/packages/xstate-fsm.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-fsm.mdx
@@ -3,6 +3,17 @@ title: '@xstate/fsm'
 description: 'The @xstate/fsm package contains a minimal, 1kb implementation of XState for finite state machines. Learn how to install and use @xstate/fsm.'
 ---
 
+
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+The [@xstate/fsm package](https://github.com/statelyai/xstate/tree/main/packages/xstate-fsm) is deprecated in XState v5. Use [XState](https://github.com/statelyai/xstate) instead.
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+:::
+
 The [@xstate/fsm package](https://github.com/statelyai/xstate/tree/main/packages/xstate-fsm) contains a minimal, 1kb implementation of [XState](https://github.com/statelyai/xstate) for **finite state machines**.
 
 ## Features

--- a/versioned_docs/version-4/xstate/packages/xstate-graph.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-graph.mdx
@@ -3,6 +3,16 @@ title: '@xstate/graph'
 description: 'The @xstate/graph package contains graph algorithms and utilities for XState machines. Learn how to install and use @xstate/graph.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about the `@xstate/graph package` in XState v5](/docs/xstate-graph).
+
+:::
+
 The [@xstate/graph package](https://github.com/statelyai/xstate/tree/main/packages/xstate-graph) contains graph algorithms and utilities for XState machines.
 
 ## Quick start

--- a/versioned_docs/version-4/xstate/packages/xstate-immer.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-immer.mdx
@@ -3,6 +3,16 @@ title: '@xstate/immer'
 description: 'The @xstate/immer package contains utilities for using Immer with XState. Learn how to install and get started quickly with @xstate/immer.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+The [@xstate/immer package](https://github.com/statelyai/xstate/tree/main/packages/xstate-immer) is deprecated in XState v5. Use [XState](https://github.com/statelyai/xstate) instead.
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+:::
+
 The [@xstate/immer package](https://github.com/statelyai/xstate/tree/main/packages/xstate-immer) contains utilities for using [Immer](https://immerjs.github.io/immer) with [XState](https://github.com/statelyai/xstate).
 
 ## Quick start

--- a/versioned_docs/version-4/xstate/packages/xstate-react.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-react.mdx
@@ -3,6 +3,16 @@ title: '@xstate/react'
 description: 'The @xstate/react package contains utilities for using React with XState. Learn how to install and get started quickly with @xstate/react.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about the `@xstate/react package` in XState v5](/docs/xstate-react).
+
+:::
+
 The [@xstate/react package](https://github.com/statelyai/xstate/tree/main/packages/xstate-react) contains utilities for using [XState](https://github.com/statelyai/xstate) with [React](https://github.com/facebook/react/).
 
 ## Quick start

--- a/versioned_docs/version-4/xstate/packages/xstate-svelte.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-svelte.mdx
@@ -3,6 +3,16 @@ title: '@xstate/svelte'
 description: 'The @xstate/svelte package contains utilities for using Svelte with XState. Learn how to install and get started quickly with @xstate/svelte.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about the `@xstate/svelte package` in XState v5](/docs/xstate-svelte).
+
+:::
+
 The [@xstate/svelte package](https://github.com/statelyai/xstate/tree/main/packages/xstate-svelte) contains utilities for using [XState](https://github.com/statelyai/xstate) with [Svelte](https://github.com/sveltejs/svelte).
 
 ## Quick start

--- a/versioned_docs/version-4/xstate/packages/xstate-test.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-test.mdx
@@ -3,6 +3,16 @@ title: '@xstate/test'
 description: 'The @xstate/test package contains utilities for facilitating model-based testing with XState. Learn how to install and get started quickly with @xstate/test.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about the `@xstate/test package` in XState v5](/docs/xstate-test).
+
+:::
+
 The [@xstate/test package](https://github.com/statelyai/xstate/tree/main/packages/xstate-test) contains utilities for facilitating [model-based testing](https://en.wikipedia.org/wiki/Model-based_testing) for any software.
 
 **Watch the talk**: [Write Fewer Tests! From Automation to Autogeneration](https://slides.com/davidkhourshid/mbt) at React Rally 2019 ([🎥 Video](https://www.youtube.com/watch?v=tpNmPKjPSFQ))

--- a/versioned_docs/version-4/xstate/packages/xstate-vue.mdx
+++ b/versioned_docs/version-4/xstate/packages/xstate-vue.mdx
@@ -3,6 +3,16 @@ title: '@xstate/vue'
 description: 'The @xstate/vue package contains utilities for using Vue with XState. Learn how to install and get started quickly with @xstate/vue.'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about the `@xstate/vue package` in XState v5](/docs/xstate-vue).
+
+:::
+
 The [@xstate/vue package](https://github.com/statelyai/xstate/tree/main/packages/xstate-vue) contains utilities for using [XState](https://github.com/statelyai/xstate) with [Vue](https://github.com/vuejs/vue).
 
 :::warning

--- a/versioned_docs/version-4/xstate/running-machines/intro.mdx
+++ b/versioned_docs/version-4/xstate/running-machines/intro.mdx
@@ -5,7 +5,15 @@ description: 'Depending on where you’re using XState, you’ll likely need to 
 
 # Running machines
 
-<!-- deps: ["transitions-and-events", "states", "context", "options-intro"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read the XState V5 docs](/docs/xstate).
+
+:::
 
 We’ve now covered configuring statecharts and setting up their states, transitions, and options.
 
@@ -114,17 +122,11 @@ const actor = interpret(machine).start();
 actor.stop();
 ```
 
-<!-- TODO - add reference section for interpret \-->
-
 `interpret` can run _anywhere JavaScript runs_, which means you can run XState in the browser, Node, Electron, React Native… anywhere!
-
-<!-- TODO - add URL below \-->
 
 Check out the reference docs on the interpret API for a full deep dive into everything a `actor` can do.
 
 ## State API
-
-<!-- deps: ["states", "running-machines-intro", "actions", "context"] -->
 
 When running your machine, you’ll want to query the machine to understand which state it’s in. When you run a machine using `interpret`, you can find the state as follows:
 
@@ -235,8 +237,6 @@ You can check if a state was _changed_ by the most recently received event. The 
 2. A value in context was changed.
 
 ## Running machines as pure functions
-
-<!-- deps: ["transitions-and-events","intro-to-state-api","actions"] -->
 
 You can use `machine.transition` to run your machine as a pure function without executing any of its actions. `machine.transition` is a pure function that takes two arguments:
 

--- a/versioned_docs/version-4/xstate/running-machines/node.mdx
+++ b/versioned_docs/version-4/xstate/running-machines/node.mdx
@@ -5,6 +5,16 @@ description: 'Patterns for long-running processes and async functions when runni
 
 # Node
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read the XState V5 docs](/docs/xstate).
+
+:::
+
 When running machines in Node, a few common patterns emerge.
 
 ## Long-running processes

--- a/versioned_docs/version-4/xstate/running-machines/react.mdx
+++ b/versioned_docs/version-4/xstate/running-machines/react.mdx
@@ -5,7 +5,15 @@ description: 'You can use XState with React to coordinate local state, manage gl
 
 # XState in React
 
-<!-- deps: ["running-machines-intro", "intro-to-state-api"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read more about using XState with React](/docs/xstate-react).
+
+:::
 
 You can use XState with React to:
 

--- a/versioned_docs/version-4/xstate/states/advanced-transitions.mdx
+++ b/versioned_docs/version-4/xstate/states/advanced-transitions.mdx
@@ -4,11 +4,19 @@ title: Advanced transitions
 
 # Advanced transitions
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about transitions in XState V5](/docs/transitions).
+
+:::
+
 Parent and child states offer more opportunities for various types of transitions. You can transition from any state to any other state. XState has a few different syntaxes to help you out.
 
 ## Transitioning to a node’s own children
-
-<!-- deps: ["states", "parent-and-child-states"] -->
 
 Use the `.target` syntax to transition to a child state from a parent state.
 
@@ -33,8 +41,6 @@ const machine = createMachine({
 Whichever state the machine is in, whenever it receives a `HOVER` event, it’ll transition to the `hovered` state.
 
 ## Transitioning to another node’s children
-
-<!-- deps: ["states", "parent-and-child-states"] -->
 
 Transition directly into a node’s children using the `a.b` syntax.
 
@@ -67,8 +73,6 @@ In the example above, the machine transitions directly to `active.hovered` when 
 The `initial` state of `focused` inside `active` is ignored.
 
 ## Transitioning to any node
-
-<!-- deps: ["parent-and-child-states","transitions-and-events","targeting-children","targeting-children-of-siblings"] -->
 
 If you want to transition to _any_ state:
 

--- a/versioned_docs/version-4/xstate/states/final-states.mdx
+++ b/versioned_docs/version-4/xstate/states/final-states.mdx
@@ -4,6 +4,16 @@ title: Final states
 
 # Final states
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about final states in XState V5](/docs/final-states).
+
+:::
+
 When a machine reaches the [final state](../../states/final-states.mdx), it can no longer receive any events, and anything running inside it is canceled and cleaned up. A machine can have multiple final states or no final states.
 
 :::studio

--- a/versioned_docs/version-4/xstate/states/history-states.mdx
+++ b/versioned_docs/version-4/xstate/states/history-states.mdx
@@ -4,7 +4,15 @@ title: History states
 
 # History states
 
-<!-- deps: ["parent-and-child-states","transitions-and-events","targeting-children","targeting-children-of-siblings"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about history states in XState V5](/docs/history-states).
+
+:::
 
 When using statecharts, sometimes you’ll want to relaunch a process in a previous state.
 
@@ -109,8 +117,6 @@ In the example above, we’ve changed the target of `TURN_ON` to target `powerOn
 A history state can’t be specified as its parent’s initial state as this will result in an infinite loop.
 
 ## Types of history state
-
-<!-- deps: ["history-states", "parallel-states"] -->
 
 You can specify two types of history state:
 

--- a/versioned_docs/version-4/xstate/states/in-state-guards.mdx
+++ b/versioned_docs/version-4/xstate/states/in-state-guards.mdx
@@ -4,7 +4,15 @@ title: In-state guards
 
 # In-state guards
 
-<!-- deps: ["guards","parallel-states","transitioning-to-nodes-by-id","actions"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about in-state guards in XState V5](/docs/guards#in-state-guards).
+
+:::
 
 You can check if the machine is in a certain state using an `in` property on a transition. The `in` property takes a state ID as an argument and returns `true` if that state node is active in the current state, which can be useful in parallel states.
 

--- a/versioned_docs/version-4/xstate/states/other-state-attributes.mdx
+++ b/versioned_docs/version-4/xstate/states/other-state-attributes.mdx
@@ -4,11 +4,21 @@ title: Other state attributes
 
 # Other state attributes
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+- [Read about tags in XState V5](/docs/tags).
+- [Read about meta in XState V5](/docs/finite-states/#meta).
+- [Read about descriptions in XState V5](/docs/descriptions).
+
+:::
+
 States can have various other attributes, most of which are useful for narrower cases.
 
 ## State tags
-
-<!-- deps: ["parent-and-child-states", "intro-to-state-api"] -->
 
 State nodes can have **tags**, a list of strings that help describe the state node. Tags can be useful when categorizing different state nodes. For example, you can signify which state nodes represent “loading data” using a `"loading"` tag and determine if a state contains those tagged state nodes with `state.hasTag(tag)`:
 
@@ -126,8 +136,6 @@ First, select the state or event you want to tag.
 
 ## State meta
 
-<!-- deps: ["states","intro-to-state-api","after","transitioning-to-nodes-by-id"] -->
-
 You can attach arbitrary data to any state by specifying it as `meta` on the state node:
 
 ```ts
@@ -176,8 +184,6 @@ For instance, if the machine above is in the `timedOut` state, the `meta` will b
 ```
 
 ## State descriptions
-
-<!-- deps: ["parent-and-child-states"] -->
 
 You can add descriptive text to states with the `description` attribute.
 

--- a/versioned_docs/version-4/xstate/states/parallel-states.mdx
+++ b/versioned_docs/version-4/xstate/states/parallel-states.mdx
@@ -4,6 +4,16 @@ title: Parallel states
 
 # Parallel states
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about parallel states in XState V5](/docs/parallel-states).
+
+:::
+
 A [parallel state](/states/parallel-states.mdx) is a state separated into multiple regions of child states, where each region is active simultaneously.
 
 :::studio

--- a/versioned_docs/version-4/xstate/states/parent-and-child-states.mdx
+++ b/versioned_docs/version-4/xstate/states/parent-and-child-states.mdx
@@ -4,6 +4,16 @@ title: Parent and child states
 
 # Parent and child states
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about parent and child states in XState V5](/docs/parent-states).
+
+:::
+
 States can contain more states, also known as [child states](/states/parent-states.mdx). These child states are only active when the parent state is active. Child states are nested inside their parent states.
 
 :::studio

--- a/versioned_docs/version-4/xstate/templates.mdx
+++ b/versioned_docs/version-4/xstate/templates.mdx
@@ -3,6 +3,16 @@ title: 'Templates'
 description: 'We have XState templates for TypeScript, React Typescript, Vue, Svelte, and more!'
 ---
 
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Check out our templates for XState v5](/docs/templates).
+
+:::
+
 Check out our new templates:
 
 - [XState TypeScript template](https://github.com/statelyai/xstate/tree/main/templates/vanilla-ts)

--- a/versioned_docs/version-4/xstate/transitions-and-choices/always.mdx
+++ b/versioned_docs/version-4/xstate/transitions-and-choices/always.mdx
@@ -4,7 +4,15 @@ title: Always
 
 # Always
 
-<!-- deps: ["transitions-and-events", "guards", "self-transitions"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about eventless (always) transitions in XState V5](/docs/eventless-transitions).
+
+:::
 
 Sometimes you’ll need to make checks in your statechart’s current state _without_ receiving an event. You can do this with an eventless transition.
 

--- a/versioned_docs/version-4/xstate/transitions-and-choices/guarded-actions.mdx
+++ b/versioned_docs/version-4/xstate/transitions-and-choices/guarded-actions.mdx
@@ -4,7 +4,15 @@ title: Guarded actions
 
 # Guarded actions
 
-<!-- deps: ["actions", "guards", "transitions-and-events", "context"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about guards in XState V5](/docs/guards).
+
+:::
 
 You can use actions and guards together to run actions conditionally on transitions.
 
@@ -96,11 +104,7 @@ In the example above, if we have at least ten dollars in the account, we’ll lo
 
 Remember, **the cond always runs _before_ the action**. XState first checks if it should run the action by running the `cond`, and only then runs the action.
 
-<!-- TODO: write a tip (or section on its own) on using always to run actions on every transition… Sometimes you’ll want to run actions on every branch of a transition. Read our tip for that use case below. \-->
-
 ## The `choose` action
-
-<!-- deps: ["actions", "guards", "guarded-actions"] -->
 
 The `choose()` built-in action is an alternative API for guarded actions. `choose` lets you pick which actions should be executed based on some conditions inside the action itself.
 

--- a/versioned_docs/version-4/xstate/transitions-and-choices/guards.mdx
+++ b/versioned_docs/version-4/xstate/transitions-and-choices/guards.mdx
@@ -4,7 +4,15 @@ title: Guards
 
 # Guards
 
-<!-- deps: ["options-intro","transitions-and-events","events-and-context-in-actions"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about guards in XState V5](/docs/guards).
+
+:::
 
 A guard is a condition that the machine checks when it goes through an event. If the condition is true, the transition can be taken. If the condition is false, the next potential transition is tested to determine if it can be taken. Any transition can be a guarded transition.
 

--- a/versioned_docs/version-4/xstate/transitions-and-choices/internal-external.mdx
+++ b/versioned_docs/version-4/xstate/transitions-and-choices/internal-external.mdx
@@ -4,7 +4,15 @@ title: Internal and external transitions
 
 # Internal and external transitions
 
-<!-- deps: ["actions","transitions-and-events","self-transitions","after"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about re-entering transitions in XState V5](/docs/transitions#re-entering).
+
+:::
 
 Transitions in statecharts can be one of two types: **internal** or **external**. External transitions are transitions that leave the machine’s current state node; the “source” state node on which the transition is defined.
 
@@ -92,5 +100,3 @@ createMachine(
 ```
 
 When `target` is `a`, the transition becomes external, which means the node is exited and re-entered and the **entry and exit actions will be re-fired**. You can use this trick to re-run delays, restart services and it is also useful in parent and child states.
-
-<!-- TODO - rewrite this so that it uses delays as its example, now that it depends on after \-->

--- a/versioned_docs/version-4/xstate/transitions-and-choices/transition-descriptions.mdx
+++ b/versioned_docs/version-4/xstate/transitions-and-choices/transition-descriptions.mdx
@@ -4,7 +4,15 @@ title: Transition descriptions
 
 # Transition descriptions
 
-<!-- deps: ["transitions-and-events", "actions"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about descriptions in XState V5](/docs/descriptions).
+
+:::
 
 You can add descriptions to transitions to illustrate what they do.
 

--- a/versioned_docs/version-4/xstate/typescript/troubleshooting.mdx
+++ b/versioned_docs/version-4/xstate/typescript/troubleshooting.mdx
@@ -2,7 +2,15 @@
 title: Troubleshooting
 ---
 
-<!-- deps: ["context-typescript", "events-typescript"] -->
+:::warning
+
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about TypeScript in XState v5](/docs/machines#typescript).
+
+:::
 
 There are some known limitations with XState and TypeScript. We love TypeScript, and we’re _constantly_ pressing ahead to make it a better experience in XState.
 
@@ -82,8 +90,6 @@ createMachine(config, {
 ```
 
 Sometimes it’s also possible to move the implementation inline.
-
-<!-- TODO - remove the noErrors tag below when https://github.com/statelyai/xstate/pull/3217 is fixed-->
 
 ```ts
 import { createMachine } from 'xstate';
@@ -194,8 +200,6 @@ createMachine({
 ```
 
 ### Assign action behaving strangely
-
-<!-- TODO - rewrite this assign section when we figure out what's happening with the mixed syntax below-->
 
 When run in `strict: true` mode, assign actions can sometimes behave strangely.
 

--- a/versioned_docs/version-4/xstate/typescript/type-helpers.mdx
+++ b/versioned_docs/version-4/xstate/typescript/type-helpers.mdx
@@ -2,9 +2,15 @@
 title: Type helpers
 ---
 
-<!-- Needs technical review -->
+:::warning
 
-<!-- deps: ["context-typescript","events-typescript","running-machines-intro","intro-to-state-api"] -->
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about TypeScript in XState v5](/docs/machines#typescript).
+
+:::
 
 XState makes several type helpers available to you for composing types in TypeScript. You can use these helpers for creating custom functions or typing various integrations.
 

--- a/versioned_docs/version-4/xstate/typescript/typegen.mdx
+++ b/versioned_docs/version-4/xstate/typescript/typegen.mdx
@@ -21,7 +21,7 @@ All you need to do is to install the [Stately XState extension](https://marketpl
 
 #### How to get started with the CLI (other editors)
 
-Install the [CLI](/docs/xstate-v4/tools/developer-tools.mdx#xstate-cli-command-line-interface) and run the `xstate typegen` command with the `--watch` flag.
+Install the [CLI](/docs/xstate-v4/tools/developer-tools/#xstate-cli-command-line-interface) and run the `xstate typegen` command with the `--watch` flag.
 
 ### Typegen in action
 

--- a/versioned_docs/version-4/xstate/typescript/typegen.mdx
+++ b/versioned_docs/version-4/xstate/typescript/typegen.mdx
@@ -3,17 +3,17 @@ title: Typegen
 description: 'You can automatically generate intelligent typings for XState using our VS Code extension or our CLI.'
 ---
 
-<!-- Needs technical review -->
-
-<!-- deps: ["context-typescript","events-typescript","promise-actors"] -->
-
 :::warning
 
-**This feature is in beta!** Read the section below on [known limitations](/#known-limitations) to find out what we’re actively looking to improve.
+**Docs for XState v4 are no longer maintained** 
+
+This page is no longer maintained as [XState V5 has been released](/blog/2023-12-01-xstate-v5).
+
+[Read about TypeScript in XState v5](/docs/machines#typescript).
 
 :::
 
-You can automatically generate intelligent typings for XState using our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) or our [CLI](../../tools/developer-tools#xstate-cli-command-line-interface).
+You can automatically generate intelligent typings for XState using our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode) or our [CLI](/docs/xstate-v4/tools/developer-tools#xstate-cli-command-line-interface).
 
 #### How to get started with VS Code
 
@@ -21,7 +21,7 @@ All you need to do is to install the [Stately XState extension](https://marketpl
 
 #### How to get started with the CLI (other editors)
 
-Install the [CLI](/tools/developer-tools.mdx#xstate-cli-command-line-interface) and run the `xstate typegen` command with the `--watch` flag.
+Install the [CLI](/docs/xstate-v4/tools/developer-tools.mdx#xstate-cli-command-line-interface) and run the `xstate typegen` command with the `--watch` flag.
 
 ### Typegen in action
 


### PR DESCRIPTION
This PR removes the default v4 banner and replaces it with custom admonitions on every concept and XState page (every v4 page except the Studio pages.)

This allows us to link directly to equivalent and more relevant docs and provide additional information if needed. This benefits our readers as well as search engines!

**Example of before:**

![CleanShot 2023-12-05 at 17 32 26@2x](https://github.com/statelyai/docs/assets/266663/ec648bf4-7035-4ef7-8c1f-d597c106016a)

**Example of after:**

![CleanShot 2023-12-05 at 17 32 07@2x](https://github.com/statelyai/docs/assets/266663/afdec78b-18b8-4128-a0d7-1b4eb385212b)

I’ve also removed now-redundant todos and comments from these pages.