### PR TITLE
multi-word examples for state.matches

### DIFF
--- a/docs/states.mdx
+++ b/docs/states.mdx
@@ -214,6 +214,12 @@ state.matches('form'); // true
 state.matches('question'); // false
 state.matches({ form: 'invalid' }); // true
 state.matches({ form: 'valid' }); // false
+
+// state.value === { 'form submitting' : 'invalid value' }
+state.matches('form submitting'); // true
+state.matches('form'); // false
+state.matches({ 'form submitting' : 'invalid value' }); // true
+state.matches({ 'form submitting' : 'value' }); // false
 ```
 
 ## `state.output`


### PR DESCRIPTION
(from [Discord](https://discordapp.com/channels/795785288994652170/838444044774277151/1274402303570481295))
Hi all. A quick thought on the state.matches examples given in https://stately.ai/docs/states#statematchesstatevalue. Given that many examples of states have more than one word, could we have examples that show this usage with child states too? It seems obvious how to do it now I've figured it out, but this actually had me scratching my head for a while!
E.g.
// state.value === { 'fetching question' : 'displaying loading' }
state.matches({ 'fetching question' : 'displaying loading' }); // true 
