### PR TITLE
Add missing import in getting-started code example

### DIFF
--- a/docs/xstate.mdx
+++ b/docs/xstate.mdx
@@ -92,7 +92,7 @@ countActor.send({ type: 'SET', value: 10 });
 ## Create a more complex machine
 
 ```js
-import { createMachine, createActor } from 'xstate';
+import { createMachine, assign, createActor } from 'xstate';
 
 const textMachine = createMachine({
   context: {


### PR DESCRIPTION
The ["Create a more complex state machine"](https://stately.ai/docs/xstate#create-a-more-complex-machine) code is missing the `assign` import.

Also, I think these PRs could be closed as they seem outdated:
- #155 which was fixing the same issue, but on the previous version of the docs
-  #174 and #208 which fix typos on pages that don't seem to exist anymore