### PR TITLE
Fix typo in actors invoke

### DIFF
--- a/docs/invoke.mdx
+++ b/docs/invoke.mdx
@@ -886,7 +886,7 @@ For best results, use the latest TypeScript version. [Read more about XState and
 
 :::
 
-You should leverage the `setup({ ... })` API to properly infer types for invoked actor logic.
+You should use the `setup({ ... })` API to properly infer types for invoked actor logic.
 
 ```ts
 import { setup, fromPromise, assign } from 'xstate';

--- a/docs/invoke.mdx
+++ b/docs/invoke.mdx
@@ -886,7 +886,7 @@ For best results, use the latest TypeScript version. [Read more about XState and
 
 :::
 
-You should the `setup({ ... })` API to properly infer types for invoked actor logic.
+You should leverage the `setup({ ... })` API to properly infer types for invoked actor logic.
 
 ```ts
 import { setup, fromPromise, assign } from 'xstate';


### PR DESCRIPTION
Found another typo while reading the docs

![image](https://github.com/user-attachments/assets/266e52af-c91c-4042-a552-4595e62f0e36)
