### PR TITLE
Fix small grammar error in State -> Accessing state snapshots

### DIFF
--- a/docs/states.mdx
+++ b/docs/states.mdx
@@ -69,7 +69,7 @@ console.log(actor.getSnapshot());
 
 ## Accessing state snapshots
 
-You can access an actor’s the emitted state (or _snapshot_) by subscribing to or reading from the actor’s `.getSnapshot()` method.
+You can access an actor’s emitted state (or _snapshot_) by subscribing to or reading from the actor’s `.getSnapshot()` method.
 
 ```ts
 const actor = createActor(feedbackMachine);


### PR DESCRIPTION
Seen in [State -> Accessing state snapshots](https://stately.ai/docs/states#accessing-state-snapshots)

I checked the contribution guide and didn't see anything about small changes, but feel perfectly free to close the PR and include it in something larger.