### PR TITLE
fix: typo in tags.mdx example

### DIFF
--- a/docs/tags.mdx
+++ b/docs/tags.mdx
@@ -29,7 +29,7 @@ const feedbackMachine = createMachine({
 
 const feedbackActor = createActor(feedbackMachine).start();
 
-console.log(feedbackActor..getSnapshot().hasTag('visible'));
+console.log(feedbackActor.getSnapshot().hasTag('visible'));
 // logs true
 ```
 


### PR DESCRIPTION
A subtle, but jarring typo 😉 