### PR TITLE
Fix the final example.

### DIFF
--- a/blog/2024-02-12-xstate-react-global-state/index.mdx
+++ b/blog/2024-02-12-xstate-react-global-state/index.mdx
@@ -216,11 +216,12 @@ State machines are very powerful and useful, but sometimes you don't need all th
 ```ts
 // highlight-next-line
 import { fromTransition, createActor } from 'xstate';
+import { useSelector } from '@xstate/react'
 
 // highlight-start
 // Actor logic
 const counterLogic = fromTransition((state, event) => {
-  if (event.type === 'INC') {
+  if (event.type === 'inc') {
     return { count: state.count + 1 };
   }
   return state;


### PR DESCRIPTION
1. Add the missing import for useSelector in the code.
2. Correct the typo by replacing `inc` with `INC` as the event type throughout the code.