### PR TITLE
docs: use correct variable name for logged event and fix indentation

### DIFF
--- a/blog/2023-12-01-xstate-v5/index.mdx
+++ b/blog/2023-12-01-xstate-v5/index.mdx
@@ -152,10 +152,10 @@ Instead of magically setting `devTools: true`, the Inspect API lets you attach a
 ```jsx
 const actor = createActor(machine, {
   inspect: (inspectionEvent) => {
-  // type: '@xstate.actor' or
-  // type: '@xstate.snapshot' or
-  // type: '@xstate.event'
-  console.log(event);
+    // type: '@xstate.actor' or
+    // type: '@xstate.snapshot' or
+    // type: '@xstate.event'
+    console.log(inspectionEvent);
   }
 });
 ```


### PR DESCRIPTION
Minor adjustments to the Inspect section of v5 blog post