### PR TITLE
Add `options` param to `useActor`

### DIFF
--- a/docs/xstate-react.mdx
+++ b/docs/xstate-react.mdx
@@ -53,7 +53,7 @@ _Coming soon_
 
 ## API
 
-### `useActor(actorLogic)`
+### `useActor(actorLogic, options?)`
 
 A [React hook](https://reactjs.org/hooks) that creates an actor from the the given `actorLogic` and starts an actor that runs for the lifetime of the component.
 

--- a/docs/xstate-react.mdx
+++ b/docs/xstate-react.mdx
@@ -60,7 +60,7 @@ A [React hook](https://reactjs.org/hooks) that creates an actor from the the giv
 #### Arguments
 
 - `actorLogic` - The actor logic to create an actor from; e.g. `createMachine(...)`, `fromPromise(...)`, etc.
-- `options?` (optional) - Actor options
+- `options?` (optional) - Actor options.
 
 **Returns** a tuple of `[snapshot, send, actorRef]`:
 
@@ -103,7 +103,7 @@ A [React hook](https://reactjs.org/hooks) that creates an actor from the given `
 #### Arguments
 
 - `machine` - An [XState machine](machines.mdx)
-- `options?` - [Actor options](machines.mdx#creating-actors-from-machines).
+- `options?` (optional) - Actor options.
 
 **Returns** a tuple of `[snapshot, send, actorRef]`:
 
@@ -144,7 +144,7 @@ You can use the `useSelector(...)` hook to select part of the snapshot from the 
 #### Arguments
 
 - `actorLogic`- The actor logic to create an actor from; e.g. `createMachine(...)`, `fromPromise(...)`, etc.
-- `options?` (optional) - Actor options
+- `options?` (optional) - Actor options.
 
 ```js
 import { useActorRef } from '@xstate/react';


### PR DESCRIPTION
`useActor` had an optional `options` argument listed, but it was missing from the header.

Let's add it like other hooks, but let's ensure consistency across `options` definitions where not all of them had the mention `(optional)` and one of them had a link to a page that doesn't mention options.