### PR TITLE
Add messaging about GitHub Sync working best for smaller repos

### DIFF
--- a/docs/import-from-github.mdx
+++ b/docs/import-from-github.mdx
@@ -11,6 +11,12 @@ Connect GitHub repo is a premium feature of Stately Studio. You can try Stately 
 
 :::
 
+:::info
+While this feature is in beta, it works best when connecting less than
+100 files. For larger repos, we recommend creating single-file PRs.
+Read about that feature [here](/blog/2024-02-16-changelog#make-github-pull-requests-for-single-files-from-inside-stately-studio).
+:::
+
 ## Connect GitHub repo
 
 Use the **Connect GitHub repo** button found in the Projects dashboard to start connecting a GitHub repo. There are three steps to setting up your GitHub repo as a connected project:
@@ -87,7 +93,7 @@ If you want to quickly import a machine, or multiple machines, from a GitHub fil
 3. The editor will then display your imported machine.
 4. **Save** the machine to enable editing and easily find your machine in your projects later.
 
-Importing from a GitHub URL works with files in any branch in your private repositories, public repositories, and files in pull requests. 
+Importing from a GitHub URL works with files in any branch in your private repositories, public repositories, and files in pull requests.
 
 ### Pull requests
 
@@ -95,17 +101,25 @@ Once you’ve made changes to your imported machine, you can use the **Create pu
 
 ### Bookmarklet
 
-Use the bookmarklet below to import single file machines from GitHub with one click. 
+Use the bookmarklet below to import single file machines from GitHub with one click.
 
 1. Add a new bookmark to your browser
 2. Set the bookmark’s web address to the following:
-    ```javascript:(function(){ location.href = 'https://github.stately.ai/' + window.location.pathname;})();```
+   `javascript:(function(){ location.href = 'https://github.stately.ai/' + window.location.pathname;})();`
 3. Click the bookmarklet when viewing a GitHub file containing one or more machines to import that machine to Stately Studio.
 
 Or drag the following bookmarklet link to your bookmarks:
 
-<a style={{border: '1px solid', borderRadius: '1rem', padding: '0.5rem 0.75rem'}} href="javascript:(function()%7Bjavascript%3A(function()%7B%20location.href%20%3D%20'https%3A%2F%2Fgithub.stately.ai%2F'%20%2B%20window.location.pathname%3B%7D)()%3B%7D)()%3B">GitHub → Stately</a>
-
+<a
+  style={{
+    border: '1px solid',
+    borderRadius: '1rem',
+    padding: '0.5rem 0.75rem',
+  }}
+  href="javascript:(function()%7Bjavascript%3A(function()%7B%20location.href%20%3D%20'https%3A%2F%2Fgithub.stately.ai%2F'%20%2B%20window.location.pathname%3B%7D)()%3B%7D)()%3B"
+>
+  GitHub → Stately
+</a>
 
 ### Example
 

--- a/versioned_docs/version-4/import-from-github.mdx
+++ b/versioned_docs/version-4/import-from-github.mdx
@@ -11,6 +11,12 @@ Connect GitHub repo is a premium feature of Stately Studio. You can try Stately 
 
 :::
 
+:::info
+While this feature is in beta, it works best when connecting less than
+100 files. For larger repos, we recommend creating single-file PRs.
+Read about that feature [here](/blog/2024-02-16-changelog#make-github-pull-requests-for-single-files-from-inside-stately-studio).
+:::
+
 ## Connect GitHub repo
 
 Use the **Connect GitHub repo** button found in the Projects dashboard to start connecting a GitHub repo. There are three steps to setting up your GitHub repo as a connected project:
@@ -95,16 +101,25 @@ Once you’ve made changes to your imported machine, you can use the **Create pu
 
 ### Bookmarklet
 
-Use the bookmarklet below to import single file machines from GitHub with one click. 
+Use the bookmarklet below to import single file machines from GitHub with one click.
 
 1. Add a new bookmark to your browser
 2. Set the bookmark’s web address to the following:
-    ```javascript:(function(){ location.href = 'https://github.stately.ai/' + window.location.pathname;})();```
+   `javascript:(function(){ location.href = 'https://github.stately.ai/' + window.location.pathname;})();`
 3. Click the bookmarklet when viewing a GitHub file containing one or more machines to import that machine to Stately Studio.
 
 Or drag the following bookmarklet link to your bookmarks:
 
-<a style={{border: '1px solid', borderRadius: '1rem', padding: '0.5rem 0.75rem'}} href="javascript:(function()%7Bjavascript%3A(function()%7B%20location.href%20%3D%20'https%3A%2F%2Fgithub.stately.ai%2F'%20%2B%20window.location.pathname%3B%7D)()%3B%7D)()%3B">GitHub → Stately</a>
+<a
+  style={{
+    border: '1px solid',
+    borderRadius: '1rem',
+    padding: '0.5rem 0.75rem',
+  }}
+  href="javascript:(function()%7Bjavascript%3A(function()%7B%20location.href%20%3D%20'https%3A%2F%2Fgithub.stately.ai%2F'%20%2B%20window.location.pathname%3B%7D)()%3B%7D)()%3B"
+>
+  GitHub → Stately
+</a>
 
 ### Example
 


### PR DESCRIPTION
This PR adds info about connecting large repos when trying to connect to GitHub.

![CleanShot 2024-02-19 at 15 12 10](https://github.com/statelyai/docs/assets/167574/7f583b1e-64e2-4f1d-92a5-5378d591a62f)
