### PR TITLE
Update pricing page for the 7-day Pro trial

### DIFF
--- a/app/(home)/pricing/page.tsx
+++ b/app/(home)/pricing/page.tsx
@@ -15,65 +15,29 @@ export default function PricingPage() {
               Pricing
             </h1>
             <p className="text-lg md:text-xl text-fd-muted-foreground max-w-3xl mx-auto">
-              Create unlimited public projects for free. Upgrade to work
-              privately and unlock more features. Get a team to add users and
-              enable collaboration.
+              Every new account starts with a free 7-day trial of Pro, no credit
+              card required. Upgrade to keep building and working privately. Get
+              a Team plan to add users and enable collaboration.
             </p>
           </div>
 
           {/* Main Tiers with Arrows */}
           <div className="mb-12">
-            <div className="grid md:grid-cols-[1fr_auto_1fr_auto_1fr] gap-6 items-center max-w-6xl mx-auto">
-              {/* Community Tier */}
+            <div className="grid md:grid-cols-[1fr_auto_1fr] gap-6 items-center max-w-4xl mx-auto">
+              {/* Pro Tier */}
               <PricingCard
-                name="Community"
-                price="FREE"
-                cta="Get started"
-                ctaHref="/registry/billing"
-                features={[
-                  {
-                    text: 'Public projects and state machines',
-                    href: '/docs/projects#change-a-projects-visibility',
-                  },
-                  {
-                    text: 'Export to JavaScript and TypeScript',
-                    href: '/docs/export-as-code',
-                  },
-                  {
-                    text: 'State machine simulation',
-                    href: '/docs/simulate-mode',
-                  },
-                  {
-                    text: 'Generate and modify state machines using AI ✨',
-                    subtext: '3 generations / month',
-                    href: '/docs/generate-flow',
-                  },
-                  { text: 'Community support' },
-                ]}
-              />
-
-              {/* Arrow */}
-              <div className="hidden md:flex justify-center">
-                <ArrowRight className="w-8 h-8 text-fd-muted-foreground" />
-              </div>
-
-              {/* Professional Tier */}
-              <PricingCard
-                name="Professional"
+                name="Pro"
                 price="$33"
                 priceDetails="per month for an annual plan."
                 priceSubtext="$39 per month for a monthly plan."
+                trialNote="Free 7-day trial included"
+                trialDetail="When your trial ends, your machines and projects become read-only until you upgrade."
                 cta="Start a free trial"
                 ctaHref="/registry/billing"
                 highlighted
                 features={[
                   {
-                    text: 'Everything from Community',
-                    href: '/docs/studio-community-plan',
-                    strong: true,
-                  },
-                  {
-                    text: 'Private and unlisted projects',
+                    text: 'Unlimited public, private, and unlisted projects',
                     href: '/docs/projects#change-a-projects-visibility',
                   },
                   {
@@ -82,8 +46,9 @@ export default function PricingPage() {
                     href: '/docs/generate-flow',
                   },
                   {
-                    text: 'Generate React UIs',
-                    href: '/docs/generate-react',
+                    text: 'Deploy state machines as workflows with Stately Sky',
+                    subtext: 'Beta feature',
+                    href: '/docs/stately-sky-getting-started',
                   },
                   {
                     text: 'Version history',
@@ -102,8 +67,13 @@ export default function PricingPage() {
                     href: '/docs/colors',
                   },
                   {
-                    text: 'GitHub Sync',
+                    text: 'Codebase sync',
+                    subtext: 'via GitHub or the CLI',
                     href: '/docs/import-from-github',
+                  },
+                  {
+                    text: 'Export to JavaScript and TypeScript',
+                    href: '/docs/export-as-code',
                   },
                   { text: 'Priority support' },
                 ]}
@@ -120,7 +90,7 @@ export default function PricingPage() {
                 price="$167"
                 priceDetails="per month for an annual plan."
                 priceSubtext="$199 per month for a monthly plan."
-                cta="Start a free trial"
+                cta="Get started"
                 ctaHref="/registry/billing"
                 features={[
                   {
@@ -145,6 +115,7 @@ export default function PricingPage() {
                     text: 'Unlimited view-only access for non-team members',
                     href: '/docs/teams',
                   },
+                  { text: 'Live collaboration', subtext: 'Coming soon' },
                   { text: 'Priority support' },
                 ]}
               />
@@ -161,7 +132,7 @@ export default function PricingPage() {
               ctaHref="mailto:support@stately.ai?subject=I'm interested in the Stately Studio Enterprise plan"
               features={[
                 {
-                  text: 'Everything from the Community, Pro, and Team plans',
+                  text: 'Everything from the Pro and Team plans',
                   href: '/docs/studio-pro-plan',
                 },
                 {
@@ -203,6 +174,12 @@ export default function PricingPage() {
               ]}
             />
           </div>
+
+          {/* Free is a state, not a plan: it is what an account falls back to */}
+          <p className="mt-8 text-sm text-fd-muted-foreground text-center max-w-3xl mx-auto">
+            Not ready to upgrade? You can keep viewing your machines and
+            projects, and browse and simulate public machines, for free.
+          </p>
         </div>
       </main>
       <Footer />
@@ -223,6 +200,10 @@ interface PricingCardProps {
   customPrice?: string;
   priceDetails?: string;
   priceSubtext?: string;
+  /** Short badge under the price, e.g. "Free 7-day trial included". */
+  trialNote?: string;
+  /** Fine print under the trial note, e.g. what expiry means. */
+  trialDetail?: string;
   cta: string;
   ctaHref: string;
   features: Feature[];
@@ -235,6 +216,8 @@ function PricingCard({
   customPrice,
   priceDetails,
   priceSubtext,
+  trialNote,
+  trialDetail,
   cta,
   ctaHref,
   features,
@@ -278,6 +261,18 @@ function PricingCard({
           <div className="text-2xl font-semibold text-fd-muted-foreground mb-4">
             {customPrice}
           </div>
+        )}
+
+        {trialNote && (
+          <div className="mb-2">
+            <span className="inline-block rounded-md bg-blue-500/15 px-2 py-1 text-xs font-semibold text-blue-500">
+              {trialNote}
+            </span>
+          </div>
+        )}
+
+        {trialDetail && (
+          <p className="mb-4 text-xs text-fd-muted-foreground">{trialDetail}</p>
         )}
 
         {/* CTA Button */}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -478,7 +478,7 @@ const tree = {
         },
         {
           type: 'page' as const,
-          name: 'Stately Studio Community',
+          name: 'Stately Studio Free',
           url: '/docs/studio-community-plan',
         },
         {

--- a/content/docs/sign-up.mdx
+++ b/content/docs/sign-up.mdx
@@ -9,7 +9,7 @@ Sign up using your email address and password, or sign in using your GitHub, Goo
 
 <Callout>
 
-Every new account starts with a **free 7-day trial** of the [Pro](studio-pro-plan) plan, no credit card required, so you can explore how our premium features work for you and your team. You can [upgrade](/upgrade) to a Pro, [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time when you’re signed into Stately Studio.
+Every new account starts with a **free 7-day trial** of the [Pro](studio-pro-plan) plan, no credit card required, so you can explore how our premium features work for you and your team. You can [upgrade](upgrade) to a Pro, [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time when you’re signed into Stately Studio.
 
 </Callout>
 

--- a/content/docs/sign-up.mdx
+++ b/content/docs/sign-up.mdx
@@ -9,7 +9,7 @@ Sign up using your email address and password, or sign in using your GitHub, Goo
 
 <Callout>
 
-We offer a **free trial** on the Stately Studio [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plans so you can explore how our premium features work for you and your team. You can [upgrade](/upgrade) when you’re signed into Stately Studio.
+Every new account starts with a **free 7-day trial** of the [Pro](studio-pro-plan) plan, no credit card required, so you can explore how our premium features work for you and your team. You can [upgrade](/upgrade) to a Pro, [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time when you’re signed into Stately Studio.
 
 </Callout>
 

--- a/content/docs/studio-community-plan.mdx
+++ b/content/docs/studio-community-plan.mdx
@@ -6,7 +6,7 @@ Every new Stately Studio account starts with a **free 7-day trial** of the [Pro]
 
 <Callout>
 
-You can [upgrade](/upgrade) to a [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time, during your trial or after it ends. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
+You can [upgrade](upgrade) to a [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time, during your trial or after it ends. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
 </Callout>
 

--- a/content/docs/studio-community-plan.mdx
+++ b/content/docs/studio-community-plan.mdx
@@ -1,25 +1,31 @@
 ---
-title: Stately Studio Community plan
+title: Stately Studio Free plan
 ---
 
-**Stately Studio will always be free to our Community users** on this free plan, and we will make many future features available on every plan. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
+Every new Stately Studio account starts with a **free 7-day trial** of the [Pro](studio-pro-plan) plan, no credit card required. When the trial ends, your account falls back to the free plan: you keep everything you made, but your machines and projects become read-only until you [upgrade](upgrade).
 
 <Callout>
 
-We offer a **free trial** on the Stately Studio [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plans so you can explore how our premium features work for you and your team. You can [upgrade](/upgrade) when you’re signed into Stately Studio.
+You can [upgrade](/upgrade) to a [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time, during your trial or after it ends. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
 </Callout>
 
-## Community features
+## Free features
 
-Our Community plan features include the following:
+The free plan includes the following:
 
-- Unlimited [public projects](projects.mdx#change-a-projects-visibility)
-- [Design and simulate flows](/studio.mdx#studio-editor)
-- [Import from code](import-from-code)
+- View your own machines and projects
+- Browse and [simulate](simulate-mode) public machines
+- [Discover](discover) public machines
 - [Export as code](export-as-code)
-- [Discover and fork public machines](discover)
 - [XState VS Code extension](xstate-vscode-extension)
+- Community support on [our Discord](https://discord.stately.ai)
+
+<Callout title="Community accounts">
+
+Accounts created before we introduced the Pro trial are on the legacy Community plan and keep editing their public projects as before.
+
+</Callout>
 
 <Callout>
 

--- a/content/docs/studio-pro-plan.mdx
+++ b/content/docs/studio-pro-plan.mdx
@@ -6,13 +6,12 @@ title: Stately Studio Pro plan
 
 ## Pro features
 
-- Everything from the [Community plan](studio-community-plan)
-- [Private and unlisted projects](/docs/projects/#change-a-projects-visibility)
+- Unlimited [public, private, and unlisted projects](/docs/projects/#change-a-projects-visibility)
 - [Generate and modify using AI](generate-flow)
 - [Deploy live workflows](stately-sky-getting-started)
 - [Generate React UIs](generate-react)
 - [Version history](versions)
-- [Import from GitHub](import-from-github)
+- [Codebase sync, via GitHub or the CLI](import-from-github)
 - [Live simulation mode](live-simulation)
 - [Embed Figma frames](figma)
 - [State assets](assets)
@@ -22,16 +21,15 @@ title: Stately Studio Pro plan
 - [Export flows to markdown](export-as-code)
 - [Export flows as stories](export-as-code)
 - [Priority support](/docs/studio-pro-plan/#priority-support)
-- [GitHub Sync](import-from-github)
 - Actors (coming soon!)
 
 We have many more pro features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
-We offer a **free trial** on all of our premium plans so you can explore how our Pro features work for you.
+Every new Stately Studio account starts with a **free 7-day trial** of Pro, no credit card required, so you can explore how our Pro features work for you.
 
 <Callout>
 
-**Stately Studio will always be free to our Community users** on the free plan, and we will make many future features available on every plan.
+When your trial ends, your machines and projects become [read-only](studio-community-plan) until you [upgrade](upgrade). Nothing is deleted, and you can upgrade at any time.
 
 </Callout>
 

--- a/content/docs/studio-team-plan.mdx
+++ b/content/docs/studio-team-plan.mdx
@@ -16,11 +16,11 @@ title: Stately Studio Team plan
 
 We have many more team features coming soon. Request features and check out what we’ve got planned on [our roadmap](https://feedback.stately.ai).
 
-We offer a **free trial** on all of our premium plans so you can explore how our Team features work for you and your team.
+Every new Stately Studio account starts with a **free 7-day trial** of the [Pro](studio-pro-plan) plan, so you can explore our premium features before choosing a Team plan.
 
 <Callout>
 
-**Stately Studio will always be free to our Community users** on the free plan, and we will make many future features available on every plan.
+When your trial ends, your machines and projects become [read-only](studio-community-plan) until you [upgrade](upgrade). Nothing is deleted, and you can upgrade at any time.
 
 </Callout>
 

--- a/content/docs/upgrade.mdx
+++ b/content/docs/upgrade.mdx
@@ -6,9 +6,9 @@ import { CircleDollarSign, ThemedImage } from 'lucide-react';
 
 # Upgrade
 
-**Stately Studio will always be free to our Community users** on the [Community plan](studio-community-plan), and we will make many future features available on every plan.
+Every new Stately Studio account starts with a **free 7-day trial** of the [Pro](studio-pro-plan) plan, no credit card required, so you can explore how our premium features work for you and your team. When the trial ends, your machines and projects become [read-only](studio-community-plan) until you upgrade.
 
-We offer a **free trial** on the Stately Studio [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plans so you can explore how our premium features work for you and your team. You can [upgrade](upgrade) when you’re signed into Stately Studio.
+You can upgrade to a [Pro](studio-pro-plan), [Team](studio-team-plan), or [Enterprise](studio-enterprise-plan) plan at any time while you’re signed into Stately Studio.
 
 ## Upgrade to a Pro or Team plan
 


### PR DESCRIPTION
Matches https://stately.ai/pricing to the billing page in Studio (statelyai/studio#3270), now that every new account starts on a 7-day Pro trial instead of a Community plan.

