### PR TITLE
Change relative paths (./docs --> /docs)

### DIFF
--- a/blog/2023-06-14-supercharge-the-canvas/index.mdx
+++ b/blog/2023-06-14-supercharge-the-canvas/index.mdx
@@ -132,7 +132,7 @@ And the Studio now supports action parameters and several categories of [actions
 - sendTo
 - stop
 
-You can [learn more about tags and the actions built into XState in our documentation](../docs/xstate-v4/xstate/actions).
+You can [learn more about tags and the actions built into XState in our documentation](/docs/xstate-v4/xstate/actions).
 
 Also, you can try exporting your machines to XState v5 beta. Note that support for importing from v5 beta is coming soon.
 

--- a/blog/2023-5-30-what-is-the-actor-model-and-when-should-i-use-it/index.mdx
+++ b/blog/2023-5-30-what-is-the-actor-model-and-when-should-i-use-it/index.mdx
@@ -100,6 +100,6 @@ const todosMachine = createMachine({
 ```
 
 With the use of `spawn()` and `assign()`, we create a new actor instance when provided the machine logic and a unique identifier.
-By their nature, actions are ["fire and forget" effects](../docs/xstate-v4/xstate/actions), meaning they are executed with no expectation of receiving events back to the actor. This makes sense for creating a new actor, but we may still want the parent actor to have a reference to its child, so we save that in its context using `assign()`. `spawn()` is the function called that actually creates the new actor. The parent can access this state easily by calling `getSnapshot()` on the reference to the child.
+By their nature, actions are ["fire and forget" effects](/docs/xstate-v4/xstate/actions), meaning they are executed with no expectation of receiving events back to the actor. This makes sense for creating a new actor, but we may still want the parent actor to have a reference to its child, so we save that in its context using `assign()`. `spawn()` is the function called that actually creates the new actor. The parent can access this state easily by calling `getSnapshot()` on the reference to the child.
 
-For more detailed examples around working with actors in XState, like callback or promised-based actor spawning, sending updates, and communicating between actors, [check out our docs on actors](../docs/xstate-v4/actions-and-actors/actors).
+For more detailed examples around working with actors in XState, like callback or promised-based actor spawning, sending updates, and communicating between actors, [check out our docs on actors](/docs/xstate-v4/actions-and-actors/actors).

--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -17,14 +17,14 @@ hide_title: true
     </svg>
   </h2>
   <p>
-    <a href="./docs/xstate">XState</a> is a best-in-class open source library
-    for orchestrating and managing state in JavaScript and TypeScript apps.
+    <a href="/docs/xstate">XState</a> is a best-in-class open source library for
+    orchestrating and managing state in JavaScript and TypeScript apps.
   </p>
 </div>
 
 <ul className="content-boxes">
   <li>
-    <a className="link-box" href="./docs/states">
+    <a className="link-box" href="/docs/states">
       <RocketIcon size="40" />
       <strong>Get started</strong>
       <p>
@@ -34,7 +34,7 @@ hide_title: true
     </a>
   </li>
   <li>
-    <a className="link-box" href="./docs/studio">
+    <a className="link-box" href="/docs/studio">
       <LayoutIcon size="40" />
       <strong>Stately Studio overview</strong>
       <p>
@@ -44,14 +44,14 @@ hide_title: true
     </a>
   </li>
   <li>
-    <a className="link-box" href="./docs/state-machines-and-statecharts">
+    <a className="link-box" href="/docs/state-machines-and-statecharts">
       <BookOpenTextIcon size="40" />
       <strong>Learn state machines and statecharts</strong>
       <p>With our no-code introduction.</p>
     </a>
   </li>
   <li>
-    <a className="link-box" href="./docs/xstate">
+    <a className="link-box" href="/docs/xstate">
       <CodeIcon size="40" />
       <strong>Learn XState</strong>
       <p>


### PR DESCRIPTION
Paths like ./docs aren't necessary since /docs is a root path. This was causing cases where links like ./docs would resolve to /docs/docs/...

Video showing changes work as intended:

https://github.com/user-attachments/assets/1dd7e7f0-62f8-4060-9c11-eec75f6a4c8d

