### PR TITLE
fix: double-period typo in finite state tags documentation

### DIFF
--- a/docs/finite-states.mdx
+++ b/docs/finite-states.mdx
@@ -156,7 +156,7 @@ const feedbackMachine = createMachine({
 
 const feedbackActor = createActor(feedbackMachine).start();
 
-console.log(feedbackActor..getSnapshot().hasTag('visible'));
+console.log(feedbackActor.getSnapshot().hasTag('visible'));
 // logs true
 ```
 


### PR DESCRIPTION
The documentation for [tags & finite states](https://stately.ai/docs/finite-states#tags) has an extra period in the example code, which this PR fixes.