### PR TITLE
Update link to persisted-donut-maker example

### DIFF
--- a/blog/2023-10-02-persisting-state/index.mdx
+++ b/blog/2023-10-02-persisting-state/index.mdx
@@ -149,7 +149,7 @@ For the server, you can:
 
 There are [examples of persisting state that can be found in the XState git repository](https://github.com/statelyai/xstate/tree/main/examples):
 
-- [Persisting state to a writable `.json` file](https://github.com/statelyai/xstate/blob/next/examples/persisted-donut-maker)
+- [Persisting state to a writable `.json` file](https://github.com/statelyai/xstate/tree/main/examples/persisted-donut-maker)
 - [Persisting state to MongoDB](https://github.com/statelyai/xstate/tree/main/examples/mongodb-persisted-state)
 
 Feel free to [suggest other examples at on our examples request board](https://feedback.stately.ai/examples), or [contribute your own examples](https://github.com/statelyai/xstate/tree/main/examples)!


### PR DESCRIPTION
Update the link to the persisted-donut-maker example in [the blog post on persisting state](https://stately.ai/blog/2023-10-02-persisting-state) so it doesn't result in a 404.