### PR TITLE
Add React Native info

### DIFF
--- a/docs/stately-sky-getting-started.mdx
+++ b/docs/stately-sky-getting-started.mdx
@@ -44,7 +44,7 @@ Sky only supports [XState](https://github.com/statelyai/xstate) V5 machines. The
 
 :::typescript
 
-**XState v5 requires TypeScript version 5.0 or greater.** 
+**XState v5 requires TypeScript version 5.0 or greater.**
 
 For best results, use the latest TypeScript version. [Read more about XState and TypeScript](typescript.mdx)
 
@@ -137,3 +137,4 @@ Add your generated `sky.ts` files to source control.
 And that’s it! You can now interact with your running actor in much the same way you would with local actors, like sending events with the `send()` function. Sky is still in its early days, so there are some limitations and things to remember. Specifically:
 
 - Only XState V5 machines are supported.
+- If you're using React Native, see [this comment](https://github.com/statelyai/sky/issues/6#issuecomment-1766967479) if you're having issues.


### PR DESCRIPTION
This pull request adds a link at the end of the Sky "Getting Started" page with information on how to make React Native work with Sky.