### PR TITLE
[Docs] Fix broken hyperlinks to blog posts

### DIFF
--- a/content/docs/figma.mdx
+++ b/content/docs/figma.mdx
@@ -6,7 +6,7 @@ import { Plus, Paperclip, Star, Info, Settings } from 'lucide-react';
 
 You can embed Figma frames in your states to keep your design and code in sync. Embedded Figma frames will stay up to date with the latest changes in your Figma files. Figma frames are a special type of [asset](assets).
 
-[In Nick’s blog post, read about how you can improve your team workflows with Stately and Figma](../../docs/assets/blog/2024-01-24-embed-figma/).
+[In Nick’s blog post, read about how you can improve your team workflows with Stately and Figma](../../blog/2024-01-24-embed-figma/).
 
 <Callout>
 

--- a/content/docs/import-from-github.mdx
+++ b/content/docs/import-from-github.mdx
@@ -17,7 +17,7 @@ Connect GitHub repo is a premium feature of Stately Studio. You can try Stately 
   While this feature is in beta, it works best when connecting less than 100
   files. For larger repos, we recommend creating single-file PRs. Read about
   that feature
-  [here](../../docs/assets/blog/2024-02-16-changelog#make-github-pull-requests-for-single-files-from-inside-stately-studio).
+  [here](../../blog/2024-02-16-changelog#make-github-pull-requests-for-single-files-from-inside-stately-studio).
 </Callout>
 
 ## Connect GitHub repo

--- a/content/docs/inspection.mdx
+++ b/content/docs/inspection.mdx
@@ -11,7 +11,7 @@ The Inspect API is a way to inspect the state transitions of your state machines
 
 <Callout>
 
-[We’ve recently released Stately Inspector](../../docs/assets/blog/2024-01-15-stately-inspector/), a universal tool that enables you to visually inspect the state of any application, frontend or backend, with the visualization of Stately’s editor.
+[We’ve recently released Stately Inspector](../../blog/2024-01-15-stately-inspector/), a universal tool that enables you to visually inspect the state of any application, frontend or backend, with the visualization of Stately’s editor.
 
 [Learn more about Stately Inspector](inspector)
 

--- a/content/docs/inspector.mdx
+++ b/content/docs/inspector.mdx
@@ -8,7 +8,7 @@ Stately Inspector is a tool that allows you to inspect your application’s stat
 
 <Callout>
 
-[Read about our recent release of Stately Inspector on our blog](../../docs/assets/blog/2024-01-15-stately-inspector/).
+[Read about our recent release of Stately Inspector on our blog](../../blog/2024-01-15-introducing-stately-inspector/).
 
 </Callout>
 

--- a/content/docs/migration.mdx
+++ b/content/docs/migration.mdx
@@ -6,7 +6,7 @@ The guide below explains how to migrate from XState version 4 to version 5. Migr
 
 <Callout>
 
-Read [David’s blog post on the launch of XState v5](../../docs/assets/blog/2023-12-01-xstate-v5).
+Read [David’s blog post on the launch of XState v5](../../blog/2023-12-01-xstate-v5).
 
 </Callout>
 

--- a/content/docs/persistence.mdx
+++ b/content/docs/persistence.mdx
@@ -201,4 +201,4 @@ const restoredActor = createActor(actorMachine, {
 
 ## Resources
 
-- [Blog: Persisting state in XState](../../docs/assets/blog/2023-10-02-persisting-state)
+- [Blog: Persisting state in XState](../../blog/2023-10-02-persisting-state)


### PR DESCRIPTION
This PR changes hyperlinks to blog posts under the `/content/docs` directory.

_Note:_ I believe that the hyperlinks to blog posts under the `/content/blog` are also in need of being updated.