### PR TITLE
docs: clarify that context should be an object

### DIFF
--- a/docs/context.mdx
+++ b/docs/context.mdx
@@ -28,6 +28,12 @@ feedbackActor.start();
 // logs 'Some feedback'
 ```
 
+:::warning
+
+The `context` must be an object.  If you need to store a list of items, wrap it in an object, e.g., `context: { items: [] }`.
+
+:::
+
 ## Initial context
 
 Set the initial context of a machine in the `context` property of the machine config:


### PR DESCRIPTION
As discussed in [Discussion #5411](https://github.com/statelyai/xstate/discussions/5411), `context` is expected to always be an object.
If an array is used as `context`, it gets converted into an object after an `assign` action, which might be unexpected for users.

This PR adds a warning to the Context documentation to clarify that `context` should always be an object, and recommends wrapping arrays in an object (e.g., `{ items: [] }`).