### PR TITLE
Add wording to indicate that `after` events are internal XState events

### DIFF
--- a/docs/editor-states-and-transitions.mdx
+++ b/docs/editor-states-and-transitions.mdx
@@ -106,7 +106,7 @@ There are a few different types of transitions:
 
 - **Normal** transitions are triggered by an event.
 - [**Guarded transitions**](#add-guards) are triggered by an event, but only if a specified condition is met.
-- [**Delayed transitions**](#delayed-after-transitions) (also known as _after_ transitions) are triggered by an event, but only after a specified time interval.
+- [**Delayed transitions**](#delayed-after-transitions) (also known as _after_ transitions) are triggered by an internal XState event, but only after a specified time interval.
 - [**Eventless transitions**](#eventless-always-transitions) (also known as _always_ transitions) are triggered by a timer or other condition, and don’t have an event.
 
 <EmbedMachine

--- a/versioned_docs/version-4/editor-states-and-transitions.mdx
+++ b/versioned_docs/version-4/editor-states-and-transitions.mdx
@@ -106,7 +106,7 @@ There are a few different types of transitions:
 
 - **Normal** transitions are triggered by an event.
 - [**Guarded transitions**](#add-guards) are triggered by an event, but only if a specified condition is met.
-- [**Delayed transitions**](#delayed-after-transitions) (also known as _after_ transitions) are triggered by an event, but only after a specified time interval.
+- [**Delayed transitions**](#delayed-after-transitions) (also known as _after_ transitions) are triggered by an internal XState event, but only after a specified time interval.
 - [**Eventless transitions**](#eventless-always-transitions) (also known as _always_ transitions) are triggered by a timer or other condition, and don’t have an event.
 
 <EmbedMachine


### PR DESCRIPTION
Discord [issue](https://discord.com/channels/795785288994652170/1306927942823313439/1306927942823313439)