### PR TITLE
Fix minor typo in first code example

### DIFF
--- a/docs/eventless-transitions.mdx
+++ b/docs/eventless-transitions.mdx
@@ -14,7 +14,7 @@ You can easily visualize and simulated eventless transitions in Stately’s edit
 
 ```ts
 import { createMachine } from 'xstate';
-const machine = createmachine({
+const machine = createMachine({
   states: {
     form: {
       initial: 'valid',


### PR DESCRIPTION
Syntax error due to `usemachine` != `useMachine`. Reviewed the rest of this page and didn't see any other issues.