### PR TITLE
Update persistence.mdx by fixing Inspection API link

### DIFF
--- a/docs/persistence.mdx
+++ b/docs/persistence.mdx
@@ -135,7 +135,7 @@ restoredActor.start();
 
 An alternative to persisting state is **event sourcing**, which is a way of restoring the state of an actor by replaying the [events](transitions.mdx) that led to that state. Event sourcing can be more reliable than persisting state, because it is less prone to [incompatible state](#caveats) and it also allows you to replay actions.
 
-One way to implement event sourcing is to persist the events as they happen using the [inspection API](/inspection), and then replay them to restore the state of the actor:
+One way to implement event sourcing is to persist the events as they happen using the [inspection API](/docs/inspection), and then replay them to restore the state of the actor:
 
 ```ts
 const events = [];


### PR DESCRIPTION
This fixes the broken link to the Inspection API in the Docs as reported by Carlos on Discord https://discord.com/channels/795785288994652170/838444044774277151/1230472231797133425