### PR TITLE
Fix @xstate/store selector example

### DIFF
--- a/docs/xstate-store.mdx
+++ b/docs/xstate-store.mdx
@@ -270,7 +270,7 @@ const store = createStore({
 });
 
 // Create a selector for the position
-const position = store.select((state) => state.context.position);
+const position = store.select((state) => state.position);
 
 // Get current value
 console.log(position.get()); // { x: 0, y: 0 }

--- a/docs/xstate-store.mdx
+++ b/docs/xstate-store.mdx
@@ -270,7 +270,7 @@ const store = createStore({
 });
 
 // Create a selector for the position
-const position = store.select((state) => state.position);
+const position = store.select((context) => context.position);
 
 // Get current value
 console.log(position.get()); // { x: 0, y: 0 }


### PR DESCRIPTION
The example code accesses the context on the state object, as if it is working on a `StoreSnapshot`. This is wrong.

In reality [the context itself](https://github.com/statelyai/xstate/blob/77d7dc5585422c598f04fb5dd798afb81a8fd1d1/packages/xstate-store/src/store.ts#L209) is passed to the `Selector`:

```typescript
      return createAtom(() => selector(store.get().context), {
```

The `select` method of the store accepts a `Selector` as its first argument, which [is defined as](https://github.com/statelyai/xstate/blob/77d7dc5585422c598f04fb5dd798afb81a8fd1d1/packages/xstate-store/src/types.ts#L359):

```typescript
export type Selector<TContext, TSelected> = (context: TContext) => TSelected;
```

This PR updates the code example to pass in a selector function that works directly on the context.