### PR TITLE
Clarify that calling send on an actor is also not imperative

### DIFF
--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -236,7 +236,7 @@ XState provides a number of useful built-in actions that are a core part of the 
 
 :::warning
 
-Built-in actions, such as `assign(…)`, `sendTo(…)`, and `raise(…)`, are **not imperative**; they return a special [action object](#action-objects) (e.g. `{ type: 'xstate.assign', … }`) that are interpreted by the state machine. Do not call built-in action in custom action functions.
+Built-in actions, such as `assign(…)`, `sendTo(…)` (including calling `send` on an actor), and `raise(…)`, are **not imperative**; they return a special [action object](#action-objects) (e.g. `{ type: 'xstate.assign', … }`) that are interpreted by the state machine. Do not call built-in action in custom action functions.
 
 ```ts
 // ❌ This will have no effect

--- a/docs/actions.mdx
+++ b/docs/actions.mdx
@@ -236,7 +236,7 @@ XState provides a number of useful built-in actions that are a core part of the 
 
 :::warning
 
-Built-in actions, such as `assign(…)`, `sendTo(…)` (including calling `send` on an actor), and `raise(…)`, are **not imperative**; they return a special [action object](#action-objects) (e.g. `{ type: 'xstate.assign', … }`) that are interpreted by the state machine. Do not call built-in action in custom action functions.
+Built-in actions, such as `assign(…)`, `sendTo(…)` (including calling `send(…)` on an actor), and `raise(…)`, are **not imperative**; they return a special [action object](#action-objects) (e.g. `{ type: 'xstate.assign', … }`) that are interpreted by the state machine. Do not call built-in action in custom action functions.
 
 ```ts
 // ❌ This will have no effect


### PR DESCRIPTION
Spent an entire day trying to figure out why I was getting warnings on my state machine.
Silly of me in hindsight, but since sendTo is mentioned as not being imperative, that also means calling send directly on an actor is also considered not being imperative.

This pull request explicitly mentions this behavior.